### PR TITLE
Resource cleanup

### DIFF
--- a/libp2p/connection.nim
+++ b/libp2p/connection.nim
@@ -86,30 +86,18 @@ method readExactly*(s: Connection,
                     pbytes: pointer,
                     nbytes: int):
                     Future[void] {.async, gcsafe.} =
-  try:
-    await s.stream.readExactly(pbytes, nbytes)
-  except CatchableError as exc:
-    await s.close()
-    raise exc
+  await s.stream.readExactly(pbytes, nbytes)
 
 method readOnce*(s: Connection,
                  pbytes: pointer,
                  nbytes: int):
                  Future[int] {.async, gcsafe.} =
-  try:
-    result = await s.stream.readOnce(pbytes, nbytes)
-  except CatchableError as exc:
-    await s.close()
-    raise exc
+  result = await s.stream.readOnce(pbytes, nbytes)
 
 method write*(s: Connection,
               msg: seq[byte]):
               Future[void] {.async, gcsafe.} =
-  try:
-    await s.stream.write(msg)
-  except CatchableError as exc:
-    await s.close()
-    raise exc
+  await s.stream.write(msg)
 
 method atEof*(s: Connection): bool {.inline.} =
   if isNil(s.stream):

--- a/libp2p/connection.nim
+++ b/libp2p/connection.nim
@@ -30,9 +30,6 @@ type
     peerInfo*: PeerInfo
     stream*: LPStream
     observedAddrs*: Multiaddress
-    # notice this is a ugly circular reference collection
-    # (we got many actually :-))
-    readLoops*: seq[Future[void]]
 
   ConnectionTracker* = ref object of TrackerBase
     opened*: uint64
@@ -144,12 +141,6 @@ method close*(s: Connection) {.async, gcsafe.} =
         # s.stream = nil
 
       s.closeEvent.fire()
