### PR TITLE
Add peer lifetime feature for PeerInfo.

### DIFF
--- a/examples/directchat.nim
+++ b/examples/directchat.nim
@@ -68,7 +68,7 @@ proc dialPeer(p: ChatProto, address: string) {.async, gcsafe.} =
     quit("invalid or incompelete peerId")
 
   var remotePeer = PeerInfo.init(parts[^1],
-                                 @[MultiAddress.init(address)])
+                                 [MultiAddress.init(address)])
 
   echo &"dialing peer: {address}"
   p.conn = await p.switch.dial(remotePeer, ChatCodec)

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -90,6 +90,9 @@ proc join*(p: PeerInfo): Future[void] {.inline.} =
 proc isClosed*(p: PeerInfo): bool {.inline.} =
   result = p.lifefut.finished()
 
+proc lifeFuture*(p: PeerInfo): Future[void] {.inline.} =
+  result = p.lifefut
+
 proc publicKey*(p: PeerInfo): Option[PublicKey] {.inline.} =
   if p.keyType == HasPublic:
     if p.peerId.hasPublicKey():

--- a/libp2p/standard_setup.nim
+++ b/libp2p/standard_setup.nim
@@ -18,7 +18,7 @@ proc newStandardSwitch*(privKey = none(PrivateKey),
 
   let
     seckey = privKey.get(otherwise = PrivateKey.random(ECDSA))
-    peerInfo = PeerInfo.init(seckey, @[address])
+    peerInfo = PeerInfo.init(seckey, [address])
     mplexProvider = newMuxerProvider(createMplex, MplexCodec)
     transports = @[Transport(newTransport(TcpTransport))]
     muxers = {MplexCodec: mplexProvider}.toTable

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -144,6 +144,10 @@ proc cleanupConn(s: Switch, conn: Connection) {.async, gcsafe.} =
         await s.connections[id].close()
       s.connections.del(id)
 
+    # TODO: Investigate cleanupConn() always called twice for one peer.
+    if not(conn.peerInfo.isClosed()):
+      conn.peerInfo.close()
+
 proc disconnect*(s: Switch, peer: PeerInfo) {.async, gcsafe.} =
   let conn = s.connections.getOrDefault(peer.id)
   if not isNil(conn):

--- a/tests/testidentify.nim
+++ b/tests/testidentify.nim
@@ -19,9 +19,9 @@ suite "Identify":
       let ma: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
       let remoteSecKey = PrivateKey.random(RSA)
       let remotePeerInfo = PeerInfo.init(remoteSecKey,
-                                        @[ma],
-                                        @["/test/proto1/1.0.0",
-                                        "/test/proto2/1.0.0"])
+                                        [ma],
+                                        ["/test/proto1/1.0.0",
+                                         "/test/proto2/1.0.0"])
       var serverFut: Future[void]
       let identifyProto1 = newIdentify(remotePeerInfo)
       let msListen = newMultistream()
@@ -37,7 +37,7 @@ suite "Identify":
       let transport2: TcpTransport = newTransport(TcpTransport)
       let conn = await transport2.dial(transport1.ma)
 
-      var peerInfo = PeerInfo.init(PrivateKey.random(RSA), @[ma])
+      var peerInfo = PeerInfo.init(PrivateKey.random(RSA), [ma])
       let identifyProto2 = newIdentify(peerInfo)
       discard await msDial.select(conn, IdentifyCodec)
       let id = await identifyProto2.identify(conn, remotePeerInfo)
@@ -59,7 +59,7 @@ suite "Identify":
   test "handle failed identify":
     proc testHandleError() {.async.} =
       let ma: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
-      var remotePeerInfo = PeerInfo.init(PrivateKey.random(RSA), @[ma])
+      var remotePeerInfo = PeerInfo.init(PrivateKey.random(RSA), [ma])
       let identifyProto1 = newIdentify(remotePeerInfo)
       let msListen = newMultistream()
 
@@ -74,7 +74,7 @@ suite "Identify":
       let transport2: TcpTransport = newTransport(TcpTransport)
       let conn = await transport2.dial(transport1.ma)
 
-      var localPeerInfo = PeerInfo.init(PrivateKey.random(RSA), @[ma])
+      var localPeerInfo = PeerInfo.init(PrivateKey.random(RSA), [ma])
       let identifyProto2 = newIdentify(localPeerInfo)
       discard await msDial.select(conn, IdentifyCodec)
       discard await identifyProto2.identify(conn, PeerInfo.init(PrivateKey.random(RSA)))

--- a/tests/testinterop.nim
+++ b/tests/testinterop.nim
@@ -72,7 +72,7 @@ proc createNode*(privKey: Option[PrivateKey] = none(PrivateKey),
   if privKey.isNone:
     seckey = some(PrivateKey.random(RSA))
 
-  var peerInfo = NativePeerInfo.init(seckey.get(), @[Multiaddress.init(address)])
+  var peerInfo = NativePeerInfo.init(seckey.get(), [Multiaddress.init(address)])
   proc createMplex(conn: Connection): Muxer = newMplex(conn)
   let mplexProvider = newMuxerProvider(createMplex, MplexCodec)
   let transports = @[Transport(newTransport(TcpTransport))]


### PR DESCRIPTION
* Refactor peerinfo to use openarrays instead of sequences.
* Fix tests and examples to use arrays instead of sequences.
* Add tests for lifetime.