### PR TITLE
Mplex timeout & size limits

### DIFF
--- a/libp2p/connection.nim
+++ b/libp2p/connection.nim
@@ -122,8 +122,10 @@ proc readLp*(s: Connection): Future[seq[byte]] {.async, gcsafe.} =
       res = LP.getUVarint(buff.toOpenArray(0, i), length, size)
       if res == VarintStatus.Success:
         break
-    if res != VarintStatus.Success or size > DefaultReadSize:
+    if res != VarintStatus.Success:
       raise newInvalidVarintException()
+    if size > DefaultReadSize:
+      raise newLPStreamLimitError()
     buff.setLen(size)
     if size > 0.uint:
       trace "reading exact bytes from stream", size = size

--- a/libp2p/connection.nim
+++ b/libp2p/connection.nim
@@ -28,7 +28,7 @@ type
   InvalidVarintException = object of LPStreamError
 
 proc newInvalidVarintException*(): ref InvalidVarintException =
-  newException(InvalidVarintException, "unable to prase varint")
+  newException(InvalidVarintException, "unable to parse varint")
 
 proc newConnection*(stream: LPStream,
                     timeout: Duration = DefaultRWTimeout): Connection =

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -107,8 +107,7 @@ method handle*(m: Mplex) {.async, gcsafe.} =
                                            size = data.len
 
           if data.len > MaxMsgSize:
-             raise newException(CatchableError,
-                                "Message size over the limit of 1MiB per message.")
+             raise newLPStreamLimitError();
           await channel.pushTo(data)
         of MessageType.CloseIn, MessageType.CloseOut:
           trace "closing channel", id = id,

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -103,8 +103,12 @@ method handle*(m: Mplex) {.async, gcsafe.} =
         of MessageType.MsgIn, MessageType.MsgOut:
           trace "pushing data to channel", id = id,
                                            initiator = initiator,
-                                           msgType = msgType
+                                           msgType = msgType,
+                                           size = data.len
 
+          if data.len > MaxMsgSize:
+             raise newException(CatchableError,
+                                "Message size over the limit of 1MiB per message.")
           await channel.pushTo(data)
         of MessageType.CloseIn, MessageType.CloseOut:
           trace "closing channel", id = id,

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -1,4 +1,4 @@
-import unittest, sequtils, sugar, strformat, options, strformat, random
+import unittest, sequtils, sugar, strformat, options, strformat
 import chronos, nimcrypto/utils, chronicles
 import ../libp2p/[connection,
                   stream/lpstream,

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -1,4 +1,4 @@
-import unittest, sequtils, sugar, strformat, options, strformat
+import unittest, sequtils, sugar, strformat, options, strformat, random
 import chronos, nimcrypto/utils, chronicles
 import ../libp2p/[connection,
                   stream/lpstream,

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -1,4 +1,4 @@
-import unittest, sequtils, sugar, strformat, options, strformat
+import unittest, sequtils, sugar, strformat, options, strformat, random
 import chronos, nimcrypto/utils, chronicles
 import ../libp2p/[connection,
                   stream/lpstream,
@@ -119,12 +119,16 @@ suite "Mplex":
 
   test "e2e - read/write receiver":
     proc testNewStream(): Future[bool] {.async.} =
-      let ma: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
+      let
+        ma: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
+        lock = newFuture[void]()
+        timeout = sleepAsync(5_000)
 
       proc connHandler(conn: Connection) {.async, gcsafe.} =
         proc handleMplexListen(stream: Connection) {.async, gcsafe.} =
           let msg = await stream.readLp()
           check cast[string](msg) == "Hello from stream!"
+          lock.complete()
           await stream.close()
 
         let mplexListen = newMplex(conn)
@@ -140,6 +144,8 @@ suite "Mplex":
       let mplexDial = newMplex(conn)
       let stream  = await mplexDial.newStream()
       await stream.writeLp("Hello from stream!")
+      await lock or timeout
+      check lock.finished
       await conn.close()
       result = true
 
@@ -148,11 +154,15 @@ suite "Mplex":
 
   test "e2e - write limits":
     proc testNewStream(): Future[bool] {.async.} =
-      let ma: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
+      let
+        ma: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
+        lock = newFuture[void]()
+        timeout = sleepAsync(5_000)
 
       proc connHandler(conn: Connection) {.async, gcsafe.} =
         proc handleMplexListen(stream: Connection) {.async, gcsafe.} =
           let msg = await stream.readLp()
+          lock.complete()
           check cast[string](msg) == "Hello from stream!"
           await stream.close()
 
@@ -168,8 +178,12 @@ suite "Mplex":
 
       let mplexDial = newMplex(conn)
       let stream  = await mplexDial.newStream()
-      let bigseq = newSeq[uint8](MaxMsgSize + 1)
+      var bigseq = newSeqOfCap[uint8](MaxMsgSize + 1)
+      for _ in 0..<MaxMsgSize:
+        bigseq.add(uint8(rand(int('A')..int('z'))))
       await stream.writeLp(bigseq)
+      await lock or timeout
+      check timeout.finished # this test has to timeout!
       await conn.close()
       result = true
 

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -146,6 +146,7 @@ suite "Mplex":
       await stream.writeLp("Hello from stream!")
       await lock or timeout
       check lock.finished
+      timeout.cancel()
       await conn.close()
       result = true
 
@@ -184,6 +185,7 @@ suite "Mplex":
       await stream.writeLp(bigseq)
       await lock or timeout
       check timeout.finished # this test has to timeout!
+      lock.cancel();
       await conn.close()
       result = true
 

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -146,6 +146,36 @@ suite "Mplex":
     check:
       waitFor(testNewStream()) == true
 
+  test "e2e - write limits":
+    proc testNewStream(): Future[bool] {.async.} =
+      let ma: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
+
+      proc connHandler(conn: Connection) {.async, gcsafe.} =
+        proc handleMplexListen(stream: Connection) {.async, gcsafe.} =
+          let msg = await stream.readLp()
+          check cast[string](msg) == "Hello from stream!"
+          await stream.close()
+
+        let mplexListen = newMplex(conn)
+        mplexListen.streamHandler = handleMplexListen
+        discard mplexListen.handle()
+
+      let transport1: TcpTransport = newTransport(TcpTransport)
+      discard await transport1.listen(ma, connHandler)
+
+      let transport2: TcpTransport = newTransport(TcpTransport)
+      let conn = await transport2.dial(transport1.ma)
+
+      let mplexDial = newMplex(conn)
+      let stream  = await mplexDial.newStream()
+      let bigseq = newSeq[uint8](MaxMsgSize + 1)
+      await stream.writeLp(bigseq)
+      await conn.close()
+      result = true
+
+    check:
+      waitFor(testNewStream()) == true
+
   test "e2e - read/write initiator":
     proc testNewStream(): Future[bool] {.async.} =
       let ma: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")


### PR DESCRIPTION
Partial small addition in order to close https://github.com/status-im/nim-libp2p/issues/45

@dryajov 
What's the current best practice for error handling btw? such this max size
Also, I added a WIP test and the curious thing is that it makes another test fail:
`[1m[31m  [FAILED] [0me2e - multiple read/write streams[0m`
Trying to figure things out now :)