-      trace "waiting readloops", count=s.readLoops.len,
-                                 conn = $s,
-                                 oid = s.oid
-      await all(s.readLoops)
-      s.readLoops = @[]
-
       trace "connection closed", closed = s.closed,
                                  conn = $s,
                                  oid = s.oid

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -71,18 +71,19 @@ proc select*(m: MultistreamSelect,
   trace "reading first requested proto"
   result.removeSuffix("\n")
   if result == proto[0]:
-    trace "succesfully selected ", proto = proto
+    trace "successfully selected ", proto = proto
     return
 
-  if not result.len > 0:
-    trace "selecting one of several protos"
-    for p in proto[1..<proto.len()]:
-      await conn.writeLp((p & "\n")) # select proto
-      result = string.fromBytes(await conn.readLp(1024)) # read the first proto
-      result.removeSuffix("\n")
-      if result == p:
-        trace "selected protocol", protocol = result
-        break
+  let protos = proto[1..<proto.len()]
+  trace "selecting one of several protos", protos = protos
+  for p in protos:
+    trace "selecting proto", proto = p
+    await conn.writeLp((p & "\n")) # select proto
+    result = string.fromBytes(await conn.readLp(1024)) # read the first proto
+    result.removeSuffix("\n")
+    if result == p:
+      trace "selected protocol", protocol = result
+      break
 
 proc select*(m: MultistreamSelect,
              conn: Connection,
@@ -157,7 +158,7 @@ proc addHandler*[T: LPProtocol](m: MultistreamSelect,
                                 matcher: Matcher = nil) =
   ## register a protocol
   # TODO: This is a bug in chronicles,
-  # it break if I uncoment this line.
+  # it break if I uncomment this line.
   # Which is almost the same as the
   # one on the next override of addHandler
   #

--- a/libp2p/muxers/mplex/coder.nim
+++ b/libp2p/muxers/mplex/coder.nim
@@ -57,7 +57,7 @@ proc writeMsg*(conn: Connection,
     let
       chunkSize = if left > MaxMsgSize: MaxMsgSize - 64 else: left
       chunk = if chunkSize > 0 : data[offset..(offset + chunkSize - 1)] else: data
-    ## write lenght prefixed
+    ## write length prefixed
     var buf = initVBuffer()
     buf.writePBVarint(id shl 3 or ord(msgType).uint64)
     buf.writePBVarint(chunkSize.uint64) # size should be always sent

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -127,6 +127,8 @@ proc newChannel*(id: uint64,
                                  name = result.name
 
 proc closeMessage(s: LPChannel) {.async.} =
+  ## send close message - this will not raise
+  ## on EOF or Closed
   withEOFExceptions:
     withWriteLock(s.writeLock):
       trace "sending close message", id = s.id,
@@ -137,6 +139,7 @@ proc closeMessage(s: LPChannel) {.async.} =
       await s.conn.writeMsg(s.id, s.closeCode) # write close
 
 proc resetMessage(s: LPChannel) {.async.} =
+  ## send reset message - this will not raise
   withEOFExceptions:
     withWriteLock(s.writeLock):
       trace "sending reset message", id = s.id,

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -77,6 +77,7 @@ proc newChannel*(id: uint64,
   result.msgCode = if initiator: MessageType.MsgOut else: MessageType.MsgIn
   result.closeCode = if initiator: MessageType.CloseOut else: MessageType.CloseIn
   result.resetCode = if initiator: MessageType.ResetOut else: MessageType.ResetIn
+  result.writeLock = newAsyncLock()
   result.isLazy = lazy
 
   let chan = result
@@ -177,7 +178,6 @@ method close*(s: LPChannel) {.async, gcsafe.} =
   s.closedLocal = true
   if s.atEof: # already closed by remote close parent buffer imediately
     await procCall BufferStream(s).close()
-
   trace "lpchannel closed local", id = s.id,
                                   initiator = s.initiator,
                                   name = s.name,

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -77,7 +77,6 @@ proc newChannel*(id: uint64,
   result.msgCode = if initiator: MessageType.MsgOut else: MessageType.MsgIn
   result.closeCode = if initiator: MessageType.CloseOut else: MessageType.CloseIn
   result.resetCode = if initiator: MessageType.ResetOut else: MessageType.ResetIn
-  result.writeLock = newAsyncLock()
   result.isLazy = lazy
 
   let chan = result
@@ -178,6 +177,7 @@ method close*(s: LPChannel) {.async, gcsafe.} =
   s.closedLocal = true
   if s.atEof: # already closed by remote close parent buffer imediately
     await procCall BufferStream(s).close()
+
   trace "lpchannel closed local", id = s.id,
                                   initiator = s.initiator,
                                   name = s.name,

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -67,101 +67,102 @@ proc newStreamInternal*(m: Mplex,
 method handle*(m: Mplex) {.async, gcsafe.} =
   trace "starting mplex main loop", oid = m.oid
   try:
-    while not m.connection.closed:
-      trace "waiting for data", oid = m.oid
-      let (id, msgType, data) = await m.connection.readMsg()
-      trace "read message from connection", id = id,
+    try:
+      while not m.connection.closed:
+        trace "waiting for data", oid = m.oid
+        let (id, msgType, data) = await m.connection.readMsg()
+        trace "read message from connection", id = id,
+                                              msgType = msgType,
+                                              data = data.shortLog,
+                                              oid = m.oid
+        let initiator = bool(ord(msgType) and 1)
+        var channel: LPChannel
+        if MessageType(msgType) != MessageType.New:
+          let channels = m.getChannelList(initiator)
+          if id notin channels:
+            trace "Channel not found, skipping", id = id,
+                                                initiator = initiator,
+                                                msg = msgType,
+                                                oid = m.oid
+            continue
+          channel = channels[id]
+
+        case msgType:
+          of MessageType.New:
+            let name = cast[string](data)
+            channel = await m.newStreamInternal(false, id, name)
+            trace "created channel", id = id,
+                                    name = name,
+                                    inititator = channel.initiator,
+                                    channoid = channel.oid,
+                                    oid = m.oid
+            if not isNil(m.streamHandler):
+              let stream = newConnection(channel)
+              m.conns.add(stream)
+              stream.peerInfo = m.connection.peerInfo
+
+              var fut = newFuture[void]()
+              proc handler() {.async.} =
+                try:
+                  await m.streamHandler(stream)
+                except CatchableError as exc:
+                  trace "exception in stream handler", exc = exc.msg
+                finally:
+                  m.conns.keepItIf(it != stream)
+                  m.handlerFuts.keepItIf(it != fut)
+
+              fut = handler()
+
+          of MessageType.MsgIn, MessageType.MsgOut:
+            trace "pushing data to channel", id = id,
+                                            initiator = initiator,
                                             msgType = msgType,
-                                            data = data.shortLog,
+                                            size = data.len,
+                                            name = channel.name,
+                                            channoid = channel.oid,
                                             oid = m.oid
-      let initiator = bool(ord(msgType) and 1)
-      var channel: LPChannel
-      if MessageType(msgType) != MessageType.New:
-        let channels = m.getChannelList(initiator)
-        if id notin channels:
-          trace "Channel not found, skipping", id = id,
-                                               initiator = initiator,
-                                               msg = msgType,
-                                               oid = m.oid
-          continue
-        channel = channels[id]
 
-      case msgType:
-        of MessageType.New:
-          let name = cast[string](data)
-          channel = await m.newStreamInternal(false, id, name)
-          trace "created channel", id = id,
-                                   name = name,
-                                   inititator = channel.initiator,
-                                   channoid = channel.oid,
-                                   oid = m.oid
-          if not isNil(m.streamHandler):
-            let stream = newConnection(channel)
-            m.conns.add(stream)
-            stream.peerInfo = m.connection.peerInfo
+            if data.len > MaxMsgSize:
+              raise newLPStreamLimitError()
+            await channel.pushTo(data)
+          of MessageType.CloseIn, MessageType.CloseOut:
+            trace "closing channel", id = id,
+                                    initiator = initiator,
+                                    msgType = msgType,
+                                    name = channel.name,
+                                    channoid = channel.oid,
+                                    oid = m.oid
 
-            var fut = newFuture[void]()
-            proc handler() {.async.} =
-              try:
-                await m.streamHandler(stream)
-              except CatchableError as exc:
-                trace "exception in stream handler", exc = exc.msg
-              finally:
-                m.conns.keepItIf(it != stream)
-                m.handlerFuts.keepItIf(it != fut)
+            await channel.closeRemote()
+            m.getChannelList(initiator).del(id)
+            trace "deleted channel", id = id,
+                                    initiator = initiator,
+                                    msgType = msgType,
+                                    name = channel.name,
+                                    channoid = channel.oid,
+                                    oid = m.oid
+          of MessageType.ResetIn, MessageType.ResetOut:
+            trace "resetting channel", id = id,
+                                      initiator = initiator,
+                                      msgType = msgType,
+                                      name = channel.name,
+                                      channoid = channel.oid,
+                                      oid = m.oid
 
-            fut = handler()
-
-        of MessageType.MsgIn, MessageType.MsgOut:
-          trace "pushing data to channel", id = id,
-                                           initiator = initiator,
-                                           msgType = msgType,
-                                           size = data.len,
-                                           name = channel.name,
-                                           channoid = channel.oid,
-                                           oid = m.oid
-
-          if data.len > MaxMsgSize:
-            raise newLPStreamLimitError()
-          await channel.pushTo(data)
-        of MessageType.CloseIn, MessageType.CloseOut:
-          trace "closing channel", id = id,
-                                   initiator = initiator,
-                                   msgType = msgType,
-                                   name = channel.name,
-                                   channoid = channel.oid,
-                                   oid = m.oid
-
-          await channel.closeRemote()
-          m.getChannelList(initiator).del(id)
-          trace "deleted channel", id = id,
-                                   initiator = initiator,
-                                   msgType = msgType,
-                                   name = channel.name,
-                                   channoid = channel.oid,
-                                   oid = m.oid
-        of MessageType.ResetIn, MessageType.ResetOut:
-          trace "resetting channel", id = id,
-                                     initiator = initiator,
-                                     msgType = msgType,
-                                     name = channel.name,
-                                     channoid = channel.oid,
-                                     oid = m.oid
-
-          await channel.reset()
-          m.getChannelList(initiator).del(id)
-          trace "deleted channel", id = id,
-                                   initiator = initiator,
-                                   msgType = msgType,
-                                   name = channel.name,
-                                   channoid = channel.oid,
-                                   oid = m.oid
-          break
+            await channel.reset()
+            m.getChannelList(initiator).del(id)
+            trace "deleted channel", id = id,
+                                    initiator = initiator,
+                                    msgType = msgType,
+                                    name = channel.name,
+                                    channoid = channel.oid,
+                                    oid = m.oid
+            break
+    finally:
+        trace "stopping mplex main loop", oid = m.oid
+        await m.close()
   except CatchableError as exc:
     trace "Exception occurred", exception = exc.msg, oid = m.oid
-  finally:
-    trace "stopping mplex main loop", oid = m.oid
-    await m.close()
 
 proc newMplex*(conn: Connection,
                maxChanns: uint = MaxChannels): Mplex =
@@ -199,26 +200,16 @@ method close*(m: Mplex) {.async, gcsafe.} =
 
   try:
     trace "closing mplex muxer", oid = m.oid
-    let channs = toSeq(m.remote.values) &
-      toSeq(m.local.values)
+    await all(
+      toSeq(m.remote.values).mapIt(it.reset()) &
+        toSeq(m.local.values).mapIt(it.reset()))
 
-    for chann in channs:
-      try:
-        await chann.reset()
-      except CatchableError as exc:
-        warn "error resetting channel", exc = exc.msg
-
-    for conn in m.conns:
-      try:
-        await conn.close()
-      except CatchableError as exc:
-        warn "error closing channel's connection"
-
-    checkFutures(
-      await allFinished(m.handlerFuts))
-
-    await m.connection.close()
+    await all(m.conns.mapIt(it.close())) # dispose of channel's connections
+    await all(m.handlerFuts)
+  except CatchableError as exc:
+    trace "exception in mplex close", exc = exc.msg
   finally:
+    await m.connection.close()
     m.remote.clear()
     m.local.clear()
     m.conns = @[]

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -49,7 +49,10 @@ proc newStreamInternal*(m: Mplex,
                         lazy: bool = false):
                         Future[LPChannel] {.async, gcsafe.} =
   ## create new channel/stream
-  let id = if initiator: m.currentId.inc(); m.currentId else: chanId
+  let id = if initiator:
+    m.currentId.inc(); m.currentId
+    else: chanId
+
   trace "creating new channel", channelId = id,
                                 initiator = initiator,
                                 name = name,
@@ -100,12 +103,7 @@ method handle*(m: Mplex) {.async, gcsafe.} =
             var fut = newFuture[void]()
             proc handler() {.async.} =
               try:
-                try:
-                  await m.streamHandler(stream)
-                  trace "streamhandler ended", oid = stream.oid
-                finally:
-                  if not(stream.closed):
-                    await stream.close()
+                await m.streamHandler(stream)
               except CatchableError as exc:
                 trace "exception in stream handler", exc = exc.msg
               finally:

--- a/libp2p/muxers/muxer.nim
+++ b/libp2p/muxers/muxer.nim
@@ -60,8 +60,7 @@ method init(c: MuxerProvider) =
       if not isNil(c.muxerHandler):
         futs &= c.muxerHandler(muxer)
 
-      # log and re-raise on errors
-      await all(futs)
+      checkFutures(await allFinished(futs))
     except CatchableError as exc:
       trace "exception in muxer handler", exc = exc.msg
 

--- a/libp2p/muxers/muxer.nim
+++ b/libp2p/muxers/muxer.nim
@@ -60,7 +60,7 @@ method init(c: MuxerProvider) =
       if not isNil(c.muxerHandler):
         futs &= c.muxerHandler(muxer)
 
-      checkFutures(await allFinished(futs))
+      await all(futs)
     except CatchableError as exc:
       trace "exception in muxer handler", exc = exc.msg
 

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -429,9 +429,7 @@ method publish*(g: GossipSub,
       trace "publishing on topic", name = topic
       g.mcache.put(msg)
       sent.add(g.peers[p].send(@[RPCMsg(messages: @[msg])]))
-
-    sent = await allFinished(sent)
-    checkFutures(sent)
+    checkFutures(await allFinished(sent))
 
 method start*(g: GossipSub) {.async.} =
   ## start pubsub

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -135,24 +135,27 @@ method handleConn*(p: PubSub,
   ##    that we're interested in
   ##
 
-  if isNil(conn.peerInfo):
-    trace "no valid PeerId for peer"
-    await conn.close()
-    return
+  try:
+    if isNil(conn.peerInfo):
+      trace "no valid PeerId for peer"
+      await conn.close()
+      return
 
-  proc handler(peer: PubSubPeer, msgs: seq[RPCMsg]) {.async.} =
-    # call pubsub rpc handler
-    await p.rpcHandler(peer, msgs)
+    proc handler(peer: PubSubPeer, msgs: seq[RPCMsg]) {.async.} =
+      # call pubsub rpc handler
+      await p.rpcHandler(peer, msgs)
 
-  let peer = p.getPeer(conn.peerInfo, proto)
-  let topics = toSeq(p.topics.keys)
-  if topics.len > 0:
-    await p.sendSubs(peer, topics, true)
+    let peer = p.getPeer(conn.peerInfo, proto)
+    let topics = toSeq(p.topics.keys)
+    if topics.len > 0:
+      await p.sendSubs(peer, topics, true)
 
-  peer.handler = handler
-  await peer.handle(conn) # spawn peer read loop
-  trace "pubsub peer handler ended, cleaning up"
-  await p.internalCleanup(conn)
+    peer.handler = handler
+    await peer.handle(conn) # spawn peer read loop
+    trace "pubsub peer handler ended, cleaning up"
+    await p.internalClenaup(conn)
+  except CatchableError as exc:
+    trace "exception ocurred in pubsub handle", exc = exc.msg
 
 method subscribeToPeer*(p: PubSub,
                         conn: Connection) {.base, async.} =

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -153,7 +153,7 @@ method handleConn*(p: PubSub,
     peer.handler = handler
     await peer.handle(conn) # spawn peer read loop
     trace "pubsub peer handler ended, cleaning up"
-    await p.internalClenaup(conn)
+    await p.internalCleanup(conn)
   except CatchableError as exc:
     trace "exception ocurred in pubsub handle", exc = exc.msg
 

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -118,7 +118,7 @@ proc internalCleanup(p: PubSub, conn: Connection) {.async.} =
 
   var peer = p.getPeer(conn.peerInfo, p.codec)
   await conn.closeEvent.wait()
-  trace "connection closed, cleaning up peer", peer = conn.peerInfo.id
+  trace "pubsub conn closed, cleaning up peer", peer = conn.peerInfo.id
   await p.cleanUpHelper(peer)
 
 method handleConn*(p: PubSub,

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -79,7 +79,7 @@ proc handle*(p: PubSubPeer, conn: Connection) {.async.} =
 
 proc send*(p: PubSubPeer, msgs: seq[RPCMsg]) {.async.} =
   for m in msgs.items:
-    trace "sending msgs to peer", toPeer = p.id, msgs = msgs
+    trace "sending msgs to peer", toPeer = p.id, msgs = $msgs
     let encoded = encodeRpcMsg(m)
     # trigger hooks
     if not(isNil(p.observers)) and p.observers[].len > 0:

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -244,7 +244,6 @@ proc encodeRpcMsg*(msg: RPCMsg): ProtoBuffer {.gcsafe.} =
 proc decodeRpcMsg*(msg: seq[byte]): RPCMsg {.gcsafe.} =
   var pb = initProtoBuffer(msg)
 
-  result.subscriptions = newSeq[SubOpts]()
   while true:
     # decode SubOpts array
     var field = pb.enterSubMessage()

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -267,12 +267,12 @@ template read_s: untyped =
 
 proc receiveHSMessage(sconn: Connection): Future[seq[byte]] {.async.} =
   var besize: array[2, byte]
-  await sconn.stream.readExactly(addr besize[0], besize.len)
+  await sconn.readExactly(addr besize[0], besize.len)
   let size = uint16.fromBytesBE(besize).int
   trace "receiveHSMessage", size
   var buffer = newSeq[byte](size)
   if buffer.len > 0:
-    await sconn.stream.readExactly(addr buffer[0], buffer.len)
+    await sconn.readExactly(addr buffer[0], buffer.len)
   return buffer
 
 proc sendHSMessage(sconn: Connection; buf: seq[byte]) {.async.} =

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -267,12 +267,12 @@ template read_s: untyped =
 
 proc receiveHSMessage(sconn: Connection): Future[seq[byte]] {.async.} =
   var besize: array[2, byte]
-  await sconn.readExactly(addr besize[0], besize.len)
+  await sconn.stream.readExactly(addr besize[0], besize.len)
   let size = uint16.fromBytesBE(besize).int
   trace "receiveHSMessage", size
   var buffer = newSeq[byte](size)
   if buffer.len > 0:
-    await sconn.readExactly(addr buffer[0], buffer.len)
+    await sconn.stream.readExactly(addr buffer[0], buffer.len)
   return buffer
 
 proc sendHSMessage(sconn: Connection; buf: seq[byte]) {.async.} =

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -500,7 +500,8 @@ method handshake*(p: Noise, conn: Connection, initiator: bool = false): Future[S
       raise newException(NoiseHandshakeError, "Noise handshake, peer infos don't match! " & $pid & " != " & $conn.peerInfo.peerId)
 
   var secure = new NoiseConnection
-  inc getConnectionTracker().opened
+  secure.initStream()
+
   secure.stream = conn
   secure.closeEvent = newAsyncEvent()
   secure.peerInfo = PeerInfo.init(remotePubKey)

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -436,35 +436,24 @@ method write*(sconn: NoiseConnection, message: seq[byte]): Future[void] {.async.
   if message.len == 0:
     return
 
-  try:
+  var
+    left = message.len
+    offset = 0
+  while left > 0:
+    let
+      chunkSize = if left > MaxPlainSize: MaxPlainSize else: left
+      packed = packNoisePayload(message.toOpenArray(offset, offset + chunkSize - 1))
+      cipher = sconn.writeCs.encryptWithAd([], packed)
+    left = left - chunkSize
+    offset = offset + chunkSize
     var
-      left = message.len
-      offset = 0
-    while left > 0:
-      let
-        chunkSize = if left > MaxPlainSize: MaxPlainSize else: left
-        packed = packNoisePayload(message.toOpenArray(offset, offset + chunkSize - 1))
-        cipher = sconn.writeCs.encryptWithAd([], packed)
-      left = left - chunkSize
-      offset = offset + chunkSize
-      var
-        lesize = cipher.len.uint16
-        besize = lesize.toBytesBE
-        outbuf = newSeqOfCap[byte](cipher.len + 2)
-      trace "sendEncryptedMessage", size = lesize, peer = $sconn.peerInfo, left, offset
-      outbuf &= besize
-      outbuf &= cipher
-      await sconn.stream.write(outbuf)
-  except LPStreamEOFError:
-    trace "Ignoring EOF while writing"
-  except CancelledError as exc:
-    raise exc
-  except CatchableError as exc:
-    # TODO these exceptions are ignored since it's likely that if writes are
-    #      are failing, the underlying connection is already closed - this needs
-    #      more cleanup though
-    debug "Could not write to connection", error = exc.name
-    trace "Could not write to connection - verbose", msg = exc.msg
+      lesize = cipher.len.uint16
+      besize = lesize.toBytesBE
+      outbuf = newSeqOfCap[byte](cipher.len + 2)
+    trace "sendEncryptedMessage", size = lesize, peer = $sconn.peerInfo, left, offset
+    outbuf &= besize
+    outbuf &= cipher
+    await sconn.stream.write(outbuf)
 
 method handshake*(p: Noise, conn: Connection, initiator: bool = false): Future[SecureConn] {.async.} =
   trace "Starting Noise handshake", initiator

--- a/libp2p/protocols/secure/secio.nim
+++ b/libp2p/protocols/secure/secio.nim
@@ -212,40 +212,29 @@ method write*(sconn: SecioConn, message: seq[byte]) {.async.} =
   if message.len == 0:
     return
 
-  try:
-    var
-      left = message.len
-      offset = 0
-    while left > 0:
-      let
-        chunkSize = if left > SecioMaxMessageSize - 64: SecioMaxMessageSize - 64 else: left
-        macsize = sconn.writerMac.sizeDigest()
-        length = chunkSize + macsize
+  var
+    left = message.len
+    offset = 0
+  while left > 0:
+    let
+      chunkSize = if left > SecioMaxMessageSize - 64: SecioMaxMessageSize - 64 else: left
+      macsize = sconn.writerMac.sizeDigest()
+      length = chunkSize + macsize
 
-      var msg = newSeq[byte](chunkSize + 4 + macsize)
-      msg[0..<4] = uint32(length).toBytesBE()
+    var msg = newSeq[byte](chunkSize + 4 + macsize)
+    msg[0..<4] = uint32(length).toBytesBE()
 
-      sconn.writerCoder.encrypt(message.toOpenArray(offset, offset + chunkSize - 1),
-                                msg.toOpenArray(4, 4 + chunkSize - 1))
-      left = left - chunkSize
-      offset = offset + chunkSize
-      let mo = 4 + chunkSize
-      sconn.writerMac.update(msg.toOpenArray(4, 4 + chunkSize - 1))
-      sconn.writerMac.finish(msg.toOpenArray(mo, mo + macsize - 1))
-      sconn.writerMac.reset()
+    sconn.writerCoder.encrypt(message.toOpenArray(offset, offset + chunkSize - 1),
+                              msg.toOpenArray(4, 4 + chunkSize - 1))
+    left = left - chunkSize
+    offset = offset + chunkSize
+    let mo = 4 + chunkSize
+    sconn.writerMac.update(msg.toOpenArray(4, 4 + chunkSize - 1))
+    sconn.writerMac.finish(msg.toOpenArray(mo, mo + macsize - 1))
+    sconn.writerMac.reset()
 
-      trace "Writing message", message = msg.shortLog, left, offset
-      await sconn.stream.write(msg)
-  except LPStreamEOFError:
-    trace "Ignoring EOF while writing"
-  except CancelledError as exc:
-    raise exc
-  except CatchableError as exc:
-    # TODO these exceptions are ignored since it's likely that if writes are
-    #      are failing, the underlying connection is already closed - this needs
-    #      more cleanup though
-    debug "Could not write to connection", error = exc.name
-    trace "Could not write to connection - verbose", msg = exc.msg
+    trace "Writing message", message = msg.shortLog, left, offset
+    await sconn.stream.write(msg)
 
 proc newSecioConn(conn: Connection,
                   hash: string,

--- a/libp2p/protocols/secure/secio.nim
+++ b/libp2p/protocols/secure/secio.nim
@@ -246,9 +246,8 @@ proc newSecioConn(conn: Connection,
   ## cipher algorithm ``cipher``, stretched keys ``secrets`` and order
   ## ``order``.
   new result
-
+  result.initStream()
   result.stream = conn
-  result.closeEvent = newAsyncEvent()
 
   let i0 = if order < 0: 1 else: 0
   let i1 = if order < 0: 0 else: 1
@@ -267,10 +266,6 @@ proc newSecioConn(conn: Connection,
                           secrets.ivOpenArray(i1))
 
   result.peerInfo = PeerInfo.init(remotePubKey)
-  when chronicles.enabledLogLevel == LogLevel.TRACE:
-    result.oid = genOid()
-
-  inc  getConnectionTracker().opened
 
 proc transactMessage(conn: Connection,
                      msg: seq[byte]): Future[seq[byte]] {.async.} =

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -170,9 +170,6 @@ method pushTo*(s: BufferStream, data: seq[byte]) {.base, async.} =
   if s.atEof:
     raise newLPStreamEOFError()
 
-  if s.atEof:
-    raise newLPStreamEOFError()
-
   try:
     await s.lock.acquire()
     var index = 0

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -170,6 +170,9 @@ method pushTo*(s: BufferStream, data: seq[byte]) {.base, async.} =
   if s.atEof:
     raise newLPStreamEOFError()
 
+  if s.atEof:
+    raise newLPStreamEOFError()
+
   try:
     await s.lock.acquire()
     var index = 0

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -60,9 +60,9 @@ method write*(s: ChronosStream, msg: seq[byte]) {.async.} =
     return
 
   withExceptions:
-    var writen = 0
-    while (writen < msg.len):
-      writen += await s.client.write(msg[writen..<msg.len]) # TODO: does the slice create a copy here?
+    # Returns 0 sometimes when write fails - but there's not much we can do here?
+    if (await s.client.write(msg)) != msg.len:
+      raise (ref LPStreamError)(msg: "Write couldn't finish writing")
 
 method closed*(s: ChronosStream): bool {.inline.} =
   result = s.client.closed

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -16,12 +16,6 @@ logScope:
 type ChronosStream* = ref object of LPStream
     client: StreamTransport
 
-proc onTransportClose(s: ChronosStream,
-                      client: StreamTransport) {.async.} =
-  await client.join()
-  trace "Transport closed, closing connection"
-  await s.close()
-
 proc newChronosStream*(client: StreamTransport): ChronosStream =
   new result
   result.client = client

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -16,6 +16,12 @@ logScope:
 type ChronosStream* = ref object of LPStream
     client: StreamTransport
 
+proc onTransportClose(s: ChronosStream,
+                      client: StreamTransport) {.async.} =
+  await client.join()
+  trace "Transport closed, closing connection"
+  await s.close()
+
 proc newChronosStream*(client: StreamTransport): ChronosStream =
   new result
   result.client = client

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -60,11 +60,11 @@ method write*(s: ChronosStream, msg: seq[byte]) {.async.} =
     return
 
   withExceptions:
-    var writen = 0
-    while not s.client.closed and writen < msg.len:
-      writen += await s.client.write(msg[writen..<msg.len])
+    var written = 0
+    while not s.client.closed and written < msg.len:
+      written += await s.client.write(msg[written..<msg.len])
 
-    if writen < msg.len:
+    if written < msg.len:
       raise (ref LPStreamClosedError)(msg: "Write couldn't finish writing")
 
 method closed*(s: ChronosStream): bool {.inline.} =

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -60,9 +60,9 @@ method write*(s: ChronosStream, msg: seq[byte]) {.async.} =
     return
 
   withExceptions:
-    # Returns 0 sometimes when write fails - but there's not much we can do here?
-    if (await s.client.write(msg)) != msg.len:
-      raise (ref LPStreamError)(msg: "Write couldn't finish writing")
+    var writen = 0
+    while (writen < msg.len):
+      writen += await s.client.write(msg[writen..<msg.len]) # TODO: does the slice create a copy here?
 
 method closed*(s: ChronosStream): bool {.inline.} =
   result = s.client.closed

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -21,12 +21,12 @@ proc newChronosStream*(client: StreamTransport): ChronosStream =
   result.client = client
   result.closeEvent = newAsyncEvent()
 
-
 template withExceptions(body: untyped) =
   try:
     body
   except TransportIncompleteError:
-    raise newLPStreamIncompleteError()
+    # for all intents and purposes this is an EOF
+    raise newLPStreamEOFError()
   except TransportLimitError:
     raise newLPStreamLimitError()
   except TransportUseClosedError:
@@ -60,9 +60,12 @@ method write*(s: ChronosStream, msg: seq[byte]) {.async.} =
     return
 
   withExceptions:
-    # Returns 0 sometimes when write fails - but there's not much we can do here?
-    if (await s.client.write(msg)) != msg.len:
-      raise (ref LPStreamError)(msg: "Write couldn't finish writing")
+    var writen = 0
+    while not s.client.closed and writen < msg.len:
+      writen += await s.client.write(msg[writen..<msg.len])
+
+    if writen < msg.len:
+      raise (ref LPStreamClosedError)(msg: "Write couldn't finish writing")
 
 method closed*(s: ChronosStream): bool {.inline.} =
   result = s.client.closed
@@ -71,16 +74,14 @@ method atEof*(s: ChronosStream): bool {.inline.} =
   s.client.atEof()
 
 method close*(s: ChronosStream) {.async.} =
-  if not s.isClosed:
-    s.isClosed = true
-    trace "shutting chronos stream", address = $s.client.remoteAddress()
-    if not s.client.closed():
-      try:
-        await s.client.closeWait()
-      except CancelledError as exc:
-        raise exc
-      except CatchableError as exc:
-        # Shouldn't happen, but we can't be sure
-        warn "error while closing connection", msg = exc.msg
+  try:
+    if not s.isClosed:
+      s.isClosed = true
 
-    s.closeEvent.fire()
+      trace "shutting down chronos stream", address = $s.client.remoteAddress()
+      if not s.client.closed():
+        await s.client.closeWait()
+
+      s.closeEvent.fire()
+  except CatchableError as exc:
+    trace "error closing chronosstream", exc = exc.msg

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -48,7 +48,7 @@ type
       pubSub*: Option[PubSub]
       dialedPubSubPeers: HashSet[string]
 
-proc newNoPubSubException(): ref Exception {.inline.} =
+proc newNoPubSubException(): ref CatchableError {.inline.} =
   result = newException(NoPubSubException, "no pubsub provided!")
 
 proc secure(s: Switch, conn: Connection): Future[Connection] {.async, gcsafe.} =
@@ -134,23 +134,26 @@ proc mux(s: Switch, conn: Connection): Future[void] {.async, gcsafe.} =
     s.muxed[conn.peerInfo.id] = muxer
 
 proc cleanupConn(s: Switch, conn: Connection) {.async, gcsafe.} =
-  if not isNil(conn.peerInfo):
-    let id = conn.peerInfo.id
-    trace "cleaning up connection for peer", peerId = id
-    if id in s.muxed:
-      await s.muxed[id].close()
-      s.muxed.del(id)
+  try:
+    if not isNil(conn.peerInfo):
+      let id = conn.peerInfo.id
+      trace "cleaning up connection for peer", peerId = id
+      if id in s.muxed:
+        await s.muxed[id].close()
+        s.muxed.del(id)
 
-    if id in s.connections:
-      if not s.connections[id].closed:
-        await s.connections[id].close()
-      s.connections.del(id)
+      if id in s.connections:
+        if not s.connections[id].closed:
+          await s.connections[id].close()
+        s.connections.del(id)
 
-    s.dialedPubSubPeers.excl(id)
+      s.dialedPubSubPeers.excl(id)
 
-    # TODO: Investigate cleanupConn() always called twice for one peer.
-    if not(conn.peerInfo.isClosed()):
-      conn.peerInfo.close()
+      # TODO: Investigate cleanupConn() always called twice for one peer.
+      if not(conn.peerInfo.isClosed()):
+        conn.peerInfo.close()
+  except CatchableError as exc:
+    trace "exception cleaning up connection", exc = exc.msg
 
 proc disconnect*(s: Switch, peer: PeerInfo) {.async, gcsafe.} =
   let conn = s.connections.getOrDefault(peer.id)
@@ -167,25 +170,19 @@ proc getMuxedStream(s: Switch, peerInfo: PeerInfo): Future[Connection] {.async, 
     result = conn
 
 proc upgradeOutgoing(s: Switch, conn: Connection): Future[Connection] {.async, gcsafe.} =
-  try:
-    trace "handling connection", conn = $conn
-    result = conn
+  trace "handling connection", conn = $conn
+  result = conn
 
-    # don't mux/secure twise
-    if conn.peerInfo.id in s.muxed:
-      return
+  # don't mux/secure twise
+  if conn.peerInfo.id in s.muxed:
+    return
 
-    result = await s.secure(result) # secure the connection
-    if isNil(result):
-      return
+  result = await s.secure(result) # secure the connection
+  if isNil(result):
+    return
 
-    await s.mux(result) # mux it if possible
-    s.connections[conn.peerInfo.id] = result
-  except CancelledError as exc:
-    raise exc
-  except CatchableError as exc:
-    debug "Couldn't upgrade outgoing connection", msg = exc.msg
-    return nil
+  await s.mux(result) # mux it if possible
+  s.connections[conn.peerInfo.id] = result
 
 proc upgradeIncoming(s: Switch, conn: Connection) {.async, gcsafe.} =
   trace "upgrading incoming connection", conn = $conn
@@ -207,27 +204,33 @@ proc upgradeIncoming(s: Switch, conn: Connection) {.async, gcsafe.} =
         ms.addHandler(muxer.codec, muxer)
 
       # handle subsequent requests
-      await ms.handle(sconn)
-      await sconn.close()
+      try:
+        await ms.handle(sconn)
+      finally:
+        await sconn.close()
+
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
       debug "ending secured handler", err = exc.msg
 
-  if (await ms.select(conn)): # just handshake
-    # add the secure handlers
-    for k in s.secureManagers.keys:
-      ms.addHandler(k, securedHandler)
-
   try:
-    # handle secured connections
-    await ms.handle(conn)
+    try:
+      if (await ms.select(conn)): # just handshake
+        # add the secure handlers
+        for k in s.secureManagers.keys:
+          ms.addHandler(k, securedHandler)
+
+        # handle secured connections
+      await ms.handle(conn)
+    finally:
+      await conn.close()
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
     debug "ending multistream", err = exc.msg
 
-proc subscribeToPeer(s: Switch, peerInfo: PeerInfo) {.async, gcsafe.}
+proc subscribeToPeer*(s: Switch, peerInfo: PeerInfo) {.async, gcsafe.}
 
 proc internalConnect(s: Switch,
                      peer: PeerInfo): Future[Connection] {.async.} =
@@ -239,13 +242,7 @@ proc internalConnect(s: Switch,
       for a in peer.addrs: # for each address
         if t.handles(a):   # check if it can dial it
           trace "Dialing address", address = $a
-          try:
-            conn = await t.dial(a)
-          except CancelledError as exc:
-            raise exc
-          except CatchableError as exc:
-            trace "couldn't dial peer, transport failed", exc = exc.msg, address = a
-            continue
+          conn = await t.dial(a)
           # make sure to assign the peer to the connection
           conn.peerInfo = peer
           conn = await s.upgradeOutgoing(conn)
@@ -253,8 +250,9 @@ proc internalConnect(s: Switch,
             continue
 
           conn.closeEvent.wait()
-            .addCallback do (udata: pointer):
-              asyncCheck s.cleanupConn(conn)
+          .addCallback do(udata: pointer):
+            asyncCheck s.cleanupConn(conn)
+
           break
   else:
     trace "Reusing existing connection"
@@ -289,7 +287,7 @@ proc dial*(s: Switch,
 
   if not await s.ms.select(result, proto):
     warn "Unable to select sub-protocol", proto = proto
-    raise newException(CatchableError, &"unable to select protocol: {proto}")
+    return nil
 
 proc mount*[T: LPProtocol](s: Switch, proto: T) {.gcsafe.} =
   if isNil(proto.handler):
@@ -307,14 +305,14 @@ proc start*(s: Switch): Future[seq[Future[void]]] {.async, gcsafe.} =
 
   proc handle(conn: Connection): Future[void] {.async, closure, gcsafe.} =
     try:
-      await s.upgradeIncoming(conn) # perform upgrade on incoming connection
+      try:
+        await s.upgradeIncoming(conn) # perform upgrade on incoming connection
+      finally:
+        await s.cleanupConn(conn)
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
       trace "Exception occurred in Switch.start", exc = exc.msg
-    finally:
-      await conn.close()
-      await s.cleanupConn(conn)
 
   var startFuts: seq[Future[void]]
   for t in s.transports: # for each transport
@@ -338,27 +336,27 @@ proc stop*(s: Switch) {.async.} =
   if s.pubSub.isSome:
     await s.pubSub.get().stop()
 
-  checkFutures(
-    await allFinished(
-    toSeq(s.connections.values).mapIt(s.cleanupConn(it))))
+  await all(
+    toSeq(s.connections.values)
+    .mapIt(s.cleanupConn(it)))
 
-  checkFutures(
-    await allFinished(
-    s.transports.mapIt(it.close())))
+  await all(
+    s.transports.mapIt(it.close()))
 
   trace "switch stopped"
 
-proc subscribeToPeer(s: Switch, peerInfo: PeerInfo) {.async, gcsafe.} =
+proc subscribeToPeer*(s: Switch, peerInfo: PeerInfo) {.async, gcsafe.} =
   ## Subscribe to pub sub peer
   if s.pubSub.isSome and peerInfo.id notin s.dialedPubSubPeers:
     try:
       s.dialedPubSubPeers.incl(peerInfo.id)
       let conn = await s.dial(peerInfo, s.pubSub.get().codec)
+      if isNil(conn):
+        trace "unable to subscribe to peer"
+        return
       await s.pubSub.get().subscribeToPeer(conn)
-    except CancelledError as exc:
-      raise exc
     except CatchableError as exc:
-      warn "unable to initiate pubsub", exc = exc.msg
+      trace "exception in subscribe to peer", exc = exc.msg
     finally:
       s.dialedPubSubPeers.excl(peerInfo.id)
 
@@ -434,19 +432,25 @@ proc newSwitch*(peerInfo: PeerInfo,
   for key, val in muxers:
     val.streamHandler = result.streamHandler
     val.muxerHandler = proc(muxer: Muxer) {.async, gcsafe.} =
-      trace "got new muxer"
-      let stream = await muxer.newStream()
-      muxer.connection.peerInfo = await s.identify(stream)
-      await stream.close()
+      var stream: Connection
+      try:
+        trace "got new muxer"
+        stream = await muxer.newStream()
+        muxer.connection.peerInfo = await s.identify(stream)
 
-      # store muxer for connection
-      s.muxed[muxer.connection.peerInfo.id] = muxer
+        # store muxer for connection
+        s.muxed[muxer.connection.peerInfo.id] = muxer
 
-      # store muxed connection
-      s.connections[muxer.connection.peerInfo.id] = muxer.connection
+        # store muxed connection
+        s.connections[muxer.connection.peerInfo.id] = muxer.connection
 
-      # try establishing a pubsub connection
-      await s.subscribeToPeer(muxer.connection.peerInfo)
+        # try establishing a pubsub connection
+        await s.subscribeToPeer(muxer.connection.peerInfo)
+      except CatchableError as exc:
+        trace "exception in muxer handler", exc = exc.msg
+      finally:
+        if not(isNil(stream)):
+          await stream.close()
 
   for proto in secureManagers:
     trace "adding secure manager ", codec = proto.codec

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -2,12 +2,14 @@ import chronos
 
 import ../libp2p/transports/tcptransport
 import ../libp2p/stream/bufferstream
+import ../libp2p/connection
 
 const
   StreamTransportTrackerName = "stream.transport"
   StreamServerTrackerName = "stream.server"
 
   trackerNames = [
+    ConnectionTrackerName,
     BufferStreamTrackerName,
     TcpTransportTrackerName,
     StreamTransportTrackerName,

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -42,7 +42,7 @@ suite "GossipSub internal":
       await gossipSub.rebalanceMesh(topic)
       check gossipSub.mesh[topic].len == GossipSubD
 
-      await allFuturesThrowing(conns.mapIt(it.close()))
+      await all(conns.mapIt(it.close()))
 
       result = true
 
@@ -71,7 +71,7 @@ suite "GossipSub internal":
       await gossipSub.rebalanceMesh(topic)
       check gossipSub.mesh[topic].len == GossipSubD
 
-      await allFuturesThrowing(conns.mapIt(it.close()))
+      await all(conns.mapIt(it.close()))
 
       result = true
 
@@ -103,7 +103,7 @@ suite "GossipSub internal":
       await gossipSub.replenishFanout(topic)
       check gossipSub.fanout[topic].len == GossipSubD
 
-      await allFuturesThrowing(conns.mapIt(it.close()))
+      await all(conns.mapIt(it.close()))
 
       result = true
 
@@ -138,7 +138,7 @@ suite "GossipSub internal":
       await gossipSub.dropFanoutPeers()
       check topic notin gossipSub.fanout
 
-      await allFuturesThrowing(conns.mapIt(it.close()))
+      await all(conns.mapIt(it.close()))
 
       result = true
 
@@ -179,7 +179,7 @@ suite "GossipSub internal":
       check topic1 notin gossipSub.fanout
       check topic2 in gossipSub.fanout
 
-      await allFuturesThrowing(conns.mapIt(it.close()))
+      await all(conns.mapIt(it.close()))
 
       result = true
 
@@ -242,7 +242,7 @@ suite "GossipSub internal":
         check p notin gossipSub.fanout[topic]
         check p notin gossipSub.mesh[topic]
 
-      await allFuturesThrowing(conns.mapIt(it.close()))
+      await all(conns.mapIt(it.close()))
 
       result = true
 
@@ -285,7 +285,7 @@ suite "GossipSub internal":
       let peers = gossipSub.getGossipPeers()
       check peers.len == GossipSubD
 
-      await allFuturesThrowing(conns.mapIt(it.close()))
+      await all(conns.mapIt(it.close()))
 
       result = true
 
@@ -328,7 +328,7 @@ suite "GossipSub internal":
       let peers = gossipSub.getGossipPeers()
       check peers.len == GossipSubD
 
-      await allFuturesThrowing(conns.mapIt(it.close()))
+      await all(conns.mapIt(it.close()))
 
       result = true
 
@@ -371,7 +371,7 @@ suite "GossipSub internal":
       let peers = gossipSub.getGossipPeers()
       check peers.len == 0
 
-      await allFuturesThrowing(conns.mapIt(it.close()))
+      await all(conns.mapIt(it.close()))
 
       result = true
 

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -52,8 +52,7 @@ suite "GossipSub":
     proc runTests(): Future[bool] {.async.} =
       var handlerFut = newFuture[bool]()
       proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-        check:
-          topic == "foobar"
+        check topic == "foobar"
         handlerFut.complete(true)
 
       var nodes = generateNodes(2, true)
@@ -72,8 +71,7 @@ suite "GossipSub":
       proc validator(topic: string,
                      message: Message):
                      Future[bool] {.async.} =
-        check:
-          topic == "foobar"
+        check topic == "foobar"
         validatorFut.complete(true)
         result = true
 
@@ -90,8 +88,7 @@ suite "GossipSub":
   test "GossipSub validation should fail":
     proc runTests(): Future[bool] {.async.} =
       proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-        check:
-          false # if we get here, it should fail
+        check false # if we get here, it should fail
 
       var nodes = generateNodes(2, true)
       var awaiters: seq[Future[void]]
@@ -125,8 +122,7 @@ suite "GossipSub":
     proc runTests(): Future[bool] {.async.} =
       var handlerFut = newFuture[bool]()
       proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-        check:
-          topic == "foo"
+        check topic == "foo"
         handlerFut.complete(true)
 
       var nodes = generateNodes(2, true)
@@ -247,8 +243,7 @@ suite "GossipSub":
     proc runTests(): Future[bool] {.async.} =
       var passed = newFuture[void]()
       proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-        check:
-          topic == "foobar"
+        check topic == "foobar"
         passed.complete()
 
       var nodes = generateNodes(2, true)
@@ -296,8 +291,7 @@ suite "GossipSub":
     proc runTests(): Future[bool] {.async.} =
       var passed: Future[bool] = newFuture[bool]()
       proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-        check:
-          topic == "foobar"
+        check topic == "foobar"
         passed.complete(true)
 
       var nodes = generateNodes(2, true)

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -79,8 +79,8 @@ suite "GossipSub":
       await nodes[0].publish("foobar", cast[seq[byte]]("Hello!"))
 
       result = (await validatorFut) and (await handlerFut)
-      await allFuturesThrowing(nodes[0].stop(), nodes[1].stop())
-      await allFuturesThrowing(awaiters)
+      await all(nodes[0].stop(), nodes[1].stop())
+      await all(awaiters)
 
     check:
       waitFor(runTests()) == true
@@ -111,9 +111,8 @@ suite "GossipSub":
       await nodes[0].publish("foobar", cast[seq[byte]]("Hello!"))
 
       result = await validatorFut
-
-      await allFuturesThrowing(nodes[0].stop(), nodes[1].stop())
-      await allFuturesThrowing(awaiters)
+      await all(nodes[0].stop(), nodes[1].stop())
+      await all(awaiters)
 
     check:
       waitFor(runTests()) == true
@@ -152,8 +151,8 @@ suite "GossipSub":
       await nodes[0].publish("bar", cast[seq[byte]]("Hello!"))
 
       result = ((await passed) and (await failed) and (await handlerFut))
-      await allFuturesThrowing(nodes[0].stop(), nodes[1].stop())
-      await allFuturesThrowing(awaiters)
+      await all(nodes[0].stop(), nodes[1].stop())
+      await all(awaiters)
       result = true
     check:
       waitFor(runTests()) == true
@@ -183,8 +182,8 @@ suite "GossipSub":
         "foobar" in gossip1.gossipsub
         gossip2.peerInfo.id in gossip1.gossipsub["foobar"]
 
-      await allFuturesThrowing(nodes.mapIt(it.stop()))
-      await allFuturesThrowing(awaitters)
+      await all(nodes.mapIt(it.stop()))
+      await all(awaitters)
 
       result = true
 
@@ -212,7 +211,7 @@ suite "GossipSub":
       var subs: seq[Future[void]]
       subs &= waitSub(nodes[1], nodes[0], "foobar")
       subs &= waitSub(nodes[0], nodes[1], "foobar")
-      await allFuturesThrowing(subs)
+      await all(subs)
 
       let
         gossip1 = GossipSub(nodes[0].pubSub.get())
@@ -231,8 +230,8 @@ suite "GossipSub":
         gossip1.peerInfo.id in gossip2.gossipsub["foobar"] or
         gossip1.peerInfo.id in gossip2.mesh["foobar"]
 
-      await allFuturesThrowing(nodes.mapIt(it.stop()))
-      await allFuturesThrowing(awaitters)
+      await all(nodes.mapIt(it.stop()))
+      await all(awaitters)
 
       result = true
 
@@ -280,7 +279,7 @@ suite "GossipSub":
 
       await nodes[0].stop()
       await nodes[1].stop()
-      await allFuturesThrowing(wait)
+      await all(wait)
 
       result = observed == 2
 
@@ -310,7 +309,7 @@ suite "GossipSub":
 
       await nodes[0].stop()
       await nodes[1].stop()
-      await allFuturesThrowing(wait)
+      await all(wait)
 
     check:
       waitFor(runTests()) == true
@@ -345,7 +344,8 @@ suite "GossipSub":
         subs.add(allFutures(dialer.subscribe("foobar", handler),
           waitSub(nodes[0], dialer, "foobar")))
 
-      await allFuturesThrowing(subs)
+      await all(subs)
+
       await wait(nodes[0].publish("foobar",
                                   cast[seq[byte]]("from node " &
                                   nodes[1].peerInfo.id)),
@@ -356,8 +356,8 @@ suite "GossipSub":
       for k, v in seen.pairs:
         check: v == 1
 
-      await allFuturesThrowing(nodes.mapIt(it.stop()))
-      await allFuturesThrowing(awaitters)
+      await all(nodes.mapIt(it.stop()))
+      await all(awaitters)
       result = true
 
     check:

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -52,7 +52,8 @@ suite "GossipSub":
     proc runTests(): Future[bool] {.async.} =
       var handlerFut = newFuture[bool]()
       proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-        check topic == "foobar"
+        check:
+          topic == "foobar"
         handlerFut.complete(true)
 
       var nodes = generateNodes(2, true)
@@ -71,7 +72,8 @@ suite "GossipSub":
       proc validator(topic: string,
                      message: Message):
                      Future[bool] {.async.} =
-        check topic == "foobar"
+        check:
+          topic == "foobar"
         validatorFut.complete(true)
         result = true
 
@@ -88,7 +90,8 @@ suite "GossipSub":
   test "GossipSub validation should fail":
     proc runTests(): Future[bool] {.async.} =
       proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-        check false # if we get here, it should fail
+        check:
+          false # if we get here, it should fail
 
       var nodes = generateNodes(2, true)
       var awaiters: seq[Future[void]]
@@ -122,7 +125,8 @@ suite "GossipSub":
     proc runTests(): Future[bool] {.async.} =
       var handlerFut = newFuture[bool]()
       proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-        check topic == "foo"
+        check:
+          topic == "foo"
         handlerFut.complete(true)
 
       var nodes = generateNodes(2, true)
@@ -243,7 +247,8 @@ suite "GossipSub":
     proc runTests(): Future[bool] {.async.} =
       var passed = newFuture[void]()
       proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-        check topic == "foobar"
+        check:
+          topic == "foobar"
         passed.complete()
 
       var nodes = generateNodes(2, true)
@@ -291,7 +296,8 @@ suite "GossipSub":
     proc runTests(): Future[bool] {.async.} =
       var passed: Future[bool] = newFuture[bool]()
       proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
-        check topic == "foobar"
+        check:
+          topic == "foobar"
         passed.complete(true)
 
       var nodes = generateNodes(2, true)

--- a/tests/testbufferstream.nim
+++ b/tests/testbufferstream.nim
@@ -250,7 +250,7 @@ suite "BufferStream":
       await buf1.pushTo(cast[seq[byte]]("Hello2!"))
       await buf2.pushTo(cast[seq[byte]]("Hello1!"))
 
-      await allFuturesThrowing(readFut1, readFut2)
+      await all(readFut1, readFut2)
 
       check:
         res1 == cast[seq[byte]]("Hello2!")
@@ -300,7 +300,7 @@ suite "BufferStream":
 
       await buf1.write(cast[seq[byte]]("Hello1!"))
       await buf2.write(cast[seq[byte]]("Hello2!"))
-      await allFuturesThrowing(readFut1, readFut2)
+      await all(readFut1, readFut2)
 
       check:
         res1 == cast[seq[byte]]("Hello2!")
@@ -376,7 +376,7 @@ suite "BufferStream":
 
       await buf1.write(cast[seq[byte]]("Hello1!"))
       await buf2.write(cast[seq[byte]]("Hello2!"))
-      await allFuturesThrowing(readFut1, readFut2)
+      await all(readFut1, readFut2)
 
       check:
         res1 == cast[seq[byte]]("Hello2!")
@@ -437,7 +437,7 @@ suite "BufferStream":
       var writerFut = writer()
       var readerFut = reader()
 
-      await allFuturesThrowing(readerFut, writerFut)
+      await all(readerFut, writerFut)
       result = true
 
       await buf1.close()

--- a/tests/testinterop.nim
+++ b/tests/testinterop.nim
@@ -44,7 +44,7 @@ proc writeLp*(s: StreamTransport, msg: string | seq[byte]): Future[int] {.gcsafe
   result = s.write(buf.buffer)
 
 proc readLp*(s: StreamTransport): Future[seq[byte]] {.async, gcsafe.} =
-  ## read lenght prefixed msg
+  ## read length prefixed msg
   var
     size: uint
     length: int

--- a/tests/testinterop.nim
+++ b/tests/testinterop.nim
@@ -83,6 +83,7 @@ proc testPubSubDaemonPublish(gossip: bool = false,
     let smsg = cast[string](data)
     check smsg == pubsubData
     times.inc()
+    echo "TIMES ", times
     if times >= count and not finished:
       finished = true
 
@@ -107,6 +108,7 @@ proc testPubSubDaemonPublish(gossip: bool = false,
 
   await wait(publisher(), 5.minutes) # should be plenty of time
 
+  echo "HEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
   result = true
   await nativeNode.stop()
   await allFutures(awaiters)
@@ -142,6 +144,7 @@ proc testPubSubNodePublish(gossip: bool = false,
     let smsg = cast[string](message.data)
     check smsg == pubsubData
     times.inc()
+    echo "TIMES ", times
     if times >= count and not finished:
       finished = true
     result = true # don't cancel subscription
@@ -353,6 +356,7 @@ suite "Interop":
           check line == test
           await conn.writeLp(cast[seq[byte]](test))
           count.inc()
+          echo "COUNT ", count
 
         testFuture.complete(count)
         await conn.close()

--- a/tests/testinterop.nim
+++ b/tests/testinterop.nim
@@ -83,7 +83,6 @@ proc testPubSubDaemonPublish(gossip: bool = false,
     let smsg = cast[string](data)
     check smsg == pubsubData
     times.inc()
-    echo "TIMES ", times
     if times >= count and not finished:
       finished = true
 
@@ -108,7 +107,6 @@ proc testPubSubDaemonPublish(gossip: bool = false,
 
   await wait(publisher(), 5.minutes) # should be plenty of time
 
-  echo "HEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
   result = true
   await nativeNode.stop()
   await allFutures(awaiters)
@@ -144,7 +142,6 @@ proc testPubSubNodePublish(gossip: bool = false,
     let smsg = cast[string](message.data)
     check smsg == pubsubData
     times.inc()
-    echo "TIMES ", times
     if times >= count and not finished:
       finished = true
     result = true # don't cancel subscription
@@ -167,10 +164,14 @@ proc testPubSubNodePublish(gossip: bool = false,
   await daemonNode.close()
 
 suite "Interop":
-  teardown:
-    for tracker in testTrackers():
-      echo tracker.dump()
-      # check tracker.isLeaked() == false
+  # TODO: chronos transports are leaking,
+  # but those are tracked for both the daemon
+  # and libp2p, so not sure which one it is,
+  # need to investigate more
+  # teardown:
+  #   for tracker in testTrackers():
+  #     # echo tracker.dump()
+  #     # check tracker.isLeaked() == false
 
   test "native -> daemon multiple reads and writes":
     proc runTests(): Future[bool] {.async.} =
@@ -352,7 +353,6 @@ suite "Interop":
           check line == test
           await conn.writeLp(cast[seq[byte]](test))
           count.inc()
-          echo "COUNT ", count
 
         testFuture.complete(count)
         await conn.close()

--- a/tests/testinterop.nim
+++ b/tests/testinterop.nim
@@ -83,7 +83,6 @@ proc testPubSubDaemonPublish(gossip: bool = false,
     let smsg = cast[string](data)
     check smsg == pubsubData
     times.inc()
-    echo "TIMES ", times
     if times >= count and not finished:
       finished = true
 
@@ -108,7 +107,6 @@ proc testPubSubDaemonPublish(gossip: bool = false,
 
   await wait(publisher(), 5.minutes) # should be plenty of time
 
-  echo "HEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
   result = true
   await nativeNode.stop()
   await allFutures(awaiters)
@@ -144,7 +142,6 @@ proc testPubSubNodePublish(gossip: bool = false,
     let smsg = cast[string](message.data)
     check smsg == pubsubData
     times.inc()
-    echo "TIMES ", times
     if times >= count and not finished:
       finished = true
     result = true # don't cancel subscription
@@ -356,7 +353,6 @@ suite "Interop":
           check line == test
           await conn.writeLp(cast[seq[byte]](test))
           count.inc()
-          echo "COUNT ", count
 
         testFuture.complete(count)
         await conn.close()

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -186,7 +186,7 @@ suite "Mplex":
       var data = newSeq[byte](1)
       try:
         await chann.readExactly(addr data[0], 1)
-        doAssert(len(data) == 1)
+        check data.len == 1
       except LPStreamEOFError:
         result = true
       finally:
@@ -245,7 +245,7 @@ suite "Mplex":
       await done.wait(1.seconds)
       await conn.close()
       await mplexDialFut
-      await allFuturesThrowing(transport1.close(), transport2.close())
+      await all(transport1.close(), transport2.close())
       await listenFut
 
     waitFor(testNewStream())
@@ -284,7 +284,7 @@ suite "Mplex":
       await done.wait(1.seconds)
       await conn.close()
       await mplexDialFut
-      await allFuturesThrowing(transport1.close(), transport2.close())
+      await all(transport1.close(), transport2.close())
       await listenFut
 
     waitFor(testNewStream())
@@ -331,7 +331,7 @@ suite "Mplex":
       await stream.close()
       await conn.close()
       await mplexDialFut
-      await allFuturesThrowing(transport1.close(), transport2.close())
+      await all(transport1.close(), transport2.close())
       await listenFut
 
     waitFor(testNewStream())
@@ -368,7 +368,7 @@ suite "Mplex":
       await done.wait(1.seconds)
       await conn.close()
       await mplexDialFut
-      await allFuturesThrowing(transport1.close(), transport2.close())
+      await all(transport1.close(), transport2.close())
       await listenFut
 
     waitFor(testNewStream())
@@ -410,7 +410,7 @@ suite "Mplex":
       await done.wait(10.seconds)
       await conn.close()
       await mplexDialFut
-      await allFuturesThrowing(transport1.close(), transport2.close())
+      await all(transport1.close(), transport2.close())
       await listenFut
 
     waitFor(testNewStream())
@@ -454,7 +454,7 @@ suite "Mplex":
       await done.wait(5.seconds)
       await conn.close()
       await mplexDialFut
-      await allFuturesThrowing(transport1.close(), transport2.close())
+      await all(transport1.close(), transport2.close())
       await listenFut
 
     waitFor(testNewStream())
@@ -522,7 +522,7 @@ suite "Mplex":
       await complete.wait(1.seconds)
       await mplexDialFut
 
-      await allFuturesThrowing(transport1.close(), transport2.close())
+      await all(transport1.close(), transport2.close())
       await listenFut
 
     waitFor(test())
@@ -579,7 +579,7 @@ suite "Mplex":
       await stream.close()
       await conn.close()
       await mplexDialFut
-      await allFuturesThrowing(transport1.close(), transport2.close())
+      await all(transport1.close(), transport2.close())
       await listenFut
 
     waitFor(test())

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -276,10 +276,11 @@ suite "Mplex":
       let mplexDial = newMplex(conn)
       let stream = await mplexDial.newStream(lazy = true)
       let mplexDialFut = mplexDial.handle()
-      check not LPChannel(stream.stream).isOpen # assert lazy
+      let openState = cast[LPChannel](stream).isOpen
       await stream.writeLp("HELLO")
-      check LPChannel(stream.stream).isOpen # assert lazy
       await stream.close()
+
+      check not openState # assert lazy
 
       await done.wait(1.seconds)
       await conn.close()
@@ -387,6 +388,7 @@ suite "Mplex":
           check string.fromBytes(msg) == &"stream {count}!"
           count.inc
           await stream.close()
+          count.inc
           if count == 10:
             done.complete()
 

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -387,8 +387,6 @@ suite "Mplex":
           check string.fromBytes(msg) == &"stream {count}!"
           count.inc
           await stream.close()
-          count.inc
-          await stream.close()
           if count == 10:
             done.complete()
 

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -276,11 +276,10 @@ suite "Mplex":
       let mplexDial = newMplex(conn)
       let stream = await mplexDial.newStream(lazy = true)
       let mplexDialFut = mplexDial.handle()
-      let openState = cast[LPChannel](stream).isOpen
+      check not LPChannel(stream.stream).isOpen # assert lazy
       await stream.writeLp("HELLO")
+      check LPChannel(stream.stream).isOpen # assert lazy
       await stream.close()
-
-      check not openState # assert lazy
 
       await done.wait(1.seconds)
       await conn.close()

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -388,6 +388,7 @@ suite "Mplex":
           count.inc
           await stream.close()
           count.inc
+          await stream.close()
           if count == 10:
             done.complete()
 

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -175,7 +175,7 @@ suite "Noise":
 
       let
         transport1: TcpTransport = TcpTransport.init()
-      asyncCheck await transport1.listen(server, connHandler)
+        listenFut = await transport1.listen(server, connHandler)
 
       let
         transport2: TcpTransport = TcpTransport.init()
@@ -191,6 +191,7 @@ suite "Noise":
       await conn.close()
       await transport2.close()
       await transport1.close()
+      await listenFut
 
       result = true
 
@@ -219,9 +220,10 @@ suite "Noise":
       await conn.writeLp("Hello!")
       let msg = cast[string](await conn.readLp(1024))
       check "Hello!" == msg
+      await conn.close()
 
-      await allFuturesThrowing(switch1.stop(), switch2.stop())
-      await allFuturesThrowing(awaiters)
+      await all(switch1.stop(), switch2.stop())
+      await all(awaiters)
       result = true
 
     check:

--- a/tests/testpeerinfo.nim
+++ b/tests/testpeerinfo.nim
@@ -5,13 +5,8 @@ import chronos
 import ../libp2p/crypto/crypto,
        ../libp2p/peerinfo,
        ../libp2p/peer
-import ./helpers
 
 suite "PeerInfo":
-  teardown:
-    for tracker in testTrackers():
-      check tracker.isLeaked() == false
-
   test "Should init with private key":
     let seckey = PrivateKey.random(ECDSA).get()
     var peerInfo = PeerInfo.init(seckey)
@@ -43,7 +38,7 @@ suite "PeerInfo":
     check:
       PeerID.init("QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N") == peerInfo.peerId
 
-  # TODO: CIDv1 is handling is missing from PeerID
+  # TODO: CIDv1 handling is missing from PeerID
   # https://github.com/status-im/nim-libp2p/issues/53
   # test "Should init from CIDv1 string":
   #   var peerInfo = PeerInfo.init("bafzbeie5745rpv2m6tjyuugywy4d5ewrqgqqhfnf445he3omzpjbx5xqxe")

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -102,51 +102,51 @@ suite "Switch":
 
     waitFor(testSwitch())
 
-  # test "e2e use switch no proto string":
-  #   proc testSwitch(): Future[bool] {.async, gcsafe.} =
-  #     let ma1: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
-  #     let ma2: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
+  test "e2e use switch no proto string":
+    proc testSwitch(): Future[bool] {.async, gcsafe.} =
+      let ma1: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
+      let ma2: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
 
-  #     var peerInfo1, peerInfo2: PeerInfo
-  #     var switch1, switch2: Switch
-  #     var awaiters: seq[Future[void]]
+      var peerInfo1, peerInfo2: PeerInfo
+      var switch1, switch2: Switch
+      var awaiters: seq[Future[void]]
 
-  #     (switch1, peerInfo1) = createSwitch(ma1)
+      (switch1, peerInfo1) = createSwitch(ma1)
 
-  #     proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
-  #       let msg = cast[string](await conn.readLp(1024))
-  #       check "Hello!" == msg
-  #       await conn.writeLp("Hello!")
-  #       await conn.close()
+      proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+        let msg = cast[string](await conn.readLp(1024))
+        check "Hello!" == msg
+        await conn.writeLp("Hello!")
+        await conn.close()
 
-  #     let testProto = new TestProto
-  #     testProto.codec = TestCodec
-  #     testProto.handler = handle
-  #     switch1.mount(testProto)
+      let testProto = new TestProto
+      testProto.codec = TestCodec
+      testProto.handler = handle
+      switch1.mount(testProto)
 
-  #     (switch2, peerInfo2) = createSwitch(ma2)
-  #     awaiters.add(await switch1.start())
-  #     awaiters.add(await switch2.start())
-  #     await switch2.connect(switch1.peerInfo)
-  #     let conn = await switch2.dial(switch1.peerInfo, TestCodec)
+      (switch2, peerInfo2) = createSwitch(ma2)
+      awaiters.add(await switch1.start())
+      awaiters.add(await switch2.start())
+      await switch2.connect(switch1.peerInfo)
+      let conn = await switch2.dial(switch1.peerInfo, TestCodec)
 
-  #     try:
-  #       await conn.writeLp("Hello!")
-  #       let msg = cast[string](await conn.readLp(1024))
-  #       check "Hello!" == msg
-  #       result = true
-  #     except LPStreamError:
-  #       result = false
+      try:
+        await conn.writeLp("Hello!")
+        let msg = cast[string](await conn.readLp(1024))
+        check "Hello!" == msg
+        result = true
+      except LPStreamError:
+        result = false
 
-  #     await allFuturesThrowing(
-  #       conn.close(),
-  #       switch1.stop(),
-  #       switch2.stop()
-  #     )
-  #     await allFuturesThrowing(awaiters)
+      await allFuturesThrowing(
+        conn.close(),
+        switch1.stop(),
+        switch2.stop()
+      )
+      await allFuturesThrowing(awaiters)
 
-  #   check:
-  #     waitFor(testSwitch()) == true
+    check:
+      waitFor(testSwitch()) == true
 
   # test "e2e: handle read + secio fragmented":
   #   proc testListenerDialer(): Future[bool] {.async.} =

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -90,7 +90,7 @@ suite "Switch":
       let msg = cast[string](await conn.readLp(1024))
       check "Hello!" == msg
 
-      await allFuturesThrowing(
+      await all(
         done.wait(5.seconds) #[if OK won't happen!!]#,
         conn.close(),
         switch1.stop(),
@@ -98,7 +98,7 @@ suite "Switch":
       )
 
       # this needs to go at end
-      await allFuturesThrowing(awaiters)
+      await all(awaiters)
 
     waitFor(testSwitch())
 
@@ -138,12 +138,12 @@ suite "Switch":
       except LPStreamError:
         result = false
 
-      await allFuturesThrowing(
+      await all(
         conn.close(),
         switch1.stop(),
         switch2.stop()
       )
-      await allFuturesThrowing(awaiters)
+      await all(awaiters)
 
     check:
       waitFor(testSwitch()) == true

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -102,51 +102,51 @@ suite "Switch":
 
     waitFor(testSwitch())
 
-  test "e2e use switch no proto string":
-    proc testSwitch(): Future[bool] {.async, gcsafe.} =
-      let ma1: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0").tryGet()
-      let ma2: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0").tryGet()
+  # test "e2e use switch no proto string":
+  #   proc testSwitch(): Future[bool] {.async, gcsafe.} =
+  #     let ma1: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
+  #     let ma2: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
 
-      var peerInfo1, peerInfo2: PeerInfo
-      var switch1, switch2: Switch
-      var awaiters: seq[Future[void]]
+  #     var peerInfo1, peerInfo2: PeerInfo
+  #     var switch1, switch2: Switch
+  #     var awaiters: seq[Future[void]]
 
-      (switch1, peerInfo1) = createSwitch(ma1)
+  #     (switch1, peerInfo1) = createSwitch(ma1)
 
-      proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
-        let msg = cast[string](await conn.readLp(1024))
-        check "Hello!" == msg
-        await conn.writeLp("Hello!")
-        await conn.close()
+  #     proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+  #       let msg = cast[string](await conn.readLp(1024))
+  #       check "Hello!" == msg
+  #       await conn.writeLp("Hello!")
+  #       await conn.close()
 
-      let testProto = new TestProto
-      testProto.codec = TestCodec
-      testProto.handler = handle
-      switch1.mount(testProto)
+  #     let testProto = new TestProto
+  #     testProto.codec = TestCodec
+  #     testProto.handler = handle
+  #     switch1.mount(testProto)
 
-      (switch2, peerInfo2) = createSwitch(ma2)
-      awaiters.add(await switch1.start())
-      awaiters.add(await switch2.start())
-      await switch2.connect(switch1.peerInfo)
-      let conn = await switch2.dial(switch1.peerInfo, TestCodec)
+  #     (switch2, peerInfo2) = createSwitch(ma2)
+  #     awaiters.add(await switch1.start())
+  #     awaiters.add(await switch2.start())
+  #     await switch2.connect(switch1.peerInfo)
+  #     let conn = await switch2.dial(switch1.peerInfo, TestCodec)
 
-      try:
-        await conn.writeLp("Hello!")
-        let msg = cast[string](await conn.readLp(1024))
-        check "Hello!" == msg
-        result = true
-      except LPStreamError:
-        result = false
+  #     try:
+  #       await conn.writeLp("Hello!")
+  #       let msg = cast[string](await conn.readLp(1024))
+  #       check "Hello!" == msg
+  #       result = true
+  #     except LPStreamError:
+  #       result = false
 
-      await allFuturesThrowing(
-        conn.close(),
-        switch1.stop(),
-        switch2.stop()
-      )
-      await allFuturesThrowing(awaiters)
+  #     await allFuturesThrowing(
+  #       conn.close(),
+  #       switch1.stop(),
+  #       switch2.stop()
+  #     )
+  #     await allFuturesThrowing(awaiters)
 
-    check:
-      waitFor(testSwitch()) == true
+  #   check:
+  #     waitFor(testSwitch()) == true
 
   # test "e2e: handle read + secio fragmented":
   #   proc testListenerDialer(): Future[bool] {.async.} =

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -2,11 +2,12 @@
 
 import unittest, tables
 import chronos
-import chronicles
+import stew/byteutils
 import nimcrypto/sysrand
 import ../libp2p/[errors,
                   switch,
                   multistream,
+                  standard_setup,
                   stream/bufferstream,
                   protocols/identify,
                   connection,
@@ -30,25 +31,6 @@ const
 type
   TestProto = ref object of LPProtocol
 
-proc createSwitch(ma: MultiAddress): (Switch, PeerInfo) =
-  var peerInfo: PeerInfo = PeerInfo.init(PrivateKey.random(ECDSA).tryGet())
-  peerInfo.addrs.add(ma)
-  let identify = newIdentify(peerInfo)
-
-  proc createMplex(conn: Connection): Muxer =
-    result = newMplex(conn)
-
-  let mplexProvider = newMuxerProvider(createMplex, MplexCodec)
-  let transports = @[Transport(TcpTransport.init())]
-  let muxers = [(MplexCodec, mplexProvider)].toTable()
-  let secureManagers = [Secure(newSecio(peerInfo.privateKey))]
-  let switch = newSwitch(peerInfo,
-                         transports,
-                         identify,
-                         muxers,
-                         secureManagers)
-  result = (switch, peerInfo)
-
 suite "Switch":
   teardown:
     for tracker in testTrackers():
@@ -57,42 +39,53 @@ suite "Switch":
 
   test "e2e use switch dial proto string":
     proc testSwitch() {.async, gcsafe.} =
-      let ma1: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0").tryGet()
-      let ma2: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0").tryGet()
-
-      var peerInfo1, peerInfo2: PeerInfo
-      var switch1, switch2: Switch
-      var awaiters: seq[Future[void]]
-
-      (switch1, peerInfo1) = createSwitch(ma1)
-
       let done = newFuture[void]()
-
       proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
-        let msg = cast[string](await conn.readLp(1024))
-        check "Hello!" == msg
-        await conn.writeLp("Hello!")
-        await conn.close()
-        done.complete()
+        try:
+          let msg = string.fromBytes(await conn.readLp(1024))
+          check "Hello!" == msg
+          await conn.writeLp("Hello!")
+        finally:
+          await conn.close()
+          done.complete()
 
       let testProto = new TestProto
       testProto.codec = TestCodec
       testProto.handler = handle
+
+      let switch1 = newStandardSwitch()
       switch1.mount(testProto)
 
-      (switch2, peerInfo2) = createSwitch(ma2)
+      let switch2 = newStandardSwitch()
+      var awaiters: seq[Future[void]]
       awaiters.add(await switch1.start())
       awaiters.add(await switch2.start())
 
       let conn = await switch2.dial(switch1.peerInfo, TestCodec)
-
       await conn.writeLp("Hello!")
-      let msg = cast[string](await conn.readLp(1024))
+      let msg = string.fromBytes(await conn.readLp(1024))
       check "Hello!" == msg
+      await conn.close()
+
+      await sleepAsync(2.seconds) # wait a little for cleanup to happen
+      var bufferTracker = getTracker(BufferStreamTrackerName)
+      # echo bufferTracker.dump()
+
+      # plus 4 for the pubsub streams
+      check (BufferStreamTracker(bufferTracker).opened ==
+        (BufferStreamTracker(bufferTracker).closed + 4.uint64))
+
+      var connTracker = getTracker(ConnectionTrackerName)
+      # echo connTracker.dump()
+
+      # plus 8 is for the secured connection and the socket
+      # and the pubsub streams that won't clean up until
+      # `disconnect()` or `stop()`
+      check (ConnectionTracker(connTracker).opened ==
+        (ConnectionTracker(connTracker).closed + 8.uint64))
 
       await all(
-        done.wait(5.seconds) #[if OK won't happen!!]#,
-        conn.close(),
+        done.wait(5.seconds), #[if OK won't happen!!]#
         switch1.stop(),
         switch2.stop(),
       )
@@ -102,37 +95,37 @@ suite "Switch":
 
     waitFor(testSwitch())
 
-  test "e2e use switch no proto string":
+  test "e2e use connect then dial":
     proc testSwitch(): Future[bool] {.async, gcsafe.} =
-      let ma1: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
-      let ma2: MultiAddress = Multiaddress.init("/ip4/0.0.0.0/tcp/0")
-
-      var peerInfo1, peerInfo2: PeerInfo
-      var switch1, switch2: Switch
       var awaiters: seq[Future[void]]
 
-      (switch1, peerInfo1) = createSwitch(ma1)
-
       proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
-        let msg = cast[string](await conn.readLp(1024))
-        check "Hello!" == msg
-        await conn.writeLp("Hello!")
-        await conn.close()
+        try:
+          let msg = string.fromBytes(await conn.readLp(1024))
+          check "Hello!" == msg
+        finally:
+          await conn.writeLp("Hello!")
+          await conn.close()
 
       let testProto = new TestProto
       testProto.codec = TestCodec
       testProto.handler = handle
+
+      let switch1 = newStandardSwitch()
       switch1.mount(testProto)
 
-      (switch2, peerInfo2) = createSwitch(ma2)
+      let switch2 = newStandardSwitch()
       awaiters.add(await switch1.start())
       awaiters.add(await switch2.start())
+
       await switch2.connect(switch1.peerInfo)
+      check switch1.peerInfo.id in switch2.connections
+
       let conn = await switch2.dial(switch1.peerInfo, TestCodec)
 
       try:
         await conn.writeLp("Hello!")
-        let msg = cast[string](await conn.readLp(1024))
+        let msg = string.fromBytes(await conn.readLp(1024))
         check "Hello!" == msg
         result = true
       except LPStreamError:
@@ -147,6 +140,36 @@ suite "Switch":
 
     check:
       waitFor(testSwitch()) == true
+
+  test "e2e should not leak on peer disconnect":
+    proc testSwitch() {.async, gcsafe.} =
+      var awaiters: seq[Future[void]]
+
+      let switch1 = newStandardSwitch()
+      let switch2 = newStandardSwitch()
+      awaiters.add(await switch1.start())
+      awaiters.add(await switch2.start())
+      await switch2.connect(switch1.peerInfo)
+
+      await sleepAsync(100.millis)
+      await switch2.disconnect(switch1.peerInfo)
+
+      await sleepAsync(2.seconds)
+      var bufferTracker = getTracker(BufferStreamTrackerName)
+      # echo bufferTracker.dump()
+      check bufferTracker.isLeaked() == false
+
+      var connTracker = getTracker(ConnectionTrackerName)
+      # echo connTracker.dump()
+      check connTracker.isLeaked() == false
+
+      await all(
+        switch1.stop(),
+        switch2.stop()
+      )
+      await all(awaiters)
+
+    waitFor(testSwitch())
 
   # test "e2e: handle read + secio fragmented":
   #   proc testListenerDialer(): Future[bool] {.async.} =


### PR DESCRIPTION
This is a continuation of #187 (🍿), which got a bit unmanageable. 

Kind request, lets keep this on topic.

Bellow is the rationale as described in the original PR.
--------------------
This PR introduces some sane exception handling with the following rationale:

- Exceptions are polymorphic, use that to your advantage, don't overspecialize your exception handling code unless it's absolutely necessary
- Exceptions bubble up, that's by design, don't try to hide them, it will blow up in your face later on
- Exceptions flow is akin to a tree, where the leafs are exception originators and the root is where the exception eventually converges
  - the most generic handler should be at the root of the tree
  - more specialized exception handlers can be installed at different levels, depending on the need, but usually it should be allowed to bubble all the way up
  - public API shouldn't hide exceptions, it should allow the consumer to deal with them, otherwise communicating internal state becomes a huge burden and leads to all sorts for hacks (see any/most c api's)
  - roots that aren't part of the public API are terminal and should handle all exceptions in place, in libp2p's case, this are mostly internally invoked `handlers`, ie callbacks. In other words, callbacks should never raise and handle all exceptions internally, but code invoking callbacks should also guard against that by wrapping it in a `try/except/finally`.
  - As a special case, all tasks launched with `asyncCheck` should also handle their exceptions in place

