### PR TITLE
clean up mesh handling logic

### DIFF
--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -163,14 +163,24 @@ proc sendMsg*(p: PubSubPeer,
   p.send(@[RPCMsg(messages: @[Message.init(p.peerInfo, data, topic, sign)])])
 
 proc sendGraft*(p: PubSubPeer, topics: seq[string]) {.async.} =
-  for topic in topics:
-    trace "sending graft msg to peer", peer = p.id, topicID = topic
-    await p.send(@[RPCMsg(control: some(ControlMessage(graft: @[ControlGraft(topicID: topic)])))])
+  try:
+    for topic in topics:
+      trace "sending graft msg to peer", peer = p.id, topicID = topic
+      await p.send(@[RPCMsg(control: some(ControlMessage(graft: @[ControlGraft(topicID: topic)])))])
+  except CancelledError as exc:
+    raise exc
+  except CatchableError as exc:
+    trace "Could not send graft", msg = exc.msg
 
 proc sendPrune*(p: PubSubPeer, topics: seq[string]) {.async.} =
-  for topic in topics:
-    trace "sending prune msg to peer", peer = p.id, topicID = topic
-    await p.send(@[RPCMsg(control: some(ControlMessage(prune: @[ControlPrune(topicID: topic)])))])
+  try:
+    for topic in topics:
+      trace "sending prune msg to peer", peer = p.id, topicID = topic
+      await p.send(@[RPCMsg(control: some(ControlMessage(prune: @[ControlPrune(topicID: topic)])))])
+  except CancelledError as exc:
+    raise exc
+  except CatchableError as exc:
+    trace "Could not send prune", msg = exc.msg
 
 proc `$`*(p: PubSubPeer): string =
   p.id

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -137,7 +137,7 @@ suite "GossipSub internal":
 
       check gossipSub.fanout[topic].len == GossipSubD
 
-      await gossipSub.dropFanoutPeers()
+      gossipSub.dropFanoutPeers()
       check topic notin gossipSub.fanout
 
       await allFuturesThrowing(conns.mapIt(it.close()))
@@ -176,7 +176,7 @@ suite "GossipSub internal":
       check gossipSub.fanout[topic1].len == GossipSubD
       check gossipSub.fanout[topic2].len == GossipSubD
 
-      await gossipSub.dropFanoutPeers()
+      gossipSub.dropFanoutPeers()
       check topic1 notin gossipSub.fanout
       check topic2 in gossipSub.fanout
 


### PR DESCRIPTION
* gossipsub is a function of subscription messages only
* graft/prune work with mesh, get filled up from gossipsub
* fix race conditions with await
* fix exception unsafety when grafting/pruning
* fix allowing up to DHi peers in mesh on incoming graft
* fix metrics in several places