### PR TITLE
close underlying bufferstream in lpchannel

### DIFF
--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -154,7 +154,7 @@ proc handle*(m: MultistreamSelect, conn: Connection) {.async, gcsafe.} =
           warn "no handlers for ", protocol = ms
           await conn.write(m.na)
   except CatchableError as exc:
-    trace "exception occurred in MultistreamSelect.handle", exc = exc.msg
+    trace "Exception occurred", exc = exc.msg
   finally:
     trace "leaving multistream loop"
 

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -65,14 +65,21 @@ proc newChannel*(id: uint64,
 proc closeMessage(s: LPChannel) {.async.} =
   await s.conn.writeMsg(s.id, s.closeCode) # write header
 
-proc closedByRemote*(s: LPChannel) {.async.} =
-  s.closedRemote = true
-
 proc cleanUp*(s: LPChannel): Future[void] =
   # method which calls the underlying buffer's `close`
   # method used instead of `close` since it's overloaded to
   # simulate half-closed streams
   result = procCall close(BufferStream(s))
+
+proc tryCleanup(s: LPChannel) {.async, inline.} =
+  # if stream is EOF, then cleanup immediatelly
+  if s.closedRemote and s.len == 0:
+    await s.cleanUp()
+
+proc closedByRemote*(s: LPChannel) {.async.} =
+  s.closedRemote = true
+  if s.len == 0:
+    await s.cleanUp()
 
 proc open*(s: LPChannel): Future[void] =
   s.isOpen = true
@@ -88,11 +95,13 @@ proc resetMessage(s: LPChannel) {.async.} =
 proc resetByRemote*(s: LPChannel) {.async.} =
   await allFutures(s.close(), s.closedByRemote())
   s.isReset = true
+  await s.cleanUp()
 
 proc reset*(s: LPChannel) {.async.} =
   await allFutures(s.resetMessage(), s.resetByRemote())
 
 method closed*(s: LPChannel): bool =
+  trace "closing lpchannel", id = s.id, initiator = s.initiator
   result = s.closedRemote and s.len == 0
 
 proc pushTo*(s: LPChannel, data: seq[byte]): Future[void] =
@@ -107,57 +116,46 @@ proc pushTo*(s: LPChannel, data: seq[byte]): Future[void] =
 
   result = procCall pushTo(BufferStream(s), data)
 
-method read*(s: LPChannel, n = -1): Future[seq[byte]] =
+template raiseEOF(): untyped =
   if s.closed or s.isReset:
-    var retFuture = newFuture[seq[byte]]("LPChannel.read")
-    retFuture.fail(newLPStreamEOFError())
-    return retFuture
+    raise newLPStreamEOFError()
 
-  result = procCall read(BufferStream(s), n)
+method read*(s: LPChannel, n = -1): Future[seq[byte]] {.async.} =
+  raiseEOF()
+  result = (await procCall(read(BufferStream(s), n)))
+  await s.tryCleanup()
 
 method readExactly*(s: LPChannel,
                     pbytes: pointer,
                     nbytes: int):
-                    Future[void] =
-  if s.closed or s.isReset:
-    var retFuture = newFuture[void]("LPChannel.readExactly")
-    retFuture.fail(newLPStreamEOFError())
-    return retFuture
-
-  result = procCall readExactly(BufferStream(s), pbytes, nbytes)
+                    Future[void] {.async.} =
+  raiseEOF()
+  await procCall readExactly(BufferStream(s), pbytes, nbytes)
+  await s.tryCleanup()
 
 method readLine*(s: LPChannel,
                  limit = 0,
                  sep = "\r\n"):
-                 Future[string] =
-  if s.closed or s.isReset:
-    var retFuture = newFuture[string]("LPChannel.readLine")
-    retFuture.fail(newLPStreamEOFError())
-    return retFuture
-
-  result = procCall readLine(BufferStream(s), limit, sep)
+                 Future[string] {.async.} =
+  raiseEOF()
+  result = await procCall readLine(BufferStream(s), limit, sep)
+  await s.tryCleanup()
 
 method readOnce*(s: LPChannel,
                  pbytes: pointer,
                  nbytes: int):
-                 Future[int] =
-  if s.closed or s.isReset:
-    var retFuture = newFuture[int]("LPChannel.readOnce")
-    retFuture.fail(newLPStreamEOFError())
-    return retFuture
-
-  result = procCall readOnce(BufferStream(s), pbytes, nbytes)
+                 Future[int] {.async.} =
+  raiseEOF()
+  result = await procCall readOnce(BufferStream(s), pbytes, nbytes)
+  await s.tryCleanup()
 
 method readUntil*(s: LPChannel,
                   pbytes: pointer, nbytes: int,
                   sep: seq[byte]):
-                  Future[int] =
-  if s.closed or s.isReset:
-    var retFuture = newFuture[int]("LPChannel.readUntil")
-    retFuture.fail(newLPStreamEOFError())
-    return retFuture
-
-  result = procCall readOnce(BufferStream(s), pbytes, nbytes)
+                  Future[int] {.async.} =
+  raiseEOF()
+  result = await procCall readOnce(BufferStream(s), pbytes, nbytes)
+  await s.tryCleanup()
 
 template writePrefix: untyped =
   if s.isLazy and not s.isOpen:

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -123,7 +123,7 @@ method handle*(m: Mplex) {.async, gcsafe.} =
           m.getChannelList(initiator).del(id)
           break
   except CatchableError as exc:
-    trace "exception occurred", exception = exc.msg
+    trace "Exception occurred", exception = exc.msg
   finally:
     trace "stopping mplex main loop"
     if not m.connection.closed():

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -19,7 +19,7 @@ import ../protobuf/minprotobuf,
        ../utility
 
 logScope:
-  topic = "identify"
+  topic = "Identify"
 
 const
   IdentifyCodec* = "/ipfs/id/1.0.0"
@@ -123,6 +123,7 @@ method init*(p: Identify) =
 proc identify*(p: Identify,
                conn: Connection,
                remotePeerInfo: PeerInfo): Future[IdentifyInfo] {.async, gcsafe.} =
+  trace "initiating identify"
   var message = await conn.readLp()
   if len(message) == 0:
     trace "identify: Invalid or empty message received!"

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -63,7 +63,7 @@ proc handle*(p: PubSubPeer, conn: Connection) {.async.} =
       await p.handler(p, @[msg])
       p.recvdRpcCache.put($hexData.hash)
   except CatchableError as exc:
-    error "exception occurred in PubSubPeer.handle", exc = exc.msg
+    trace "Exception occurred in PubSubPeer.handle", exc = exc.msg
   finally:
     trace "exiting pubsub peer read loop", peer = p.id
     if not conn.closed():
@@ -101,7 +101,7 @@ proc send*(p: PubSubPeer, msgs: seq[RPCMsg]) {.async.} =
                                                         encoded = encodedHex
 
   except CatchableError as exc:
-    trace "exception occurred in PubSubPeer.send", exc = exc.msg
+    trace "Exception occurred in PubSubPeer.send", exc = exc.msg
 
 proc sendMsg*(p: PubSubPeer,
               peerId: PeerID,

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -42,7 +42,7 @@ proc readLoop(sconn: SecureConn, stream: BufferStream) {.async.} =
 
       await stream.pushTo(msg)
   except CatchableError as exc:
-    trace "exception occurred Secure.readLoop", exc = exc.msg
+    trace "Exception occurred Secure.readLoop", exc = exc.msg
   finally:
     if not sconn.closed:
       await sconn.close()
@@ -63,7 +63,8 @@ proc handleConn*(s: Secure, conn: Connection, initiator: bool = false): Future[C
       if not isNil(sconn) and not sconn.closed:
         asyncCheck sconn.close()
 
-  result.peerInfo = PeerInfo.init(sconn.peerInfo.publicKey.get())
+  if not isNil(sconn.peerInfo) and sconn.peerInfo.publicKey.isSome:
+    result.peerInfo = PeerInfo.init(sconn.peerInfo.publicKey.get())
 
 method init*(s: Secure) {.gcsafe.} =
   proc handle(conn: Connection, proto: string) {.async, gcsafe.} =

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -51,24 +51,36 @@ proc newLPStreamEOFError*(): ref Exception {.inline.} =
 method closed*(s: LPStream): bool {.base, inline.} =
   s.isClosed
 
-method read*(s: LPStream, n = -1): Future[seq[byte]] {.base, async.} =
+method read*(s: LPStream,
+             n = -1):
+             Future[seq[byte]] {.base, async.} =
   doAssert(false, "not implemented!")
 
-method readExactly*(s: LPStream, pbytes: pointer,
-                    nbytes: int): Future[void] {.base, async.} =
+method readExactly*(s: LPStream,
+                    pbytes: pointer,
+                    nbytes: int):
+                    Future[void] {.base, async.} =
   doAssert(false, "not implemented!")
 
-method readLine*(s: LPStream, limit = 0, sep = "\r\n"): Future[string]
+method readLine*(s: LPStream,
+                 limit = 0,
+                 sep = "\r\n"):
+                 Future[string]
   {.base, async.} =
   doAssert(false, "not implemented!")
 
-method readOnce*(s: LPStream, pbytes: pointer, nbytes: int): Future[int]
+method readOnce*(s: LPStream,
+                 pbytes: pointer,
+                 nbytes: int):
+                 Future[int]
   {.base, async.} =
   doAssert(false, "not implemented!")
 
 method readUntil*(s: LPStream,
-                  pbytes: pointer, nbytes: int,
-                  sep: seq[byte]): Future[int]
+                  pbytes: pointer,
+                  nbytes: int,
+                  sep: seq[byte]):
+                  Future[int]
   {.base, async.} =
   doAssert(false, "not implemented!")
 

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -285,7 +285,7 @@ proc start*(s: Switch): Future[seq[Future[void]]] {.async, gcsafe.} =
     try:
       await s.upgradeIncoming(conn) # perform upgrade on incoming connection
     except CatchableError as exc:
-      trace "exception occurred in Switch.start", exc = exc.msg
+      trace "Exception occurred in Switch.start", exc = exc.msg
     finally:
       if not isNil(conn) and not conn.closed:
         await conn.close()

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -62,7 +62,7 @@ method upgrade*(t: Transport) {.base, async, gcsafe.} =
 method handles*(t: Transport, address: MultiAddress): bool {.base, gcsafe.} =
   ## check if transport supportes the multiaddress
 
-  # by default we skip circuit addresses to avoid 
+  # by default we skip circuit addresses to avoid
   # having to repeat the check in every transport
   address.protocols.filterIt( it == multiCodec("p2p-circuit") ).len == 0
 

--- a/tests/testinterop.nim
+++ b/tests/testinterop.nim
@@ -59,9 +59,9 @@ proc readLp*(s: StreamTransport): Future[seq[byte]] {.async, gcsafe.} =
     result.setLen(size)
     if size > 0.uint:
       await s.readExactly(addr result[0], int(size))
-  except LPStreamIncompleteError as exc:
+  except TransportIncompleteError as exc:
     trace "remote connection ended unexpectedly", exc = exc.msg
-  except LPStreamReadError as exc:
+  except TransportError as exc:
     trace "unable to read from remote connection", exc = exc.msg
 
 proc createNode*(privKey: Option[PrivateKey] = none(PrivateKey),
@@ -382,10 +382,12 @@ suite "Interop":
       await daemonNode.connect(nativePeer.peerId, nativePeer.addrs)
       var stream = await daemonNode.openStream(nativePeer.peerId, protos)
 
-      while count < 10:
+      var count2 = 0
+      while count2 < 10:
         discard await stream.transp.writeLp(test)
         let line = await stream.transp.readLp()
         check test == cast[string](line)
+        inc(count2)
 
       result = 10 == (await wait(testFuture, 10.secs))
       await nativeNode.stop()


### PR DESCRIPTION
Properly cleanup the underlying bufferstream when closing the lpchannel.

Fixes #115.