### PR TITLE
call write until all is written out

### DIFF
--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -56,9 +56,9 @@ method write*(s: ChronosStream, msg: seq[byte]) {.async.} =
     return
 
   withExceptions:
-    # Returns 0 sometimes when write fails - but there's not much we can do here?
-    if (await s.client.write(msg)) != msg.len:
-      raise (ref LPStreamError)(msg: "Write couldn't finish writing")
+    var writen = 0
+    while (writen < msg.len):
+      writen += await s.client.write(msg[writen..<msg.len]) # TODO: does the slice create a copy here?
 
 method closed*(s: ChronosStream): bool {.inline.} =
   result = s.client.closed


### PR DESCRIPTION
Don't give up until all bytes are written. 

@cheatfate as I understand it, this api can do partial writes, does this look appropriate?