### PR TITLE
Make GossipSub initPubSub method public

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -452,7 +452,7 @@ method stop*(g: GossipSub) {.async.} =
 
   g.heartbeatLock.release()
 
-method initPubSub(g: GossipSub) =
+method initPubSub*(g: GossipSub) =
   procCall FloodSub(g).initPubSub()
 
   randomize()


### PR DESCRIPTION
This means we can use it from other protocols that inherit GossipSub. Otherwise,
a lot of internal state (heartbeat lock etc) doesn't get initialized properly.

See https://github.com/status-im/nim-waku/pull/19#issuecomment-635786640 for full context.