### PR TITLE
Read all bytes

### DIFF
--- a/libp2p/muxers/mplex/coder.nim
+++ b/libp2p/muxers/mplex/coder.nim
@@ -18,7 +18,7 @@ import types,
 logScope:
   topic = "MplexCoder"
 
-const DefaultChannelSize* = 1 shr 20
+const DefaultChannelSize* = 1 shl 20
 
 type
   Msg* = tuple


### PR DESCRIPTION
Use `readExactly` instead of `read`, because `read` doesn't guarantee that all the required bytes will be read.