### PR TITLE
allow message id provider to be specified

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -15,7 +15,6 @@ import pubsub,
        mcache,
        timedcache,
        rpc/[messages, message],
-       ../../crypto/crypto,
        ../protocol,
        ../../peerinfo,
        ../../stream/connection,
@@ -361,12 +360,16 @@ method rpcHandler*(g: GossipSub,
     if m.messages.len > 0:                           # if there are any messages
       var toSendPeers: HashSet[string]
       for msg in m.messages:                         # for every message
-        trace "processing message with id", msg = msg.msgId
-        if msg.msgId in g.seen:
-          trace "message already processed, skipping", msg = msg.msgId
+        let msgId = g.msgIdProvider(msg)
+        logScope: msgId
+
+        if msgId in g.seen:
+          trace "message already processed, skipping"
           continue
 
-        g.seen.put(msg.msgId)                        # add the message to the seen cache
+        trace "processing message"
+
+        g.seen.put(msgId)                        # add the message to the seen cache
 
         if g.verifySignature and not msg.verify(peer.peerInfo):
           trace "dropping message due to failed signature verification"
@@ -377,8 +380,8 @@ method rpcHandler*(g: GossipSub,
           continue
 
         # this shouldn't happen
-        if g.peerInfo.peerId == msg.fromPeerId():
-          trace "skipping messages from self", msg = msg.msgId
+        if g.peerInfo.peerId == msg.fromPeer:
+          trace "skipping messages from self"
           continue
 
         for t in msg.topicIDs:                     # for every topic in the message
@@ -391,10 +394,9 @@ method rpcHandler*(g: GossipSub,
 
           if t in g.topics:                        # if we're subscribed to the topic
             for h in g.topics[t].handler:
-              trace "calling handler for message", msg = msg.msgId,
-                                                   topicId = t,
+              trace "calling handler for message", topicId = t,
                                                    localPeer = g.peerInfo.id,
-                                                   fromPeer = msg.fromPeerId().pretty
+                                                   fromPeer = msg.fromPeer.pretty
               await h(t, msg.data)                 # trigger user provided handler
 
       # forward the message to all peers interested in it
@@ -409,7 +411,7 @@ method rpcHandler*(g: GossipSub,
 
           let msgs = m.messages.filterIt(
             # don't forward to message originator
-            id != it.fromPeerId()
+            id != it.fromPeer
           )
 
           var sent: seq[Future[void]]
@@ -460,9 +462,9 @@ method publish*(g: GossipSub,
   trace "about to publish message on topic", name = topic,
                                              data = data.shortLog
 
-  var peers: HashSet[string]
   # TODO: we probably don't need to try multiple times
   if data.len > 0 and topic.len > 0:
+    var peers = g.mesh.getOrDefault(topic)
     for _ in 0..<5: # try to get peers up to 5 times
       if peers.len > 0:
         break
@@ -480,7 +482,10 @@ method publish*(g: GossipSub,
       # wait a second between tries
       await sleepAsync(1.seconds)
 
-    let msg = newMessage(g.peerInfo, data, topic, g.sign)
+    let
+      msg = Message.init(g.peerInfo, data, topic, g.sign)
+      msgId = g.msgIdProvider(msg)
+
     trace "created new message", msg
     var sent: seq[Future[void]]
     for p in peers:
@@ -488,8 +493,8 @@ method publish*(g: GossipSub,
         continue
 
       trace "publishing on topic", name = topic
-      if msg.msgId notin g.mcache:
-        g.mcache.put(msg)
+      if msgId notin g.mcache:
+        g.mcache.put(msgId, msg)
 
       if p in g.peers:
         sent.add(g.peers[p].send(@[RPCMsg(messages: @[msg])]))
@@ -499,10 +504,10 @@ method publish*(g: GossipSub,
 
 method start*(g: GossipSub) {.async.} =
   debug "gossipsub start"
-  
+
   ## start pubsub
   ## start long running/repeating procedures
-  
+
   # interlock start to to avoid overlapping to stops
   await g.heartbeatLock.acquire()
 
@@ -514,7 +519,7 @@ method start*(g: GossipSub) {.async.} =
 
 method stop*(g: GossipSub) {.async.} =
   debug "gossipsub stop"
-  
+
   ## stop pubsub
   ## stop long running tasks
 

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -10,9 +10,10 @@
 import tables, sequtils, sets
 import chronos, chronicles
 import pubsubpeer,
-       rpc/messages,
+       rpc/[message, messages],
        ../protocol,
        ../../stream/connection,
+       ../../peer,
        ../../peerinfo
 import metrics
 
@@ -38,6 +39,9 @@ type
 
   TopicPair* = tuple[topic: string, handler: TopicHandler]
 
+  MsgIdProvider* =
+    proc(m: Message): string {.noSideEffect, raises: [Defect], nimcall, gcsafe.}
+
   Topic* = object
     name*: string
     handler*: seq[TopicHandler]
@@ -52,6 +56,7 @@ type
     cleanupLock: AsyncLock
     validators*: Table[string, HashSet[ValidatorHandler]]
     observers: ref seq[PubSubObserver] # ref as in smart_ptr
+    msgIdProvider*: MsgIdProvider     # Turn message into message id (not nil)
 
 proc sendSubs*(p: PubSub,
                peer: PubSubPeer,
@@ -244,6 +249,8 @@ method publish*(p: PubSub,
 method initPubSub*(p: PubSub) {.base.} =
   ## perform pubsub initialization
   p.observers = new(seq[PubSubObserver])
+  if p.msgIdProvider == nil:
+    p.msgIdProvider = defaultMsgIdProvider
 
 method start*(p: PubSub) {.async, base.} =
   ## start pubsub
@@ -292,12 +299,14 @@ proc newPubSub*(P: typedesc[PubSub],
                 peerInfo: PeerInfo,
                 triggerSelf: bool = false,
                 verifySignature: bool = true,
-                sign: bool = true): P =
+                sign: bool = true,
+                msgIdProvider: MsgIdProvider = defaultMsgIdProvider): P =
   result = P(peerInfo: peerInfo,
              triggerSelf: triggerSelf,
              verifySignature: verifySignature,
              sign: sign,
-             cleanupLock: newAsyncLock())
+             cleanupLock: newAsyncLock(),
+             msgIdProvider: msgIdProvider)
   result.initPubSub()
 
 proc addObserver*(p: PubSub; observer: PubSubObserver) = p.observers[] &= observer

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -154,7 +154,7 @@ proc sendMsg*(p: PubSubPeer,
               topic: string,
               data: seq[byte],
               sign: bool): Future[void] {.gcsafe.} =
-  p.send(@[RPCMsg(messages: @[newMessage(p.peerInfo, data, topic, sign)])])
+  p.send(@[RPCMsg(messages: @[Message.init(p.peerInfo, data, topic, sign)])])
 
 proc sendGraft*(p: PubSubPeer, topics: seq[string]) {.async.} =
   for topic in topics:

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -9,6 +9,7 @@
 
 import options, sequtils
 import ../../../utility
+import ../../../peer
 
 type
     SubOpts* = object
@@ -16,7 +17,7 @@ type
       topic*: string
 
     Message* = object
-      fromPeer*: seq[byte]
+      fromPeer*: PeerId
       data*: seq[byte]
       seqno*: seq[byte]
       topicIDs*: seq[string]
@@ -75,10 +76,10 @@ func shortLog*(c: ControlMessage): auto =
     graft: mapIt(c.graft, it.shortLog),
     prune: mapIt(c.prune, it.shortLog)
   )
-      
+
 func shortLog*(msg: Message): auto =
   (
-    fromPeer: msg.fromPeer.shortLog,
+    fromPeer: msg.fromPeer,
     data: msg.data.shortLog,
     seqno: msg.seqno.shortLog,
     topicIDs: $msg.topicIDs,

--- a/libp2p/standard_setup.nim
+++ b/libp2p/standard_setup.nim
@@ -9,7 +9,8 @@ import
   crypto/crypto, transports/[transport, tcptransport],
   muxers/[muxer, mplex/mplex, mplex/types],
   protocols/[identify, secure/secure],
-  protocols/pubsub/[pubsub, gossipsub, floodsub]
+  protocols/pubsub/[pubsub, gossipsub, floodsub],
+  protocols/pubsub/rpc/message
 
 import
   protocols/secure/noise,
@@ -30,11 +31,12 @@ proc newStandardSwitch*(privKey = none(PrivateKey),
                         secureManagers: openarray[SecureProtocol] = [
                             # array cos order matters
                             SecureProtocol.Secio,
-                            SecureProtocol.Noise, 
+                            SecureProtocol.Noise,
                           ],
                         verifySignature = libp2p_pubsub_verify,
                         sign = libp2p_pubsub_sign,
-                        transportFlags: set[ServerFlags] = {}): Switch =
+                        transportFlags: set[ServerFlags] = {},
+                        msgIdProvider: MsgIdProvider = defaultMsgIdProvider): Switch =
   proc createMplex(conn: Connection): Muxer =
     newMplex(conn)
 
@@ -60,13 +62,15 @@ proc newStandardSwitch*(privKey = none(PrivateKey),
                             peerInfo = peerInfo,
                             triggerSelf = triggerSelf,
                             verifySignature = verifySignature,
-                            sign = sign).PubSub
+                            sign = sign,
+                            msgIdProvider = msgIdProvider).PubSub
                else:
                   newPubSub(FloodSub,
                             peerInfo = peerInfo,
                             triggerSelf = triggerSelf,
                             verifySignature = verifySignature,
-                            sign = sign).PubSub
+                            sign = sign,
+                            msgIdProvider = msgIdProvider).PubSub
 
   newSwitch(
     peerInfo,

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -5,6 +5,7 @@ include ../../libp2p/protocols/pubsub/gossipsub
 import unittest
 import stew/byteutils
 import ../../libp2p/errors
+import ../../libp2p/crypto/crypto
 import ../../libp2p/stream/bufferstream
 
 import ../helpers
@@ -229,8 +230,8 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = PeerInfo.init(PrivateKey.random(ECDSA).get())
         conn.peerInfo = peerInfo
-        let msg = newMessage(peerInfo, ("HELLO" & $i).toBytes(), topic, false)
-        gossipSub.mcache.put(msg)
+        let msg = Message.init(peerInfo, ("HELLO" & $i).toBytes(), topic, false)
+        gossipSub.mcache.put(gossipSub.msgIdProvider(msg), msg)
 
       check gossipSub.fanout[topic].len == 15
       check gossipSub.mesh[topic].len == 15
@@ -279,8 +280,8 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = PeerInfo.init(PrivateKey.random(ECDSA).get())
         conn.peerInfo = peerInfo
-        let msg = newMessage(peerInfo, ("HELLO" & $i).toBytes(), topic, false)
-        gossipSub.mcache.put(msg)
+        let msg = Message.init(peerInfo, ("HELLO" & $i).toBytes(), topic, false)
+        gossipSub.mcache.put(gossipSub.msgIdProvider(msg), msg)
 
       let peers = gossipSub.getGossipPeers()
       check peers.len == GossipSubD
@@ -322,8 +323,8 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = PeerInfo.init(PrivateKey.random(ECDSA).get())
         conn.peerInfo = peerInfo
-        let msg = newMessage(peerInfo, ("HELLO" & $i).toBytes(), topic, false)
-        gossipSub.mcache.put(msg)
+        let msg = Message.init(peerInfo, ("HELLO" & $i).toBytes(), topic, false)
+        gossipSub.mcache.put(gossipSub.msgIdProvider(msg), msg)
 
       let peers = gossipSub.getGossipPeers()
       check peers.len == GossipSubD
@@ -365,8 +366,8 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = PeerInfo.init(PrivateKey.random(ECDSA).get())
         conn.peerInfo = peerInfo
-        let msg = newMessage(peerInfo, ("bar" & $i).toBytes(), topic, false)
-        gossipSub.mcache.put(msg)
+        let msg = Message.init(peerInfo, ("bar" & $i).toBytes(), topic, false)
+        gossipSub.mcache.put(gossipSub.msgIdProvider(msg), msg)
 
       let peers = gossipSub.getGossipPeers()
       check peers.len == 0

--- a/tests/pubsub/testmcache.nim
+++ b/tests/pubsub/testmcache.nim
@@ -11,25 +11,26 @@ import ../../libp2p/[peer,
 suite "MCache":
   test "put/get":
     var mCache = newMCache(3, 5)
-    var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()).data,
+    var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()),
                        seqno: "12345".toBytes())
-    mCache.put(msg)
-    check mCache.get(msg.msgId).isSome and mCache.get(msg.msgId).get() == msg
+    let msgId = defaultMsgIdProvider(msg)
+    mCache.put(msgId, msg)
+    check mCache.get(msgId).isSome and mCache.get(msgId).get() == msg
 
   test "window":
     var mCache = newMCache(3, 5)
 
     for i in 0..<3:
-      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()).data,
+      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()),
                         seqno: "12345".toBytes(),
                         topicIDs: @["foo"])
-      mCache.put(msg)
+      mCache.put(defaultMsgIdProvider(msg), msg)
 
     for i in 0..<5:
-      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()).data,
+      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()),
                         seqno: "12345".toBytes(),
                         topicIDs: @["bar"])
