### PR TITLE
Bugfix: Protobuf length prefix was assumed to be 1 byte

### DIFF
--- a/libp2p/protobuf/minprotobuf.nim
+++ b/libp2p/protobuf/minprotobuf.nim
@@ -176,12 +176,12 @@ proc write*(pb: var ProtoBuffer, field: ProtoField) =
 
 proc finish*(pb: var ProtoBuffer) =
   ## Prepare protobuf's buffer ``pb`` for writing to stream.
-  var length = 0
   assert(len(pb.buffer) > 0)
   if WithVarintLength in pb.options:
     let size = uint(len(pb.buffer) - 10)
-    let pos = 10 - vsizeof(length)
-    let res = PB.putUVarint(pb.buffer.toOpenArray(pos, 9), length, size)
+    let pos = 10 - vsizeof(size)
+    var usedBytes = 0
+    let res = PB.putUVarint(pb.buffer.toOpenArray(pos, 9), usedBytes, size)
     assert(res == VarintStatus.Success)
     pb.offset = pos
   else:


### PR DESCRIPTION
The error in the code was that the `vsizeof(n)` was called
with a dummy zeroed variable, instead of the proper size of
the buffer. This resulted in an assertion failure when the
prefix length needs to be stored in more than 1 byte.