### PR TITLE
Half closed

### DIFF
--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -162,5 +162,7 @@ method close*(s: LPChannel) {.async, gcsafe.} =
                                   oid = s.oid
 
 method reset*(s: LPChannel) {.base, async.} =
-  await s.resetMessage()
+  # we asyncCheck here becayse the other end
+  # might be dead
+  asyncCheck s.resetMessage()
   await procCall BufferStream(s).close()

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -39,7 +39,6 @@ type
     initiator*: bool              # initiated remotely or locally flag
     isLazy*: bool                 # is channel lazy
     isOpen*: bool                 # has channel been oppened (only used with isLazy)
-    isReset*: bool                # has channel been reset
     closedLocal*: bool            # has channel been closed locally
     msgCode*: MessageType         # cached in/out message code
     closeCode*: MessageType       # cached in/out close code

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -28,7 +28,7 @@ logScope:
 ## | State    | Closed local      | Closed remote
 ## |=============================================
 ## | Read     | Yes (until EOF)   | No
-## | Write    | No	              | Yes
+## | Write    | No                | Yes
 ##
 
 type
@@ -169,6 +169,10 @@ method close*(s: LPChannel) {.async, gcsafe.} =
                                    initiator = s.initiator,
                                    name = s.name,
                                    oid = s.oid
+  # TODO: we should install a timer that on expire
+  # will make sure the channel did close by the remote
+  # so the hald-closed flow completed, if it didn't
+  # we should send a `reset` and move on.
   await s.closeMessage()
   s.closedLocal = true
   if s.atEof: # already closed by remote close parent buffer imediately

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -24,19 +24,19 @@ logScope:
 
 type
   LPChannel* = ref object of BufferStream
