### PR TITLE
set log level to trace - not enabled by default

### DIFF
--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -55,7 +55,7 @@ proc newChannel*(id: uint,
   proc writeHandler(data: seq[byte]): Future[void] {.async, gcsafe.} = 
     # writes should happen in sequence
     await chan.asyncLock.acquire()
-    info "writeHandler: sending data ", data = data.toHex(), id = chan.id
+    trace "writeHandler: sending data ", data = data.toHex(), id = chan.id
     await conn.writeMsg(chan.id, chan.msgCode, data) # write header
     chan.asyncLock.release()
 

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -105,7 +105,7 @@ proc handleConn(f: FloodSub,
   ## 
 
   if conn.peerInfo.peerId.isNone:
-    debug "no valid PeerId for peer"
+    trace "no valid PeerId for peer"
     return
 
   # create new pubsub peer

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -288,7 +288,7 @@ proc newSwitch*(peerInfo: PeerInfo,
 
   let s = result # can't capture result
   result.streamHandler = proc(stream: Connection) {.async, gcsafe.} = 
-    debug "handling connection for", peerInfo = stream.peerInfo
+    trace "handling connection for", peerInfo = stream.peerInfo
     await s.ms.handle(stream) # handle incoming connection
 
   result.mount(identity)

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -67,7 +67,7 @@ method listen*(t: TcpTransport,
   # always get the resolved address in case we're bound to 0.0.0.0:0
   t.ma = MultiAddress.init(t.server.sock.getLocalAddress())
   result = t.server.join()
-  debug "started node on", address = t.ma
+  trace "started node on", address = t.ma
 
 method dial*(t: TcpTransport,
              address: MultiAddress):

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -47,7 +47,7 @@ method listen*(t: Transport,
   ## listen for incoming connections
   t.ma = ma
   t.handler = handler
-  debug "starting node", address = $ma
+  trace "starting node", address = $ma
 
 method dial*(t: Transport,
              address: MultiAddress):

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -76,13 +76,13 @@ proc main() {.async.} =
   await switch.subscribeToPeer(remotePeer)
 
   proc handler(topic: string, data: seq[byte]): Future[void] {.closure, gcsafe.} =
-    debug "IN HANDLER"
+    trace "IN HANDLER"
 
   let topic = Base58.encode(cast[seq[byte]]("chat"))
   await switch.subscribe(topic, handler)
   let msg = cast[seq[byte]]("hello from nim")
   await switch.publish(topic, msg)
-  # debug "published message from test"
+  # trace "published message from test"
   # TODO: for some reason the connection closes unless I do a forever loop
   await allFutures(libp2pFuts)
 

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -237,7 +237,7 @@ suite "Mplex":
         mplexListen.streamHandler = handleMplexListen
         listenFut = mplexListen.handle()
         listenFut.addCallback(proc(udata: pointer) {.gcsafe.}
-                                = debug "completed listener")
+                                = trace "completed listener")
 
       let transport1: TcpTransport = newTransport(TcpTransport)
       asyncCheck transport1.listen(ma, connHandler)
@@ -248,7 +248,7 @@ suite "Mplex":
       let mplexDial = newMplex(conn)
       let dialFut = mplexDial.handle()
       dialFut.addCallback(proc(udata: pointer = nil) {.gcsafe.}
-                            = debug "completed dialer")
+                            = trace "completed dialer")
       for i in 1..10:
         let stream  = await mplexDial.newStream("dialer stream")
         await stream.writeLp(&"stream {i} from dialer!")


### PR DESCRIPTION
Most logging should be trace level, which isn't enabled by default in neither debug nor release builds. I've replaced `debug` for `trace` to prevent unnecessary log pollution.