-      mCache.put(msg)
+      mCache.put(defaultMsgIdProvider(msg), msg)
 
     var mids = mCache.window("foo")
     check mids.len == 3
@@ -41,28 +42,28 @@ suite "MCache":
     var mCache = newMCache(1, 5)
 
     for i in 0..<3:
-      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()).data,
+      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()),
                         seqno: "12345".toBytes(),
                         topicIDs: @["foo"])
-      mCache.put(msg)
+      mCache.put(defaultMsgIdProvider(msg), msg)
 
     mCache.shift()
     check mCache.window("foo").len == 0
 
     for i in 0..<3:
-      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()).data,
+      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()),
                         seqno: "12345".toBytes(),
                         topicIDs: @["bar"])
-      mCache.put(msg)
+      mCache.put(defaultMsgIdProvider(msg), msg)
 
     mCache.shift()
     check mCache.window("bar").len == 0
 
     for i in 0..<3:
-      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()).data,
+      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()),
                         seqno: "12345".toBytes(),
                         topicIDs: @["baz"])
-      mCache.put(msg)
+      mCache.put(defaultMsgIdProvider(msg), msg)
 
     mCache.shift()
     check mCache.window("baz").len == 0
@@ -71,22 +72,22 @@ suite "MCache":
     var mCache = newMCache(1, 5)
 
     for i in 0..<3:
