### PR TITLE
add jitter tolerance to mplex

### DIFF
--- a/libp2p/muxers/mplex/coder.nim
+++ b/libp2p/muxers/mplex/coder.nim
@@ -57,8 +57,9 @@ proc readMsg*(conn: Connection): Future[Msg] {.async, gcsafe.} =
 
   var data: seq[byte] = newSeq[byte](dataLenVarint.int)
   if dataLenVarint.int > 0:
-    await conn.readExactly(addr data[0], dataLenVarint.int)
-    trace "read data", len = data.len
+    while data.len < dataLenVarint.int:
+      data &= await conn.read(dataLenVarint.int - data.len)
+      trace "read data", data = data
 
   let header = headerVarint
   result = (header shr 3, MessageType(header and 0x7), data)

--- a/libp2p/muxers/mplex/coder.nim
+++ b/libp2p/muxers/mplex/coder.nim
@@ -57,9 +57,8 @@ proc readMsg*(conn: Connection): Future[Msg] {.async, gcsafe.} =
 
   var data: seq[byte] = newSeq[byte](dataLenVarint.int)
   if dataLenVarint.int > 0:
-    while data.len < dataLenVarint.int:
-      data &= await conn.read(dataLenVarint.int - data.len)
-      trace "read data", data = data
+    await conn.readExactly(addr data[0], dataLenVarint.int)
+    trace "read data", data = data
 
   let header = headerVarint
   result = (header shr 3, MessageType(header and 0x7), data)

--- a/libp2p/muxers/mplex/coder.nim
+++ b/libp2p/muxers/mplex/coder.nim
@@ -58,7 +58,7 @@ proc readMsg*(conn: Connection): Future[Msg] {.async, gcsafe.} =
   var data: seq[byte] = newSeq[byte](dataLenVarint.int)
   if dataLenVarint.int > 0:
     await conn.readExactly(addr data[0], dataLenVarint.int)
-    trace "read data", data = data
+    trace "read data", data = data.len
 
   let header = headerVarint
   result = (header shr 3, MessageType(header and 0x7), data)
@@ -69,7 +69,7 @@ proc writeMsg*(conn: Connection,
                data: seq[byte] = @[]) {.async, gcsafe.} =
   trace "seding data over mplex", id,
                                   msgType,
-                                  data
+                                  data = data.len
   ## write lenght prefixed
   var buf = initVBuffer()
   buf.writePBVarint(id shl 3 or ord(msgType).uint)

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -104,7 +104,7 @@ method handle*(m: Mplex) {.async, gcsafe.} =
                                            size = data.len
 
           if data.len > MaxMsgSize:
-            raise newLPStreamLimitError();
+            raise newLPStreamLimitError()
           await channel.pushTo(data)
         of MessageType.CloseIn, MessageType.CloseOut:
           trace "closing channel", id = id,

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -428,10 +428,7 @@ suite "Mplex":
         const max = 500
         const min = 100
         while sent < total:
-          var len = 0
-          while len > max or len <= 0:
-            len = rand(min..max)
-
+          var len = rand(min..max)
           len = if len > buf.buffer.len: buf.buffer.len else: len
           var send = buf.buffer[0..<len-1]
           await conn.write(send)

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -420,7 +420,7 @@ suite "Mplex":
       mplexBuf.writePBVarint((1.uint shl 3) or ord(MessageType.MsgOut).uint)
       mplexBuf.writePBVarint(buf.buffer.len.uint) # size should be always sent
 
-      await conn.write(mplexBuf.buffer) # write out mplex header
+      await conn.write(mplexBuf.buffer)
       proc writer() {.async.} =
         var sent = 0
         randomize()


### PR DESCRIPTION
This currently doesn't work due to a possible bug in `read` that never reads the last few bytes. @cheatfate 