### PR TITLE
newTransport(): add "TransportFlags" param

### DIFF
--- a/libp2p/standard_setup.nim
+++ b/libp2p/standard_setup.nim
@@ -6,7 +6,6 @@ const
 
 import
   options, tables,
-  chronos,
   switch, peer, peerinfo, connection, multiaddress,
   crypto/crypto, transports/[transport, tcptransport],
   muxers/[muxer, mplex/mplex, mplex/types],
@@ -19,7 +18,7 @@ else:
   import protocols/secure/secio
 
 export
-  switch, peer, peerinfo, connection, multiaddress, crypto, ServerFlags
+  switch, peer, peerinfo, connection, multiaddress, crypto
 
 proc newStandardSwitch*(privKey = none(PrivateKey),
                         address = MultiAddress.init("/ip4/127.0.0.1/tcp/0"),
@@ -27,7 +26,7 @@ proc newStandardSwitch*(privKey = none(PrivateKey),
                         gossip = false,
                         verifySignature = libp2p_pubsub_verify,
                         sign = libp2p_pubsub_sign,
-                        serverFlags: set[ServerFlags] = {}): Switch =
+                        transportFlags: TransportFlags = {}): Switch =
   proc createMplex(conn: Connection): Muxer =
     result = newMplex(conn)
 
@@ -35,7 +34,7 @@ proc newStandardSwitch*(privKey = none(PrivateKey),
     seckey = privKey.get(otherwise = PrivateKey.random(ECDSA))
     peerInfo = PeerInfo.init(seckey, [address])
     mplexProvider = newMuxerProvider(createMplex, MplexCodec)
-    transports = @[Transport(newTransport(TcpTransport, serverFlags))]
+    transports = @[Transport(newTransport(TcpTransport, transportFlags))]
     muxers = {MplexCodec: mplexProvider}.toTable
     identify = newIdentify(peerInfo)
   when libp2p_secure == "noise":

--- a/libp2p/standard_setup.nim
+++ b/libp2p/standard_setup.nim
@@ -6,6 +6,7 @@ const
 
 import
   options, tables,
+  chronos,
   switch, peer, peerinfo, connection, multiaddress,
   crypto/crypto, transports/[transport, tcptransport],
   muxers/[muxer, mplex/mplex, mplex/types],
@@ -18,14 +19,15 @@ else:
   import protocols/secure/secio
 
 export
-  switch, peer, peerinfo, connection, multiaddress, crypto
+  switch, peer, peerinfo, connection, multiaddress, crypto, ServerFlags
 
 proc newStandardSwitch*(privKey = none(PrivateKey),
                         address = MultiAddress.init("/ip4/127.0.0.1/tcp/0"),
                         triggerSelf = false,
                         gossip = false,
                         verifySignature = libp2p_pubsub_verify,
-                        sign = libp2p_pubsub_sign): Switch =
+                        sign = libp2p_pubsub_sign,
+                        serverFlags: set[ServerFlags] = {}): Switch =
   proc createMplex(conn: Connection): Muxer =
     result = newMplex(conn)
 