-      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()).data,
+      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()),
                         seqno: "12345".toBytes(),
                         topicIDs: @["foo"])
-      mCache.put(msg)
+      mCache.put(defaultMsgIdProvider(msg), msg)
 
     for i in 0..<3:
-      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()).data,
+      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()),
                         seqno: "12345".toBytes(),
                         topicIDs: @["bar"])
-      mCache.put(msg)
+      mCache.put(defaultMsgIdProvider(msg), msg)
 
     for i in 0..<3:
-      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()).data,
+      var msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()),
                         seqno: "12345".toBytes(),
                         topicIDs: @["baz"])
-      mCache.put(msg)
+      mCache.put(defaultMsgIdProvider(msg), msg)
 
     mCache.shift()
     check mCache.window("foo").len == 0

--- a/tests/pubsub/testmessage.nim
+++ b/tests/pubsub/testmessage.nim
@@ -1,33 +1,14 @@
 import unittest
-import nimcrypto/sha2,
-       stew/[base64, byteutils]
-import ../../libp2p/[peer,
+
+import ../../libp2p/[peer, peerinfo,
                      crypto/crypto,
                      protocols/pubsub/rpc/message,
                      protocols/pubsub/rpc/messages]
 
 suite "Message":
-  test "default message id":
-    let msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()).data,
-                       seqno: ("12345").toBytes())
+  test "signature":
+    let
+      peer = PeerInfo.init(PrivateKey.random(ECDSA).get())
+      msg = Message.init(peer, @[], "topic", sign = true)
 
-    check msg.msgId == byteutils.toHex(msg.seqno) & PeerID.init(msg.fromPeer).pretty
-
-  test "sha256 message id":
-    let msg = Message(fromPeer: PeerID.init(PrivateKey.random(ECDSA).get()).data,
-                       seqno: ("12345").toBytes(),
-                       data: ("12345").toBytes())
-
-    proc msgIdProvider(m: Message): string =
-      Base64Url.encode(
-        sha256.
-        digest(m.data).
-        data.
-        toOpenArray(0, sha256.sizeDigest() - 1))
-
-    check msg.msgId == Base64Url.encode(
-        sha256.
-        digest(msg.data).
-        data.
-        toOpenArray(0, sha256.sizeDigest() - 1))
-
+    check verify(msg, peer)


### PR DESCRIPTION
* don't send public key in message when not signing (information leak)
* don't run rebalance if there are peers in gossip (see #242)
* don't crash randomly on bad peer id from remote