### PR TITLE
handle a few exceptions

### DIFF
--- a/libp2p/connection.nim
+++ b/libp2p/connection.nim
@@ -127,7 +127,12 @@ method close*(s: Connection) {.async, gcsafe.} =
 
     if not isNil(s.stream) and not s.stream.closed:
       trace "closing child stream", closed = s.closed, conn = $s
-      await s.stream.close()
+      try:
+        await s.stream.close()
+      except CancelledError as exc:
+        raise exc
+      except CatchableError as exc:
+        debug "Error while closing child stream", err = exc.msg
 
     s.closeEvent.fire()
 

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -61,7 +61,7 @@ proc select*(m: MultistreamSelect,
   result = cast[string]((await conn.readLp(1024))) # read ms header
   result.removeSuffix("\n")
   if result != Codec:
-    error "handshake failed", codec = result.toHex()
+    notice "handshake failed", codec = result.toHex()
     raise newMultistreamHandshakeException()
 
   if proto.len() == 0: # no protocols, must be a handshake call

--- a/libp2p/muxers/mplex/coder.nim
+++ b/libp2p/muxers/mplex/coder.nim
@@ -50,26 +50,32 @@ proc writeMsg*(conn: Connection,
   trace "sending data over mplex", id,
                                   msgType,
                                   data = data.len
-  var
+  try:
+    var
       left = data.len
       offset = 0
-  while left > 0 or data.len == 0:
-    let
-      chunkSize = if left > MaxMsgSize: MaxMsgSize - 64 else: left
-      chunk = if chunkSize > 0 : data[offset..(offset + chunkSize - 1)] else: data
-    ## write lenght prefixed
-    var buf = initVBuffer()
-    buf.writePBVarint(id shl 3 or ord(msgType).uint64)
-    buf.writePBVarint(chunkSize.uint64) # size should be always sent
-    buf.finish()
-    left = left - chunkSize
-    offset = offset + chunkSize
-    try:
+    while left > 0 or data.len == 0:
+      let
+        chunkSize = if left > MaxMsgSize: MaxMsgSize - 64 else: left
+        chunk = if chunkSize > 0 : data[offset..(offset + chunkSize - 1)] else: data
+      ## write lenght prefixed
+      var buf = initVBuffer()
+      buf.writePBVarint(id shl 3 or ord(msgType).uint64)
+      buf.writePBVarint(chunkSize.uint64) # size should be always sent
+      buf.finish()
+      left = left - chunkSize
+      offset = offset + chunkSize
       await conn.write(buf.buffer & chunk)
-    except LPStreamIncompleteError as exc:
-      trace "unable to send message", exc = exc.msg
-    if data.len == 0:
-      return
+
+      if data.len == 0:
+        return
+  except LPStreamEOFError:
+    trace "Ignoring EOF while writing"
+  except CatchableError as exc:
+    # TODO these exceptions are ignored since it's likely that if writes are
+    #      are failing, the underlying connection is already closed - this needs
+    #      more cleanup though
+    debug "Could not write to connection", msg = exc.msg
 
 proc writeMsg*(conn: Connection,
                id: uint64,

--- a/libp2p/muxers/mplex/coder.nim
+++ b/libp2p/muxers/mplex/coder.nim
@@ -71,6 +71,8 @@ proc writeMsg*(conn: Connection,
         return
   except LPStreamEOFError:
     trace "Ignoring EOF while writing"
+  except CancelledError as exc:
+    raise exc
   except CatchableError as exc:
     # TODO these exceptions are ignored since it's likely that if writes are
     #      are failing, the underlying connection is already closed - this needs

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -203,8 +203,15 @@ method publish*(p: PubSub,
       trace "triggering handler", topicID = topic
       try:
         await h(topic, data)
+      except LPStreamEOFError:
+        trace "Ignoring EOF while writing"
+      except CancelledError as exc:
+        raise exc
       except CatchableError as exc:
-        debug "Topic handler failed", msg = exc.msg
+        # TODO these exceptions are ignored since it's likely that if writes are
+        #      are failing, the underlying connection is already closed - this needs
+        #      more cleanup though
+        debug "Could not write to pubsub connection", msg = exc.msg
 
 method initPubSub*(p: PubSub) {.base.} =
   ## perform pubsub initializaion

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -201,7 +201,10 @@ method publish*(p: PubSub,
   if p.triggerSelf and topic in p.topics:
     for h in p.topics[topic].handler:
       trace "triggering handler", topicID = topic
-      await h(topic, data)
+      try:
+        await h(topic, data)
+      except CatchableError as exc:
+        debug "Topic handler failed", msg = exc.msg
 
 method initPubSub*(p: PubSub) {.base.} =
   ## perform pubsub initializaion

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -455,8 +455,13 @@ method write*(sconn: NoiseConnection, message: seq[byte]): Future[void] {.async.
       outbuf &= besize
       outbuf &= cipher
       await sconn.stream.write(outbuf)
-  except AsyncStreamWriteError:
-    trace "Could not write to connection"
+  except LPStreamEOFError:
+    trace "Ignoring EOF while writing"
+  except CatchableError as exc:
+    # TODO these exceptions are ignored since it's likely that if writes are
+    #      are failing, the underlying connection is already closed - this needs
+    #      more cleanup though
+    debug "Could not write to connection", msg = exc.msg
 
 method handshake*(p: Noise, conn: Connection, initiator: bool = false): Future[SecureConn] {.async.} =
   trace "Starting Noise handshake", initiator

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -457,6 +457,8 @@ method write*(sconn: NoiseConnection, message: seq[byte]): Future[void] {.async.
       await sconn.stream.write(outbuf)
   except LPStreamEOFError:
     trace "Ignoring EOF while writing"
+  except CancelledError as exc:
+    raise exc
   except CatchableError as exc:
     # TODO these exceptions are ignored since it's likely that if writes are
     #      are failing, the underlying connection is already closed - this needs

--- a/libp2p/protocols/secure/secio.nim
+++ b/libp2p/protocols/secure/secio.nim
@@ -236,8 +236,13 @@ method write*(sconn: SecioConn, message: seq[byte]) {.async.} =
 
       trace "Writing message", message = msg.shortLog, left, offset
       await sconn.stream.write(msg)
-  except AsyncStreamWriteError:
-    trace "Could not write to connection"
+  except LPStreamEOFError as exc:
+    trace "EOF while writing"
+  except CatchableError as exc:
+    # TODO these exceptions are ignored since it's likely that if writes are
+    #      are failing, the underlying connection is already closed - this needs
+    #      more cleanup though
+    debug "Could not write to connection", msg = exc.msg
 
 proc newSecioConn(conn: Connection,
                   hash: string,

--- a/libp2p/protocols/secure/secio.nim
+++ b/libp2p/protocols/secure/secio.nim
@@ -236,8 +236,10 @@ method write*(sconn: SecioConn, message: seq[byte]) {.async.} =
 
       trace "Writing message", message = msg.shortLog, left, offset
       await sconn.stream.write(msg)
-  except LPStreamEOFError as exc:
-    trace "EOF while writing"
+  except LPStreamEOFError:
+    trace "Ignoring EOF while writing"
+  except CancelledError as exc:
+    raise exc
   except CatchableError as exc:
     # TODO these exceptions are ignored since it's likely that if writes are
     #      are failing, the underlying connection is already closed - this needs

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -67,6 +67,12 @@ method close*(s: ChronosStream) {.async.} =
   if not s.closed:
     trace "shutting chronos stream", address = $s.client.remoteAddress()
     if not s.client.closed():
-      await s.client.closeWait()
+      try:
+        await s.client.closeWait()
+      except CancelledError as exc:
+        raise exc
+      except CatchableError as exc:
+        # Shouldn't happen, but we can't be sure
+        warn "error while closing connection", msg = exc.msg
 
     s.closeEvent.fire()

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -181,6 +181,8 @@ proc upgradeOutgoing(s: Switch, conn: Connection): Future[Connection] {.async, g
 
     await s.mux(result) # mux it if possible
     s.connections[conn.peerInfo.id] = result
+  except CancelledError as exc:
+    raise exc
   except CatchableError as exc:
     debug "Couldn't upgrade outgoing connection", msg = exc.msg
     return nil
@@ -207,6 +209,8 @@ proc upgradeIncoming(s: Switch, conn: Connection) {.async, gcsafe.} =
       # handle subsequent requests
       await ms.handle(sconn)
       await sconn.close()
+    except CancelledError as exc:
+      raise exc
     except CatchableError as exc:
       debug "ending secured handler", err = exc.msg
 

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -84,6 +84,8 @@ proc connCb(server: StreamServer,
     # we don't need result connection in this case
     # as it's added inside connHandler
     discard t.connHandler(client, false)
+  except CancelledError as exc:
+    raise exc
   except CatchableError as err:
     debug "Connection setup failed", err = err.msg
     if not client.closed:

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -153,7 +153,7 @@ suite "GossipSub internal":
       gossipSub.fanout[topic1] = initHashSet[string]()
       gossipSub.fanout[topic2] = initHashSet[string]()
       gossipSub.lastFanoutPubSub[topic1] = Moment.fromNow(100.millis)
-      gossipSub.lastFanoutPubSub[topic2] = Moment.fromNow(5.seconds)
+      gossipSub.lastFanoutPubSub[topic2] = Moment.fromNow(1.minutes)
 
       var conns = newSeq[Connection]()
       for i in 0..<6:


### PR DESCRIPTION
Some of these are maybe too aggressive, but in return, they'll log
their exception - more refactoring needed to sort this out - right now
we get crashes on unhandled exceptions of unknown origin

* during connection setup
* while closing channels
* while processing pubsubs