@@ -33,7 +35,7 @@ proc newStandardSwitch*(privKey = none(PrivateKey),
     seckey = privKey.get(otherwise = PrivateKey.random(ECDSA))
     peerInfo = PeerInfo.init(seckey, [address])
     mplexProvider = newMuxerProvider(createMplex, MplexCodec)
-    transports = @[Transport(newTransport(TcpTransport))]
+    transports = @[Transport(newTransport(TcpTransport, serverFlags))]
     muxers = {MplexCodec: mplexProvider}.toTable
     identify = newIdentify(peerInfo)
   when libp2p_secure == "noise":

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -22,8 +22,6 @@ import connection,
        errors,
        peer
 
-export ServerFlags
-
 logScope:
   topic = "Switch"
 
@@ -284,7 +282,7 @@ proc mount*[T: LPProtocol](s: Switch, proto: T) {.gcsafe.} =
 
   s.ms.addHandler(proto.codec, proto)
 
-proc start*(s: Switch, serverFlags: set[ServerFlags] = {}): Future[seq[Future[void]]] {.async, gcsafe.} =
+proc start*(s: Switch): Future[seq[Future[void]]] {.async, gcsafe.} =
   trace "starting switch"
 
   proc handle(conn: Connection): Future[void] {.async, closure, gcsafe.} =
@@ -300,7 +298,7 @@ proc start*(s: Switch, serverFlags: set[ServerFlags] = {}): Future[seq[Future[vo
   for t in s.transports: # for each transport
     for i, a in s.peerInfo.addrs:
       if t.handles(a): # check if it handles the multiaddr
-        var server = await t.listen(a, handle, serverFlags)
+        var server = await t.listen(a, handle)
         s.peerInfo.addrs[i] = t.ma # update peer's address
         startFuts.add(server)
 

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -22,6 +22,8 @@ import connection,
        errors,
        peer
 
+export ServerFlags
+
 logScope:
   topic = "Switch"
 
@@ -282,7 +284,7 @@ proc mount*[T: LPProtocol](s: Switch, proto: T) {.gcsafe.} =
 
   s.ms.addHandler(proto.codec, proto)
 
-proc start*(s: Switch): Future[seq[Future[void]]] {.async, gcsafe.} =
+proc start*(s: Switch, serverFlags: set[ServerFlags] = {}): Future[seq[Future[void]]] {.async, gcsafe.} =
   trace "starting switch"
 
   proc handle(conn: Connection): Future[void] {.async, closure, gcsafe.} =
@@ -298,7 +300,7 @@ proc start*(s: Switch): Future[seq[Future[void]]] {.async, gcsafe.} =
   for t in s.transports: # for each transport
     for i, a in s.peerInfo.addrs:
       if t.handles(a): # check if it handles the multiaddr
-        var server = await t.listen(a, handle)
+        var server = await t.listen(a, handle, serverFlags)
         s.peerInfo.addrs[i] = t.ma # update peer's address
         startFuts.add(server)
 

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -127,7 +127,7 @@ method listen*(t: TcpTransport,
   discard await procCall Transport(t).listen(ma, handler) # call base
 
   ## listen on the transport
-  t.server = createStreamServer(t.ma, connCb, {}, t)
+  t.server = createStreamServer(t.ma, connCb, {ReuseAddr}, t)
   t.server.start()
 
   # always get the resolved address in case we're bound to 0.0.0.0:0

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -16,6 +16,8 @@ import transport,
        ../multicodec,
        ../stream/chronosstream
 
+export ServerFlags
+
 logScope:
   topic = "TcpTransport"
 
@@ -122,12 +124,13 @@ method close*(t: TcpTransport) {.async, gcsafe.} =
 
 method listen*(t: TcpTransport,
                ma: MultiAddress,
-               handler: ConnHandler):
+               handler: ConnHandler,
+               serverFlags: set[ServerFlags] = {}):
                Future[Future[void]] {.async, gcsafe.} =
   discard await procCall Transport(t).listen(ma, handler) # call base
 
   ## listen on the transport
-  t.server = createStreamServer(t.ma, connCb, {ReuseAddr}, t)
+  t.server = createStreamServer(t.ma, connCb, serverFlags, t)
   t.server.start()
 
   # always get the resolved address in case we're bound to 0.0.0.0:0

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -127,7 +127,7 @@ method listen*(t: TcpTransport,
   discard await procCall Transport(t).listen(ma, handler) # call base
 
   ## listen on the transport
-  t.server = createStreamServer(t.ma, connCb, t.serverFlags, t)
+  t.server = createStreamServer(t.ma, connCb, transportFlagsToServerFlags(t.flags), t)
   t.server.start()
 
   # always get the resolved address in case we're bound to 0.0.0.0:0

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -16,8 +16,6 @@ import transport,
        ../multicodec,
        ../stream/chronosstream
 
-export ServerFlags
-
 logScope:
   topic = "TcpTransport"
 
@@ -124,13 +122,12 @@ method close*(t: TcpTransport) {.async, gcsafe.} =
 
 method listen*(t: TcpTransport,
                ma: MultiAddress,
-               handler: ConnHandler,
-               serverFlags: set[ServerFlags] = {}):
+               handler: ConnHandler):
                Future[Future[void]] {.async, gcsafe.} =
   discard await procCall Transport(t).listen(ma, handler) # call base
 
   ## listen on the transport
-  t.server = createStreamServer(t.ma, connCb, serverFlags, t)
+  t.server = createStreamServer(t.ma, connCb, t.serverFlags, t)
   t.server.start()
 
   # always get the resolved address in case we're bound to 0.0.0.0:0

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -14,6 +14,8 @@ import ../connection,
        ../multicodec,
        ../errors
 
+export ServerFlags
+
 type
   ConnHandler* = proc (conn: Connection): Future[void] {.gcsafe.}
 
@@ -39,7 +41,8 @@ method close*(t: Transport) {.base, async, gcsafe.} =
 
 method listen*(t: Transport,
                ma: MultiAddress,
-               handler: ConnHandler):
+               handler: ConnHandler,
+               serverFlags: set[ServerFlags] = {}):
                Future[Future[void]] {.base, async, gcsafe.} =
   ## listen for incoming connections
   t.ma = ma

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -24,13 +24,15 @@ type
     connections*: seq[Connection]
     handler*: ConnHandler
     multicodec*: MultiCodec
+    serverFlags*: set[ServerFlags]
 
 method init*(t: Transport) {.base, gcsafe.} =
   ## perform protocol initialization
   discard
 
-proc newTransport*(t: typedesc[Transport]): t {.gcsafe.} =
+proc newTransport*(t: typedesc[Transport], serverFlags: set[ServerFlags] = {}): t {.gcsafe.} =
   new result
+  result.serverFlags = serverFlags
   result.init()
 
 method close*(t: Transport) {.base, async, gcsafe.} =
@@ -41,8 +43,7 @@ method close*(t: Transport) {.base, async, gcsafe.} =
 
 method listen*(t: Transport,
                ma: MultiAddress,
-               handler: ConnHandler,
-               serverFlags: set[ServerFlags] = {}):
+               handler: ConnHandler):
                Future[Future[void]] {.base, async, gcsafe.} =
   ## listen for incoming connections
   t.ma = ma

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -7,32 +7,43 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import sequtils
+import sequtils, tables
 import chronos, chronicles
 import ../connection,
        ../multiaddress,
        ../multicodec,
        ../errors
 
-export ServerFlags
-
 type
   ConnHandler* = proc (conn: Connection): Future[void] {.gcsafe.}
+
+  TransportFlag* {.pure.} = enum
+    ReuseAddr
+
+  TransportFlags* = set[TransportFlag]
 
   Transport* = ref object of RootObj
     ma*: Multiaddress
     connections*: seq[Connection]
     handler*: ConnHandler
     multicodec*: MultiCodec
-    serverFlags*: set[ServerFlags]
+    flags*: TransportFlags
+
+proc transportFlagsToServerFlags*(flags: TransportFlags): set[ServerFlags] {.gcsafe.} =
+  let transportFlagToServerFlagMapping = {
+      TransportFlag.ReuseAddr: ServerFlags.ReuseAddr,
+    }.toTable()
+
+  for flag in flags:
+    result.incl(transportFlagToServerFlagMapping[flag])
 
 method init*(t: Transport) {.base, gcsafe.} =
   ## perform protocol initialization
   discard
 
-proc newTransport*(t: typedesc[Transport], serverFlags: set[ServerFlags] = {}): t {.gcsafe.} =
+proc newTransport*(t: typedesc[Transport], flags: TransportFlags = {}): t {.gcsafe.} =
   new result
-  result.serverFlags = serverFlags
+  result.flags = flags
   result.init()
 
 method close*(t: Transport) {.base, async, gcsafe.} =


### PR DESCRIPTION
in order to avoid failures when restarting the process while the OS is
keeping open sockets from previous runs