### PR TITLE
add stream metrics

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -8,11 +8,12 @@ license       = "MIT"
 skipDirs      = @["tests", "examples", "Nim"]
 
 requires "nim > 0.19.4",
-         "secp256k1",
-         "nimcrypto >= 0.4.1",
-         "chronos >= 2.3.8",
          "bearssl >= 0.1.4",
          "chronicles >= 0.7.1",
+         "chronos >= 2.3.8",
+         "metrics",
+         "nimcrypto >= 0.4.1",
+         "secp256k1",
          "stew"
 
 proc runTest(filename: string) =

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -8,8 +8,7 @@
 ## those terms.
 
 import options
-import chronos
-import chronicles
+import chronos, chronicles
 import ../protocol,
        ../../stream/bufferstream,
        ../../crypto/crypto,


### PR DESCRIPTION
- just BufferStream and Connection are tracked, for now
- flag checking is enforced more strictly in close(), since it became clear that instances are closed multiple times

The two metrics in Grafana, for the bootstrap node, while running eth2_network_simulation and starting/stopping an external node a couple of times:

![grafana](https://i.imgur.com/cn1KE29.png)

Weird behaviour:
- initial mismatch: we're starting with 30 Connection instances, but only 25 BufferStream ones. Early leak?
- strange inversion after starting the external node the first time: why are there more BufferStream instances than Connection ones?
- Connection leak after killing the external node: 10 Connection instances were not closed
- large number of connections created the second time the external node was started: why are we opening 10 Connection and BufferStream instances for just one node? Is the amount of new connections in direct relation with the number of blocks synced (the first time, 16 new ones were opened)? Aren't syncing connections supposed to be closed before the peer disconnects?
- 4 out of 10 new Connection objects are not closed after the external node is stopped