### PR TITLE
Require Nim v1.2.0 or higher

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -7,7 +7,10 @@ description   = "LibP2P implementation"
 license       = "MIT"
 skipDirs      = @["tests", "examples", "Nim"]
 
-requires "nim > 0.19.4",
+requires "nim >= 1.2.0",
+         "secp256k1",
+         "nimcrypto >= 0.4.1",
+         "chronos >= 2.3.8",
          "bearssl >= 0.1.4",
          "chronicles >= 0.7.1",
          "chronos >= 2.3.8",


### PR DESCRIPTION
As of `2b823bde68cfb5efbe145945e8c17593f44eda5a` this is required due to https://github.com/status-im/nim-secp256k1/issues/20