### PR TITLE
Fix finally use in daemonapi

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -10,7 +10,7 @@ skipDirs      = @["tests", "examples", "Nim"]
 requires "nim > 0.19.4",
          "secp256k1",
          "nimcrypto >= 0.4.1",
-         "chronos >= 2.3.1",
+         "chronos >= 2.3.4",
          "bearssl >= 0.1.3",
          "chronicles >= 0.7.0"
 

--- a/libp2p/protocols/secure/secio.nim
+++ b/libp2p/protocols/secure/secio.nim
@@ -404,7 +404,7 @@ proc readLoop(sconn: SecureConnection, stream: BufferStream) {.async.} =
     try:
       let msg = await sconn.readMessage()
       await stream.pushTo(msg)
-    except Exception as exc:
+    except CatchableError as exc:
       trace "exception in secio", exc = exc.msg
       return
     finally:

--- a/libp2p/protocols/secure/secio.nim
+++ b/libp2p/protocols/secure/secio.nim
@@ -405,7 +405,7 @@ proc readLoop(sconn: SecureConnection, stream: BufferStream) {.async.} =
       let msg = await sconn.readMessage()
       await stream.pushTo(msg)
     except CatchableError as exc:
-      trace "exception in secio", exc = exc
+      trace "exception in secio", exc = exc.msg
       return
     finally:
       trace "ending secio readLoop"

--- a/libp2p/protocols/secure/secio.nim
+++ b/libp2p/protocols/secure/secio.nim
@@ -404,7 +404,7 @@ proc readLoop(sconn: SecureConnection, stream: BufferStream) {.async.} =
     try:
       let msg = await sconn.readMessage()
       await stream.pushTo(msg)
-    except CatchableError as exc:
+    except Exception as exc:
       trace "exception in secio", exc = exc.msg
       return
     finally:


### PR DESCRIPTION
Fixes #39 

Reverting dde8c01448e0302c99c39fcd02ced88431a60d27 to proper exception handling. 

Note that `Exception` instead of `CatchableError` is used to emulate previous behavior of `raise getCurrentException()`.