### PR TITLE
Fix SomeVarint

### DIFF
--- a/libp2p/varint.nim
+++ b/libp2p/varint.nim
@@ -205,7 +205,7 @@ proc putSVarint*(pbytes: var openarray[byte], outsize: var int,
   result = PB.putUVarint(pbytes, outsize, value)
 
 proc encodeVarint*(vtype: typedesc[PB],
-                   value: PBSomeVarint): seq[byte] {.inline.} =
+                   value: SomeVarint): seq[byte] {.inline.} =
   ## Encode integer to Google ProtoBuf's `signed/unsigned varint` and returns
   ## sequence of bytes as result.
   var outsize = 0
@@ -214,7 +214,7 @@ proc encodeVarint*(vtype: typedesc[PB],
     result.setLen(5)
   else:
     result.setLen(10)
-  when type(value) is SomeSVarint:
+  when type(value) is PBSomeSVarint:
     let res = putSVarint(result, outsize, value)
   else:
     let res = putUVarint(result, outsize, value)


### PR DESCRIPTION
I was getting this error when trying the chat example:

```
/Users/matt/lib/nim-libp2p/libp2p/varint.nim(217, 23) Error: undeclared identifier: 'SomeSVarint'
```

This PR at least gets rid of that error.

Although I'm still getting this error, but I'll work on that:

```
Error: execution of an external compiler program 'clang -c  -w -pthread -I/Users/matt/lib/nim-libp2p/libp2p/crypto/BearSSL/src -I/Users/matt/lib/nim-libp2p/libp2p/crypto/BearSSL/inc -DBR_USE_UNIX_TIME=1 -DBR_USE_URANDOM=1 -DBR_LE_UNALIGNED=1 -DBR_64=1  -DBR_amd64=1 -DBR_INT128=1  -I/Users/matt/lib/Nim/lib -I/private/tmp/foo -o /Users/matt/.cache/nim/chat_d/pemdec.c.o /Users/matt/lib/nim-libp2p/libp2p/crypto/BearSSL/src/codec/pemdec.c' failed with exit code: 1

clang-8: error: no such file or directory: '/Users/matt/lib/nim-libp2p/libp2p/crypto/BearSSL/src/codec/pemdec.c'
clang-8: error: no input files
```