### PR TITLE
Fix gossip messages seqno according to spec

### DIFF
--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -39,7 +39,6 @@ type
       privateKey*: PrivateKey
     of HasPublic:
       key: Option[PublicKey]
-    seqno*: uint64
 
 proc id*(p: PeerInfo): string =
   if not(isNil(p)):

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -39,6 +39,7 @@ type
       privateKey*: PrivateKey
     of HasPublic:
       key: Option[PublicKey]
+    seqno*: uint64
 
 proc id*(p: PeerInfo): string =
   if not(isNil(p)):

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -133,7 +133,8 @@ method publish*(f: FloodSub,
     return
 
   trace "publishing on topic", name = topic
-  let msg = Message.init(f.peerInfo, data, topic, f.sign)
+  inc f.msgSeqno
+  let msg = Message.init(f.peerInfo, data, topic, f.msgSeqno, f.sign)
   # start the future but do not wait yet
   let (published, failed) = await f.sendHelper(f.floodsub.getOrDefault(topic), @[msg])
   for p in failed:

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -518,8 +518,9 @@ method publish*(g: GossipSub,
     # time
     g.lastFanoutPubSub[topic] = Moment.fromNow(GossipSubFanoutTTL)
 
+  inc g.msgSeqno
   let
-    msg = Message.init(g.peerInfo, data, topic, g.sign)
+    msg = Message.init(g.peerInfo, data, topic, g.msgSeqno, g.sign)
     msgId = g.msgIdProvider(msg)
 
   trace "created new message", msg

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -168,6 +168,7 @@ proc rebalanceMesh(g: GossipSub, topic: string) {.async.} =
         # send a graft message to the peer
         await p.sendPrune(@[topic])
         g.mesh[topic].excl(id)
+        g.gossipsub[topic].incl(id)
 
     libp2p_gossipsub_peers_per_topic_gossipsub
       .set(g.gossipsub.getOrDefault(topic).len.int64,
@@ -274,7 +275,7 @@ proc heartbeat(g: GossipSub) {.async.} =
     except CatchableError as exc:
       trace "exception ocurred in gossipsub heartbeat", exc = exc.msg
 
-    await sleepAsync(1.seconds)
+    await sleepAsync(5.seconds)
 
 method handleDisconnect*(g: GossipSub, peer: PubSubPeer) =
   ## handle peer disconnects
@@ -362,6 +363,7 @@ proc handlePrune(g: GossipSub, peer: PubSubPeer, prunes: seq[ControlPrune]) =
 
     if prune.topicID in g.mesh:
       g.mesh[prune.topicID].excl(peer.id)
+      g.gossipsub[prune.topicID].incl(peer.id)
       libp2p_gossipsub_peers_per_topic_mesh
         .set(g.mesh[prune.topicID].len.int64, labelValues = [prune.topicID])
 

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -168,7 +168,6 @@ proc rebalanceMesh(g: GossipSub, topic: string) {.async.} =
         # send a graft message to the peer
         await p.sendPrune(@[topic])
         g.mesh[topic].excl(id)
-        g.gossipsub[topic].incl(id)
 
     libp2p_gossipsub_peers_per_topic_gossipsub
       .set(g.gossipsub.getOrDefault(topic).len.int64,
@@ -275,7 +274,7 @@ proc heartbeat(g: GossipSub) {.async.} =
     except CatchableError as exc:
       trace "exception ocurred in gossipsub heartbeat", exc = exc.msg
 
-    await sleepAsync(5.seconds)
+    await sleepAsync(1.seconds)
 
 method handleDisconnect*(g: GossipSub, peer: PubSubPeer) =
   ## handle peer disconnects
@@ -363,7 +362,6 @@ proc handlePrune(g: GossipSub, peer: PubSubPeer, prunes: seq[ControlPrune]) =
 
     if prune.topicID in g.mesh:
       g.mesh[prune.topicID].excl(peer.id)
-      g.gossipsub[prune.topicID].incl(peer.id)
       libp2p_gossipsub_peers_per_topic_mesh
         .set(g.mesh[prune.topicID].len.int64, labelValues = [prune.topicID])
 

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -58,6 +58,7 @@ type
     validators*: Table[string, HashSet[ValidatorHandler]]
     observers: ref seq[PubSubObserver] # ref as in smart_ptr
     msgIdProvider*: MsgIdProvider      # Turn message into message id (not nil)
+    msgSeqno*: uint64
 
 method handleDisconnect*(p: PubSub, peer: PubSubPeer) {.base.} =
   ## handle peer disconnects

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -158,8 +158,9 @@ proc sendMsg*(p: PubSubPeer,
               peerId: PeerID,
               topic: string,
               data: seq[byte],
+              seqno: uint64,
               sign: bool): Future[void] {.gcsafe.} =
-  p.send(@[RPCMsg(messages: @[Message.init(p.peerInfo, data, topic, sign)])])
+  p.send(@[RPCMsg(messages: @[Message.init(p.peerInfo, data, topic, seqno, sign)])])
 
 proc sendGraft*(p: PubSubPeer, topics: seq[string]) {.async.} =
   try:

--- a/libp2p/protocols/pubsub/rpc/message.nim
+++ b/libp2p/protocols/pubsub/rpc/message.nim
@@ -57,22 +57,17 @@ proc verify*(m: Message, p: PeerInfo): bool =
   else:
     libp2p_pubsub_sig_verify_failure.inc()
 
-# cannot explicit init but:
-# Thread locals are initialized to binary zero (usually default(T)). (Araq)
-var tSeqno {.threadvar.}: uint64 
-
 proc init*(
     T: type Message,
     p: PeerInfo,
     data: seq[byte],
     topic: string,
+    seqno: uint64,
     sign: bool = true): Message {.gcsafe, raises: [CatchableError, Defect].} =
-  # peer is a ref obj
-  inc tSeqno
   result = Message(
     fromPeer: p.peerId,
     data: data,
-    seqno: @(tSeqno.toBytesBE), # unefficient, fine for now
+    seqno: @(seqno.toBytesBE), # unefficient, fine for now
     topicIDs: @[topic])
 
   if sign and p.publicKey.isSome:

--- a/libp2p/protocols/pubsub/rpc/message.nim
+++ b/libp2p/protocols/pubsub/rpc/message.nim
@@ -19,6 +19,7 @@ import messages, protobuf,
        ../../../peerinfo,
        ../../../crypto/crypto,
        ../../../protobuf/minprotobuf
+import stew/endians2
 
 logScope:
   topics = "pubsubmessage"
@@ -63,13 +64,12 @@ proc init*(
     topic: string,
     sign: bool = true): Message {.gcsafe, raises: [CatchableError, Defect].} =
   var seqno: seq[byte] = newSeq[byte](8)
-  if randomBytes(addr seqno[0], 8) <= 0:
-    raise (ref CatchableError)(msg: "Cannot get randomness for message")
-
+  # peer is a ref obj
+  inc p.seqno
   result = Message(
     fromPeer: p.peerId,
     data: data,
-    seqno: seqno,
+    seqno: @(p.seqno.toBytesBE), # unefficient, fine for now
     topicIDs: @[topic])
 
   if sign and p.publicKey.isSome:

--- a/libp2p/protocols/pubsub/rpc/message.nim
+++ b/libp2p/protocols/pubsub/rpc/message.nim
@@ -57,19 +57,22 @@ proc verify*(m: Message, p: PeerInfo): bool =
   else:
     libp2p_pubsub_sig_verify_failure.inc()
 
+# cannot explicit init but:
+# Thread locals are initialized to binary zero (usually default(T)). (Araq)
+var tSeqno {.threadvar.}: uint64 
+
 proc init*(
     T: type Message,
     p: PeerInfo,
     data: seq[byte],
     topic: string,
     sign: bool = true): Message {.gcsafe, raises: [CatchableError, Defect].} =
-  var seqno: seq[byte] = newSeq[byte](8)
   # peer is a ref obj
-  inc p.seqno
+  inc tSeqno
   result = Message(
     fromPeer: p.peerId,
     data: data,
-    seqno: @(p.seqno.toBytesBE), # unefficient, fine for now
+    seqno: @(tSeqno.toBytesBE), # unefficient, fine for now
     topicIDs: @[topic])
 
   if sign and p.publicKey.isSome:

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -225,12 +225,14 @@ suite "GossipSub internal":
         gossipSub.gossipsub[topic].incl(peerInfo.id)
 
       # generate messages
+      var seqno = 0'u64
       for i in 0..5:
         let conn = newBufferStream(noop)
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let msg = Message.init(peerInfo, ("HELLO" & $i).toBytes(), topic, false)
+        inc seqno
+        let msg = Message.init(peerInfo, ("HELLO" & $i).toBytes(), topic, seqno, false)
         gossipSub.mcache.put(gossipSub.msgIdProvider(msg), msg)
 
       check gossipSub.fanout[topic].len == 15
@@ -274,12 +276,14 @@ suite "GossipSub internal":
           gossipSub.gossipsub[topic].incl(peerInfo.id)
 
       # generate messages
+      var seqno = 0'u64
       for i in 0..5:
         let conn = newBufferStream(noop)
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let msg = Message.init(peerInfo, ("HELLO" & $i).toBytes(), topic, false)
+        inc seqno
+        let msg = Message.init(peerInfo, ("HELLO" & $i).toBytes(), topic, seqno, false)
         gossipSub.mcache.put(gossipSub.msgIdProvider(msg), msg)
 
       let peers = gossipSub.getGossipPeers()
@@ -316,12 +320,14 @@ suite "GossipSub internal":
           gossipSub.gossipsub[topic].incl(peerInfo.id)
 
       # generate messages
+      var seqno = 0'u64
       for i in 0..5:
         let conn = newBufferStream(noop)
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let msg = Message.init(peerInfo, ("HELLO" & $i).toBytes(), topic, false)
+        inc seqno
+        let msg = Message.init(peerInfo, ("HELLO" & $i).toBytes(), topic, seqno, false)
         gossipSub.mcache.put(gossipSub.msgIdProvider(msg), msg)
 
       let peers = gossipSub.getGossipPeers()
@@ -358,12 +364,14 @@ suite "GossipSub internal":
           gossipSub.fanout[topic].incl(peerInfo.id)
 
       # generate messages
+      var seqno = 0'u64
       for i in 0..5:
         let conn = newBufferStream(noop)
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let msg = Message.init(peerInfo, ("bar" & $i).toBytes(), topic, false)
+        inc seqno
+        let msg = Message.init(peerInfo, ("bar" & $i).toBytes(), topic, seqno, false)
         gossipSub.mcache.put(gossipSub.msgIdProvider(msg), msg)
 
       let peers = gossipSub.getGossipPeers()

--- a/tests/pubsub/testmessage.nim
+++ b/tests/pubsub/testmessage.nim
@@ -11,8 +11,9 @@ let rng = newRng()
 
 suite "Message":
   test "signature":
+    var seqno = 11'u64
     let
       peer = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get())
-      msg = Message.init(peer, @[], "topic", sign = true)
+      msg = Message.init(peer, @[], "topic", seqno, sign = true)
 
     check verify(msg, peer)


### PR DESCRIPTION
Quoting @oskarth 

> Am I reading it right that we currently don't have linearly increasing seqno in PubSub? https://github.com/status-im/nim-libp2p/blob/master/libp2p/protocols/pubsub/rpc/message.nim#L65-L66 It seems like it is picking a random set of bytes here. This seems different from https://github.com/libp2p/specs/blob/master/pubsub/README.md#the-message

Fixes