### PR TITLE
Fixed typo in link resulting in 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,16 +61,16 @@ nimble install libp2p
 ## Usage
 
 ### API
-The specification is available on [API.md](doc/API.md) (coming soon).
+The specification is available on [API.md](docs/API.md) (coming soon).
 
 ### Getting Started
-Please read the [GETTING_STARTED.md](doc/GETTING_STARTED.md) guide. 
+Please read the [GETTING_STARTED.md](docs/GETTING_STARTED.md) guide. 
 
 ### Tutorials and Examples 
 Examples can be found in the [examples folder](/examples).
 
 ### Using the Go Daemon
-Please find the installation and usage intructions in [GO_DAEMON.md](doc/GO_DAEMON.md). 
+Please find the installation and usage intructions in [GO_DAEMON.md](docs/GO_DAEMON.md). 
 
 Examples can be found in the [examples/go-daemon folder](https://github.com/status-im/nim-libp2p/tree/readme/examples/go-daemon);
 


### PR DESCRIPTION
It's a minor issue - but just wanted to bring up that the following links in the root README lead to a 404. This was because the README was pointing to a `doc/` folder instead of `docs/`. The respective directory changes were made for the following links: 
- API.md
- GETTING_STARTED.md
- GO_DAEMON.md