### PR TITLE
no empty proto dials

### DIFF
--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -321,7 +321,7 @@ proc subscribeToPeer(s: Switch, peerInfo: PeerInfo) {.async, gcsafe.} =
       let conn = await s.dial(peerInfo, s.pubSub.get().codec)
       await s.pubSub.get().subscribeToPeer(conn)
     except CatchableError as exc:
-      trace "unable to initiate pubsub", exc = exc.msg
+      warn "unable to initiate pubsub", exc = exc.msg
       s.dialedPubSubPeers.excl(peerInfo.id)
 
 proc subscribe*(s: Switch, topic: string, handler: TopicHandler): Future[void] {.gcsafe.} =

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -256,6 +256,7 @@ proc dial*(s: Switch,
   if conn.closed:
     raise newException(CatchableError, "Connection dead on arrival")
 
+  result = conn
   let stream = await s.getMuxedStream(peer)
   if not isNil(stream):
     trace "Connection is muxed, return muxed stream"

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -241,7 +241,7 @@ proc internalConnect(s: Switch,
   result = conn
 
 proc connect*(s: Switch, peer: PeerInfo) {.async.} =
-  var conn = s.internalConnect(peer)
+  var conn = await s.internalConnect(peer)
   if isNil(conn):
     raise newException(CatchableError, "Unable to connect to peer")
 

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -512,7 +512,7 @@ suite "GossipSub":
                                   nodes[1].peerInfo.id)),
                                   1.minutes)
 
-      await wait(seenFut, 1.minutes)
+      await wait(seenFut, 2.minutes)
       check: seen.len >= 10
       for k, v in seen.pairs:
         check: v == 1

--- a/tests/pubsub/utils.nim
+++ b/tests/pubsub/utils.nim
@@ -1,4 +1,3 @@
-import options, tables
 import chronos
 import ../../libp2p/standard_setup
 export standard_setup
@@ -8,10 +7,10 @@ proc generateNodes*(num: Natural, gossip: bool = false): seq[Switch] =
     result.add(newStandardSwitch(gossip = gossip))
 
 proc subscribeNodes*(nodes: seq[Switch]) {.async.} =
-  var dials: seq[Future[Connection]]
+  var dials: seq[Future[void]]
   for dialer in nodes:
     for node in nodes:
       if dialer.peerInfo.peerId != node.peerInfo.peerId:
-        dials.add(dialer.dial(node.peerInfo))
+        dials.add(dialer.connect(node.peerInfo))
   await sleepAsync(100.millis)
   await allFutures(dials)

--- a/tests/testinterop.nim
+++ b/tests/testinterop.nim
@@ -118,8 +118,8 @@ proc testPubSubDaemonPublish(gossip: bool = false,
     if times >= count and not handlerFuture.finished:
       handlerFuture.complete(true)
 
-  discard await nativeNode.dial(NativePeerInfo.init(daemonPeer.peer,
-                                                    daemonPeer.addresses))
+  await nativeNode.connect(NativePeerInfo.init(daemonPeer.peer,
+                                               daemonPeer.addresses))
   await sleepAsync(1.seconds)
   await daemonNode.connect(nativePeer.peerId, nativePeer.addrs)
 
@@ -157,8 +157,8 @@ proc testPubSubNodePublish(gossip: bool = false,
   let nativePeer = nativeNode.peerInfo
 
   var handlerFuture = newFuture[bool]()
-  discard await nativeNode.dial(NativePeerInfo.init(daemonPeer.peer,
-                                                    daemonPeer.addresses))
+  await nativeNode.connect(NativePeerInfo.init(daemonPeer.peer,
+                                               daemonPeer.addresses))
 
   await sleepAsync(1.seconds)
   await daemonNode.connect(nativePeer.peerId, nativePeer.addrs)


### PR DESCRIPTION
Don't allow empty protocol dials and adding a `connect` method to substitute for empty dials.

NOTE: This is a breaking change, all empty protocol dials such as `switch.dial(peer)` should be changed for `switch.connect(peer)`.