### PR TITLE
Track all connections

### DIFF
--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -340,9 +340,11 @@ proc stop*(s: Switch) {.async.} =
   if s.pubSub.isSome:
     futs &= s.pubSub.get().stop()
 
-  futs &= toSeq(s.connections.values).mapIt(s.cleanupConn(it))
-  futs &= s.transports.mapIt(it.close())
+  futs = toSeq(s.connections.values).mapIt(s.cleanupConn(it))
+  futs = await allFinished(futs)
+  checkFutures(futs)
 
+  futs = s.transports.mapIt(it.close())
   futs = await allFinished(futs)
   checkFutures(futs)
 

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -71,8 +71,9 @@ proc connHandler*(t: TcpTransport,
     if not isNil(t.handler):
       t.handlers &= t.handler(conn)
 
-    t.connections.add(conn)
-    t.cleanups &= t.cleanup(conn)
+  # TODO: store the streamtransport client here
+  t.connections.add(conn)
+  t.cleanups &= t.cleanup(conn)
 
   result = conn
 


### PR DESCRIPTION
Mixing connection stoppage and transport stoppage leads to deadlock which manifests itself when tracking incoming connections.

This also fixes transport not tracking incoming connections.