-    id*: uint64
-    name*: string
-    conn*: Connection
-    initiator*: bool
-    isLazy*: bool
-    isOpen*: bool
-    isReset*: bool
-    closedLocal*: bool
-    closedRemote*: bool
-    handlerFuture*: Future[void]
-    msgCode*: MessageType
-    closeCode*: MessageType
-    resetCode*: MessageType
+    id*: uint64                   # channel id
+    name*: string                 # name of the channel (for debugging)
+    conn*: Connection             # wrapped connection used to for writing
+    initiator*: bool              # initiated remotely or locally flag
+    isLazy*: bool                 # is channel lazy
+    isOpen*: bool                 # has channel been oppened (only used with isLazy)
+    isReset*: bool                # has channel been reset
+    closedLocal*: bool            # has channel been closed locally
+    closedRemote*: bool           # has channel been closed remotely
+    msgCode*: MessageType         # cached in/out message code
+    closeCode*: MessageType       # cached in/out close code
+    resetCode*: MessageType       # cached in/out reset code
+    resetLock*: AsyncLock
 
 proc newChannel*(id: uint64,
                  conn: Connection,

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -102,8 +102,7 @@ method handle*(m: Mplex) {.async, gcsafe.} =
             var fut = newFuture[void]()
             proc handler() {.async.} =
               tryAndWarn "mplex channel handler":
-                var conn = newConnection(channel)
-                await m.streamHandler(conn)
+                await m.streamHandler(stream)
 
             fut = handler()
             m.handlerFuts.add(fut)

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -16,6 +16,7 @@ import chronos, chronicles
 import ../muxer,
        ../../connection,
        ../../stream/lpstream,
+       ../../stream/bufferstream,
        ../../utility,
        ../../errors,
        coder,
@@ -101,7 +102,8 @@ method handle*(m: Mplex) {.async, gcsafe.} =
             var fut = newFuture[void]()
             proc handler() {.async.} =
               tryAndWarn "mplex channel handler":
-                await m.streamHandler(channel)
+                var conn = newConnection(channel)
+                await m.streamHandler(conn)
 
             fut = handler()
             m.handlerFuts.add(fut)

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -109,10 +109,8 @@ method handle*(m: Mplex) {.async, gcsafe.} =
             proc handler() {.async.} =
               tryAndWarn "mplex channel handler":
                 await m.streamHandler(channel)
-              # TODO closing channel
-              # or doing cleanupChann
-              # will make go interop tests fail
-              # need to investigate why
+
+            asyncCheck handler()
 
         of MessageType.MsgIn, MessageType.MsgOut:
           trace "pushing data to channel", id = id,

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -200,6 +200,11 @@ method close*(m: Mplex) {.async, gcsafe.} =
 
   # send a reset as well, this will release
   # local resources deterministically
+  # TODO: shouldn't be needed once close has a
+  # timeout to track the close flow, if the timeout
+  # expires, it will automatically send a reset,
+  # this wouldn't probably be needed. Re-evaluate
+  # as soon as timer is in place.
   checkFutures(
     await allFinished(
       toSeq(m.remote.values).mapIt(it.reset()) &

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -71,13 +71,6 @@ proc newStreamInternal*(m: Mplex,
 #     m.getChannelList(initiator).del(chann.id)
 #     trace "cleaned up channel", id = chann.id
 
-proc cleanupChann(chann: LPChannel) {.async.} =
-  trace "cleaning up channel", id = chann.id
-  await chann.reset()
-  await chann.close()
-  await chann.cleanUp()
-  trace "cleaned up channel", id = chann.id
-
 method handle*(m: Mplex) {.async, gcsafe.} =
   trace "starting mplex main loop", oid = m.oid
   try:
@@ -121,10 +114,6 @@ method handle*(m: Mplex) {.async, gcsafe.} =
               # will make go interop tests fail
               # need to investigate why
 
-            if not initiator:
-              m.handlers[0][id] = handler()
-            else:
-              m.handlers[1][id] = handler()
         of MessageType.MsgIn, MessageType.MsgOut:
           trace "pushing data to channel", id = id,
                                            initiator = initiator,
@@ -216,8 +205,6 @@ method close*(m: Mplex) {.async, gcsafe.} =
 
   checkFutures(futs)
 
-  m.handlers[0].clear()
-  m.handlers[1].clear()
   m.remote.clear()
   m.local.clear()
   m.isClosed = true

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -192,19 +192,6 @@ method close*(m: Mplex) {.async, gcsafe.} =
 
   trace "closing mplex muxer", oid = m.oid
 
-  # let the other end know that we're closing
-  checkFutures(
-    await allFinished(
-      toSeq(m.remote.values).mapIt(it.close()) &
-        toSeq(m.local.values).mapIt(it.close())))
-
-  # send a reset as well, this will release
-  # local resources deterministically
-  # TODO: shouldn't be needed once close has a
-  # timeout to track the close flow, if the timeout
-  # expires, it will automatically send a reset,
-  # this wouldn't probably be needed. Re-evaluate
-  # as soon as timer is in place.
   checkFutures(
     await allFinished(
       toSeq(m.remote.values).mapIt(it.reset()) &

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -20,7 +20,8 @@ import pubsub,
        ../../peerinfo,
        ../../connection,
        ../../peer,
-       ../../errors
+       ../../errors,
+       ../../utility
 
 logScope:
   topic = "GossipSub"

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -113,7 +113,7 @@ proc send*(p: PubSubPeer, msgs: seq[RPCMsg]) {.async.} =
       p.onConnect.wait().addCallback do (udata: pointer):
           asyncCheck sendToRemote()
       trace "enqueued message to send at a later time", peer = p.id,
-                                                        encoded = encodedHex
+                                                        encoded = digest
 
   except CatchableError as exc:
     trace "Exception occurred in PubSubPeer.send", exc = exc.msg

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -267,12 +267,12 @@ template read_s: untyped =
 
 proc receiveHSMessage(sconn: Connection): Future[seq[byte]] {.async.} =
   var besize: array[2, byte]
-  await sconn.stream.readExactly(addr besize[0], besize.len)
+  await sconn.readExactly(addr besize[0], besize.len)
   let size = uint16.fromBytesBE(besize).int
   trace "receiveHSMessage", size
   var buffer = newSeq[byte](size)
   if buffer.len > 0:
-    await sconn.stream.readExactly(addr buffer[0], buffer.len)
+    await sconn.readExactly(addr buffer[0], buffer.len)
   return buffer
 
 proc sendHSMessage(sconn: Connection; buf: seq[byte]) {.async.} =

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -267,12 +267,12 @@ template read_s: untyped =
 
 proc receiveHSMessage(sconn: Connection): Future[seq[byte]] {.async.} =
   var besize: array[2, byte]
-  await sconn.readExactly(addr besize[0], besize.len)
+  await sconn.stream.readExactly(addr besize[0], besize.len)
   let size = uint16.fromBytesBE(besize).int
   trace "receiveHSMessage", size
   var buffer = newSeq[byte](size)
   if buffer.len > 0:
-    await sconn.readExactly(addr buffer[0], buffer.len)
+    await sconn.stream.readExactly(addr buffer[0], buffer.len)
   return buffer
 
 proc sendHSMessage(sconn: Connection; buf: seq[byte]) {.async.} =

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -55,8 +55,7 @@ method secure*(s: Secure, conn: Connection, initiator: bool): Future[Connection]
     result = await s.handleConn(conn, initiator)
   except CatchableError as exc:
     warn "securing connection failed", msg = exc.msg
-    if not conn.closed():
-      await conn.close()
+    await conn.close()
 
 method readExactly*(s: SecureConn,
                     pbytes: pointer,

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -115,8 +115,8 @@ proc initBufferStream*(s: BufferStream,
   s.dataReadEvent = newAsyncEvent()
   s.lock = newAsyncLock()
   s.writeLock = newAsyncLock()
-  s.isClosed = false
   s.closeEvent = newAsyncEvent()
+  s.isClosed = false
 
   if not(isNil(handler)):
     s.writeHandler = proc (data: seq[byte]) {.async, gcsafe.} =

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -265,10 +265,10 @@ proc pipe*(s: BufferStream,
   ## interface methods `read*` and `write` are
   ## piped.
   ##
-  if s.isPiped:
+  if not(isNil(s.piped)):
     raise newAlreadyPipedError()
 
-  s.isPiped = true
+  s.piped = target
   let oldHandler = target.writeHandler
   proc handler(data: seq[byte]) {.async, closure, gcsafe.} =
     if not isNil(oldHandler):
@@ -295,7 +295,7 @@ proc `|`*(s: BufferStream, target: BufferStream): BufferStream =
   ## pipe operator to make piping less verbose
   pipe(s, target)
 
-method close*(s: BufferStream) {.async.} =
+method close*(s: BufferStream) {.async, gcsafe.} =
   ## close the stream and clear the buffer
   if not s.isClosed:
     trace "closing bufferstream", oid = s.oid
@@ -313,4 +313,4 @@ method close*(s: BufferStream) {.async.} =
       await s.piped.close()
 
   else:
-    trace "attempt to close an already closed bufferstream", trace=getStackTrace()
+    trace "attempt to close an already closed bufferstream", trace = getStackTrace()

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -309,8 +309,5 @@ method close*(s: BufferStream) {.async, gcsafe.} =
     libp2p_open_bufferstream.dec()
     trace "bufferstream closed", oid = s.oid
 
-    if not(isNil(s.piped)):
-      await s.piped.close()
-
   else:
     trace "attempt to close an already closed bufferstream", trace = getStackTrace()

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -36,6 +36,9 @@ import ../stream/lpstream
 
 export lpstream
 
+logScope:
+  topic = "BufferStream"
+
 const
   BufferStreamTrackerName* = "libp2p.bufferstream"
   DefaultBufferSize* = 1024
@@ -295,8 +298,9 @@ method close*(s: BufferStream) {.async.} =
         r.fail(newLPStreamEOFError())
     s.dataReadEvent.fire()
     s.readBuf.clear()
-    s.closeEvent.fire()
-    s.isClosed = true
+
+    await procCall Connection(s).close() # call parent close
+
     inc getBufferStreamTracker().closed
     libp2p_open_bufferstream.dec()
   else:

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -84,7 +84,7 @@ type
     maxSize*: int                     # buffer's max size in bytes
     readBuf: Deque[byte]              # this is a ring buffer based dequeue
     readReqs*: Deque[Future[void]]    # use dequeue to fire reads in order
-    dataReadEvent: AsyncEvent         # event triggered when data has been consumed from the internal buffer
+    dataReadEvent*: AsyncEvent        # event triggered when data has been consumed from the internal buffer
     writeHandler*: WriteHandler       # user provided write callback
     writeLock*: AsyncLock             # write lock to guarantee ordered writes
     lock: AsyncLock                   # pushTo lock to guarantee ordered reads
@@ -115,9 +115,10 @@ proc initBufferStream*(s: BufferStream,
   s.dataReadEvent = newAsyncEvent()
   s.lock = newAsyncLock()
   s.writeLock = newAsyncLock()
-  s.writeHandler = handler
+  s.isClosed = false
+  s.closeEvent = newAsyncEvent()
 
-  if not(isNil(s.writeHandler)):
+  if not(isNil(handler)):
     s.writeHandler = proc (data: seq[byte]) {.async, gcsafe.} =
       defer:
         s.writeLock.release()
@@ -125,11 +126,9 @@ proc initBufferStream*(s: BufferStream,
 
       await handler(data)
 
-  s.closeEvent = newAsyncEvent()
-  inc getBufferStreamTracker().opened
   when chronicles.enabledLogLevel == LogLevel.TRACE:
     s.oid = genOid()
-  s.isClosed = false
+  inc getBufferStreamTracker().opened
   libp2p_open_bufferstream.inc()
 
 proc newBufferStream*(handler: WriteHandler = nil,
@@ -201,7 +200,7 @@ method readExactly*(s: BufferStream,
   if s.atEof:
     raise newLPStreamEOFError()
 
-  trace "read()", requested_bytes = nbytes, oid = s.oid
+  trace "readExactly()", requested_bytes = nbytes, oid = s.oid
   var index = 0
 
   if s.readBuf.len() == 0:

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -299,8 +299,6 @@ method close*(s: BufferStream) {.async.} =
     s.dataReadEvent.fire()
     s.readBuf.clear()
 
-    await procCall Connection(s).close() # call parent close
-
     inc getBufferStreamTracker().closed
     libp2p_open_bufferstream.dec()
   else:

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -128,6 +128,8 @@ proc initBufferStream*(s: BufferStream,
 
   when chronicles.enabledLogLevel == LogLevel.TRACE:
     s.oid = genOid()
+
+  trace "created bufferstream", oid = s.oid
   inc getBufferStreamTracker().opened
   libp2p_open_bufferstream.inc()
 
@@ -310,6 +312,7 @@ method close*(s: BufferStream) {.async, gcsafe.} =
 
     inc getBufferStreamTracker().closed
     libp2p_open_bufferstream.dec()
+
     trace "bufferstream closed", oid = s.oid
 
   else:

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -60,9 +60,9 @@ method write*(s: ChronosStream, msg: seq[byte]) {.async.} =
     return
 
   withExceptions:
-    var writen = 0
-    while (writen < msg.len):
-      writen += await s.client.write(msg[writen..<msg.len]) # TODO: does the slice create a copy here?
+    # Returns 0 sometimes when write fails - but there's not much we can do here?
+    if (await s.client.write(msg)) != msg.len:
+      raise (ref LPStreamError)(msg: "Write couldn't finish writing")
 
 method closed*(s: ChronosStream): bool {.inline.} =
   result = s.client.closed

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -56,9 +56,9 @@ method write*(s: ChronosStream, msg: seq[byte]) {.async.} =
     return
 
   withExceptions:
-    # Returns 0 sometimes when write fails - but there's not much we can do here?
-    if (await s.client.write(msg)) != msg.len:
-      raise (ref LPStreamError)(msg: "Write couldn't finish writing")
+    var writen = 0
+    while (writen < msg.len):
+      writen += await s.client.write(msg[writen..<msg.len]) # TODO: does the slice create a copy here?
 
 method closed*(s: ChronosStream): bool {.inline.} =
   result = s.client.closed

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -16,18 +16,11 @@ logScope:
 type ChronosStream* = ref object of LPStream
     client: StreamTransport
 
-proc onTransportClose(s: ChronosStream,
-                      client: StreamTransport) {.async.} =
-  await client.join()
-  trace "Transport closed, closing connection"
-  await s.close()
-
 proc newChronosStream*(client: StreamTransport): ChronosStream =
   new result
   result.client = client
   result.closeEvent = newAsyncEvent()
 
-  asyncCheck result.onTransportClose(result.client)
 
 template withExceptions(body: untyped) =
   try:

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -38,20 +38,23 @@ template withExceptions(body: untyped) =
 method readExactly*(s: ChronosStream,
                     pbytes: pointer,
                     nbytes: int): Future[void] {.async.} =
-  if s.client.atEof:
+  if s.atEof:
     raise newLPStreamEOFError()
 
   withExceptions:
     await s.client.readExactly(pbytes, nbytes)
 
 method readOnce*(s: ChronosStream, pbytes: pointer, nbytes: int): Future[int] {.async.} =
-  if s.client.atEof:
+  if s.atEof:
     raise newLPStreamEOFError()
 
   withExceptions:
     result = await s.client.readOnce(pbytes, nbytes)
 
 method write*(s: ChronosStream, msg: seq[byte]) {.async.} =
+  if s.closed:
+    raise newLPStreamClosedError()
+
   if msg.len == 0:
     return
 
@@ -62,6 +65,9 @@ method write*(s: ChronosStream, msg: seq[byte]) {.async.} =
 
 method closed*(s: ChronosStream): bool {.inline.} =
   result = s.client.closed
+
+method atEof*(s: ChronosStream): bool {.inline.} =
+  s.client.atEof()
 
 method close*(s: ChronosStream) {.async.} =
   if not s.closed:

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -16,10 +16,18 @@ logScope:
 type ChronosStream* = ref object of LPStream
     client: StreamTransport
 
+proc onTransportClose(s: ChronosStream,
+                      client: StreamTransport) {.async.} =
+  await client.join()
+  trace "Transport closed, closing connection"
+  await s.close()
+
 proc newChronosStream*(client: StreamTransport): ChronosStream =
   new result
   result.client = client
   result.closeEvent = newAsyncEvent()
+
+  asyncCheck result.onTransportClose(result.client)
 
 template withExceptions(body: untyped) =
   try:

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -15,6 +15,7 @@ import ../varint,
 type
   LPStream* = ref object of RootObj
     isClosed*: bool
+    isEof*: bool
     closeEvent*: AsyncEvent
     when chronicles.enabledLogLevel == LogLevel.TRACE:
       oid*: Oid
@@ -28,6 +29,7 @@ type
   LPStreamWriteError* = object of LPStreamError
     par*: ref Exception
   LPStreamEOFError* = object of LPStreamError
+  LPStreamClosedError* = object of LPStreamError
 
   InvalidVarintError* = object of LPStreamError
   MaxSizeError* = object of LPStreamError
@@ -59,8 +61,14 @@ proc newLPStreamIncorrectDefect*(m: string): ref Exception =
 proc newLPStreamEOFError*(): ref Exception =
   result = newException(LPStreamEOFError, "Stream EOF!")
 
+proc newLPStreamClosedError*(): ref Exception =
+  result = newException(LPStreamClosedError, "Stream Closed!")
+
 method closed*(s: LPStream): bool {.base, inline.} =
   s.isClosed
+
+method atEof*(s: LPStream): bool {.base, inline.} =
+  s.isEof
 
 method readExactly*(s: LPStream,
                     pbytes: pointer,

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -43,8 +43,8 @@ proc getTcpTransportTracker(): TcpTransportTracker {.gcsafe.} =
 
 proc dumpTracking(): string {.gcsafe.} =
   var tracker = getTcpTransportTracker()
-  result = "Opened transports: " & $tracker.opened & "\n" &
-           "Closed transports: " & $tracker.closed
+  result = "Opened tcp transports: " & $tracker.opened & "\n" &
+           "Closed tcp transports: " & $tracker.closed
 
 proc leakTransport(): bool {.gcsafe.} =
   var tracker = getTcpTransportTracker()
@@ -98,7 +98,6 @@ proc init*(T: type TcpTransport, flags: set[ServerFlags] = {}): T =
 
 method initTransport*(t: TcpTransport) =
   t.multicodec = multiCodec("tcp")
-
   inc getTcpTransportTracker().opened
 
 method close*(t: TcpTransport) {.async, gcsafe.} =

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -141,7 +141,7 @@ suite "Mplex":
         chann = newChannel(1, conn, true)
 
       await chann.pushTo(("Hello!").toBytes)
-      let closeFut = chann.closedByRemote()
+      let closeFut = chann.closeRemote()
 
       var data = newSeq[byte](6)
       await chann.readExactly(addr data[0], 6) # this should work, since there is data in the buffer
@@ -163,7 +163,7 @@ suite "Mplex":
       let
         conn = newConnection(newBufferStream(writeHandler))
         chann = newChannel(1, conn, true)
-      await chann.closedByRemote()
+      await chann.closeRemote()
       try:
         await chann.pushTo(@[byte(1)])
       except LPStreamEOFError:

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -387,8 +387,6 @@ suite "Mplex":
           check string.fromBytes(msg) == &"stream {count}!"
           count.inc
           await stream.close()
-          count.inc
-          await stream.close()
           if count == 10:
             done.complete()
 
@@ -403,7 +401,7 @@ suite "Mplex":
 
       let mplexDial = newMplex(conn)
       # TODO: Reenable once half-closed is working properly
-      # let mplexDialFut = mplexDial.handle()
+      let mplexDialFut = mplexDial.handle()
       for i in 1..10:
         let stream  = await mplexDial.newStream()
         await stream.writeLp(&"stream {i}!")
@@ -411,7 +409,7 @@ suite "Mplex":
 
       await done.wait(10.seconds)
       await conn.close()
-      # await mplexDialFut
+      await mplexDialFut
       await allFuturesThrowing(transport1.close(), transport2.close())
       await listenFut
 

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -276,10 +276,11 @@ suite "Mplex":
       let mplexDial = newMplex(conn)
       let stream = await mplexDial.newStream(lazy = true)
       let mplexDialFut = mplexDial.handle()
-      check not LPChannel(stream.stream).isOpen # assert lazy
+      let openState = cast[LPChannel](stream).isOpen
       await stream.writeLp("HELLO")
-      check LPChannel(stream.stream).isOpen # assert lazy
       await stream.close()
+
+      check not openState # assert lazy
 
       await done.wait(1.seconds)
       await conn.close()
@@ -387,6 +388,7 @@ suite "Mplex":
           check string.fromBytes(msg) == &"stream {count}!"
           count.inc
           await stream.close()
+          count.inc
           if count == 10:
             done.complete()
 

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -276,11 +276,10 @@ suite "Mplex":
       let mplexDial = newMplex(conn)
       let stream = await mplexDial.newStream(lazy = true)
       let mplexDialFut = mplexDial.handle()
-      let openState = cast[LPChannel](stream).isOpen
+      check not LPChannel(stream.stream).isOpen # assert lazy
       await stream.writeLp("HELLO")
+      check LPChannel(stream.stream).isOpen # assert lazy
       await stream.close()
-
-      check not openState # assert lazy
 
       await done.wait(1.seconds)
       await conn.close()

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -388,6 +388,7 @@ suite "Mplex":
           count.inc
           await stream.close()
           count.inc
+          await stream.close()
           if count == 10:
             done.complete()
 

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -122,7 +122,7 @@ suite "Mplex":
       await chann.close()
       try:
         await chann.write("Hello")
-      except LPStreamEOFError:
+      except LPStreamClosedError:
         result = true
       finally:
         await chann.reset()
@@ -204,7 +204,7 @@ suite "Mplex":
       await chann.reset()
       try:
         await chann.write(("Hello!").toBytes)
-      except LPStreamEOFError:
+      except LPStreamClosedError:
         result = true
       finally:
         await conn.close()

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -71,7 +71,7 @@ proc createSwitch(ma: MultiAddress; outgoing: bool): (Switch, PeerInfo) =
 suite "Noise":
   teardown:
     for tracker in testTrackers():
-      echo tracker.dump()
+      # echo tracker.dump()
       check tracker.isLeaked() == false
 
   test "e2e: handle write + noise":

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -71,6 +71,7 @@ proc createSwitch(ma: MultiAddress; outgoing: bool): (Switch, PeerInfo) =
 suite "Noise":
   teardown:
     for tracker in testTrackers():
+      echo tracker.dump()
       check tracker.isLeaked() == false
 
   test "e2e: handle write + noise":

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -102,51 +102,51 @@ suite "Switch":
 
     waitFor(testSwitch())
 
-  # test "e2e use switch no proto string":
-  #   proc testSwitch(): Future[bool] {.async, gcsafe.} =
-  #     let ma1: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
-  #     let ma2: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
+  test "e2e use switch no proto string":
+    proc testSwitch(): Future[bool] {.async, gcsafe.} =
+      let ma1: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
+      let ma2: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
 
-  #     var peerInfo1, peerInfo2: PeerInfo
-  #     var switch1, switch2: Switch
-  #     var awaiters: seq[Future[void]]
+      var peerInfo1, peerInfo2: PeerInfo
+      var switch1, switch2: Switch
+      var awaiters: seq[Future[void]]
 
-  #     (switch1, peerInfo1) = createSwitch(ma1)
+      (switch1, peerInfo1) = createSwitch(ma1)
 
-  #     proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
-  #       let msg = cast[string](await conn.readLp(1024))
-  #       check "Hello!" == msg
-  #       await conn.writeLp("Hello!")
-  #       await conn.close()
+      proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+        let msg = cast[string](await conn.readLp(1024))
+        check "Hello!" == msg
+        await conn.writeLp("Hello!")
+        await conn.close()
 
-  #     let testProto = new TestProto
-  #     testProto.codec = TestCodec
-  #     testProto.handler = handle
-  #     switch1.mount(testProto)
+      let testProto = new TestProto
+      testProto.codec = TestCodec
+      testProto.handler = handle
+      switch1.mount(testProto)
 
-  #     (switch2, peerInfo2) = createSwitch(ma2)
-  #     awaiters.add(await switch1.start())
-  #     awaiters.add(await switch2.start())
-  #     await switch2.connect(switch1.peerInfo)
-  #     let conn = await switch2.dial(switch1.peerInfo, TestCodec)
+      (switch2, peerInfo2) = createSwitch(ma2)
+      awaiters.add(await switch1.start())
+      awaiters.add(await switch2.start())
+      await switch2.connect(switch1.peerInfo)
+      let conn = await switch2.dial(switch1.peerInfo, TestCodec)
 
-  #     try:
-  #       await conn.writeLp("Hello!")
-  #       let msg = cast[string](await conn.readLp(1024))
-  #       check "Hello!" == msg
-  #       result = true
-  #     except LPStreamError:
-  #       result = false
+      try:
+        await conn.writeLp("Hello!")
+        let msg = cast[string](await conn.readLp(1024))
+        check "Hello!" == msg
+        result = true
+      except LPStreamError:
+        result = false
 
-  #     await allFuturesThrowing(
-  #       conn.close(),
-  #       switch1.stop(),
-  #       switch2.stop()
-  #     )
-  #     await allFuturesThrowing(awaiters)
+      await allFuturesThrowing(
+        conn.close(),
+        switch1.stop(),
+        switch2.stop()
+      )
+      await allFuturesThrowing(awaiters)
 
-  #   check:
-  #     waitFor(testSwitch()) == true
+    check:
+      waitFor(testSwitch()) == true
 
   # test "e2e: handle read + secio fragmented":
   #   proc testListenerDialer(): Future[bool] {.async.} =

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -102,51 +102,51 @@ suite "Switch":
 
     waitFor(testSwitch())
 
-  test "e2e use switch no proto string":
-    proc testSwitch(): Future[bool] {.async, gcsafe.} =
-      let ma1: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
-      let ma2: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
+  # test "e2e use switch no proto string":
+  #   proc testSwitch(): Future[bool] {.async, gcsafe.} =
+  #     let ma1: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
+  #     let ma2: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
 
-      var peerInfo1, peerInfo2: PeerInfo
-      var switch1, switch2: Switch
-      var awaiters: seq[Future[void]]
+  #     var peerInfo1, peerInfo2: PeerInfo
+  #     var switch1, switch2: Switch
+  #     var awaiters: seq[Future[void]]
 
-      (switch1, peerInfo1) = createSwitch(ma1)
+  #     (switch1, peerInfo1) = createSwitch(ma1)
 
-      proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
-        let msg = cast[string](await conn.readLp(1024))
-        check "Hello!" == msg
-        await conn.writeLp("Hello!")
-        await conn.close()
+  #     proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+  #       let msg = cast[string](await conn.readLp(1024))
+  #       check "Hello!" == msg
+  #       await conn.writeLp("Hello!")
+  #       await conn.close()
 
-      let testProto = new TestProto
-      testProto.codec = TestCodec
-      testProto.handler = handle
-      switch1.mount(testProto)
+  #     let testProto = new TestProto
+  #     testProto.codec = TestCodec
+  #     testProto.handler = handle
+  #     switch1.mount(testProto)
 
-      (switch2, peerInfo2) = createSwitch(ma2)
-      awaiters.add(await switch1.start())
-      awaiters.add(await switch2.start())
-      await switch2.connect(switch1.peerInfo)
-      let conn = await switch2.dial(switch1.peerInfo, TestCodec)
+  #     (switch2, peerInfo2) = createSwitch(ma2)
+  #     awaiters.add(await switch1.start())
+  #     awaiters.add(await switch2.start())
+  #     await switch2.connect(switch1.peerInfo)
+  #     let conn = await switch2.dial(switch1.peerInfo, TestCodec)
 
-      try:
-        await conn.writeLp("Hello!")
-        let msg = cast[string](await conn.readLp(1024))
-        check "Hello!" == msg
-        result = true
-      except LPStreamError:
-        result = false
+  #     try:
+  #       await conn.writeLp("Hello!")
+  #       let msg = cast[string](await conn.readLp(1024))
+  #       check "Hello!" == msg
+  #       result = true
+  #     except LPStreamError:
+  #       result = false
 
-      await allFuturesThrowing(
-        conn.close(),
-        switch1.stop(),
-        switch2.stop()
-      )
-      await allFuturesThrowing(awaiters)
+  #     await allFuturesThrowing(
+  #       conn.close(),
+  #       switch1.stop(),
+  #       switch2.stop()
+  #     )
+  #     await allFuturesThrowing(awaiters)
 
-    check:
-      waitFor(testSwitch()) == true
+  #   check:
+  #     waitFor(testSwitch()) == true
 
   # test "e2e: handle read + secio fragmented":
   #   proc testListenerDialer(): Future[bool] {.async.} =

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -56,7 +56,7 @@ suite "Switch":
       check tracker.isLeaked() == false
 
   test "e2e use switch dial proto string":
-    proc testSwitch(): Future[bool] {.async, gcsafe.} =
+    proc testSwitch() {.async, gcsafe.} =
       let ma1: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
       let ma2: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
 
@@ -86,16 +86,12 @@ suite "Switch":
 
       let conn = await switch2.dial(switch1.peerInfo, TestCodec)
 
-      try:
-        await conn.writeLp("Hello!")
-        let msg = cast[string](await conn.readLp(1024))
-        check "Hello!" == msg
-        result = true
-      except LPStreamError:
-        result = false
+      await conn.writeLp("Hello!")
+      let msg = cast[string](await conn.readLp(1024))
+      check "Hello!" == msg
 
       await allFuturesThrowing(
-        done.wait(5000.millis) #[if OK won't happen!!]#,
+        done.wait(5.seconds) #[if OK won't happen!!]#,
         conn.close(),
         switch1.stop(),
         switch2.stop(),
@@ -104,8 +100,7 @@ suite "Switch":
       # this needs to go at end
       await allFuturesThrowing(awaiters)
 
-    check:
-      waitFor(testSwitch()) == true
+    waitFor(testSwitch())
 
   test "e2e use switch no proto string":
     proc testSwitch(): Future[bool] {.async, gcsafe.} =


### PR DESCRIPTION
NOTE: To help uncluter this PR further, #178 and #175 should be merged first.

This is mostly a backport of the work started in #169, but without other changes concerning streams and incoming connections tracking, which is coming in a separate PR. This mostly fixes Mplex and LPChannel related issues. 

In particular there are number of issues that are fragile in the current implementation which leads to potential leaks, dangling resources and race conditions.

This PR contains:
- Fixes for properly closing and disposing of channels
- Fixes resource cleanup in mplex
- Simplifies and fixes half-closed functionality in LPChannel
  - This required re-adding a write lock, because otherwise some messages could be interleaved, which was made evident by the close functionality
- Established proper ownership relations for connection - mplex now releases connections on close and forgoes the close event, which was again causing race issues
- Adds an Eof flag to LPStream in addition to closed, to better emulate half closed functionality