### PR TITLE
PubSubPeer tables refactor

### DIFF
--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -26,7 +26,7 @@ const FloodSubCodec* = "/floodsub/1.0.0"
 
 type
   FloodSub* = ref object of PubSub
-    floodsub*: Table[string, HashSet[string]] # topic to remote peer map
+    floodsub*: PeerTable # topic to remote peer map
     seen*: TimedCache[string]                 # list of messages forwarded to peers
 
 method subscribeTopic*(f: FloodSub,
@@ -35,23 +35,28 @@ method subscribeTopic*(f: FloodSub,
                        peerId: string) {.gcsafe, async.} =
   await procCall PubSub(f).subscribeTopic(topic, subscribe, peerId)
 
+  let peer = f.peers.getOrDefault(peerId)
+  if peer == nil:
+    debug "subscribeTopic on a nil peer!"
+    return
+
   if topic notin f.floodsub:
-    f.floodsub[topic] = initHashSet[string]()
+    f.floodsub[topic] = initHashSet[PubSubPeer]()
 
   if subscribe:
-    trace "adding subscription for topic", peer = peerId, name = topic
+    trace "adding subscription for topic", peer = peer.id, name = topic
     # subscribe the peer to the topic
-    f.floodsub[topic].incl(peerId)
+    f.floodsub[topic].incl(peer)
   else:
-    trace "removing subscription for topic", peer = peerId, name = topic
+    trace "removing subscription for topic", peer = peer.id, name = topic
     # unsubscribe the peer from the topic
-    f.floodsub[topic].excl(peerId)
+    f.floodsub[topic].excl(peer)
 
 method handleDisconnect*(f: FloodSub, peer: PubSubPeer) =
   ## handle peer disconnects
   for t in toSeq(f.floodsub.keys):
     if t in f.floodsub:
-      f.floodsub[t].excl(peer.id)
+      f.floodsub[t].excl(peer)
 
   procCall PubSub(f).handleDisconnect(peer)
 
@@ -62,7 +67,7 @@ method rpcHandler*(f: FloodSub,
 
   for m in rpcMsgs:                                  # for all RPC messages
     if m.messages.len > 0:                           # if there are any messages
-      var toSendPeers: HashSet[string] = initHashSet[string]()
+      var toSendPeers = initHashSet[PubSubPeer]()
       for msg in m.messages:                         # for every message
         let msgId = f.msgIdProvider(msg)
         logScope: msgId
@@ -158,6 +163,6 @@ method initPubSub*(f: FloodSub) =
   procCall PubSub(f).initPubSub()
   f.peers = initTable[string, PubSubPeer]()
   f.topics = initTable[string, Topic]()
-  f.floodsub = initTable[string, HashSet[string]]()
+  f.floodsub = initTable[string, HashSet[PubSubPeer]]()
   f.seen = newTimedCache[string](2.minutes)
   f.init()

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -43,9 +43,34 @@ type
 
   RPCHandler* = proc(peer: PubSubPeer, msg: seq[RPCMsg]): Future[void] {.gcsafe.}
 
-proc hash*(p: PubSubPeer): Hash = 
+func hash*(p: PubSubPeer): Hash = 
   # int is either 32/64, so intptr basically, pubsubpeer is a ref
-  cast[int](p).hash
+  cast[pointer](p).hash
+
+func `==`*(a, b: PubSubPeer): bool =
+  # override equiality to support both nil and peerInfo comparisons
+  # this in the future will allow us to recycle refs
+  let
+    aptr = cast[pointer](a)
+    bptr = cast[pointer](b)
+  if aptr == nil:
+    if bptr == nil:
+      true
+    else:
+      false
+  elif bptr == nil:
+    false
+  else:
+    if a.peerInfo == nil:
+      if b.peerInfo == nil:
+        true
+      else:
+        false
+    else:
+      if b.peerInfo == nil:
+        false
+      else:
+        a.peerInfo == b.peerInfo
 
 proc id*(p: PubSubPeer): string = p.peerInfo.id
 

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -43,6 +43,10 @@ type
 
   RPCHandler* = proc(peer: PubSubPeer, msg: seq[RPCMsg]): Future[void] {.gcsafe.}
 
+proc hash*(p: PubSubPeer): Hash = 
+  # int is either 32/64, so intptr basically, pubsubpeer is a ref
+  cast[int](p).hash
+
 proc id*(p: PubSubPeer): string = p.peerInfo.id
 
 proc connected*(p: PubSubPeer): bool =

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -70,7 +70,7 @@ func `==`*(a, b: PubSubPeer): bool =
       if b.peerInfo == nil:
         false
       else:
-        a.peerInfo == b.peerInfo
+        a.peerInfo.id == b.peerInfo.id
 
 proc id*(p: PubSubPeer): string = p.peerInfo.id
 

--- a/tests/pubsub/testfloodsub.nim
+++ b/tests/pubsub/testfloodsub.nim
@@ -29,7 +29,7 @@ proc waitSub(sender, receiver: auto; key: string) {.async, gcsafe.} =
   var ceil = 15
   let fsub = cast[FloodSub](sender.pubSub.get())
   while not fsub.floodsub.hasKey(key) or
-        not fsub.floodsub[key].contains(receiver.peerInfo.id):
+        not fsub.floodsub.hasPeerID(key, receiver.peerInfo.id):
     await sleepAsync(100.millis)
     dec ceil
     doAssert(ceil > 0, "waitSub timeout!")

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -242,8 +242,8 @@ suite "GossipSub internal":
       let peers = gossipSub.getGossipPeers()
       check peers.len == GossipSubD
       for p in peers.keys:
-        check gossipSub.fanout.hasPeerID(topic, p)
-        check gossipSub.mesh.hasPeerID(topic, p)
+        check not gossipSub.fanout.hasPeerID(topic, p)
+        check not gossipSub.mesh.hasPeerID(topic, p)
 
       await allFuturesThrowing(conns.mapIt(it.close()))
 

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -32,11 +32,11 @@ proc waitSub(sender, receiver: auto; key: string) {.async, gcsafe.} =
   var ceil = 15
   let fsub = GossipSub(sender.pubSub.get())
   while (not fsub.gossipsub.hasKey(key) or
-         not fsub.gossipsub[key].contains(receiver.peerInfo.id)) and
+         not fsub.gossipsub.hasPeerID(key, receiver.peerInfo.id)) and
         (not fsub.mesh.hasKey(key) or
-         not fsub.mesh[key].contains(receiver.peerInfo.id)) and
+         not fsub.mesh.hasPeerID(key, receiver.peerInfo.id)) and
         (not fsub.fanout.hasKey(key) or
-         not fsub.fanout[key].contains(receiver.peerInfo.id)):
+         not fsub.fanout.hasPeerID(key , receiver.peerInfo.id)):
     trace "waitSub sleeping..."
     await sleepAsync(1.seconds)
     dec ceil
@@ -192,7 +192,7 @@ suite "GossipSub":
       check:
         "foobar" in gossip2.topics
         "foobar" in gossip1.gossipsub
-        gossip2.peerInfo.id in gossip1.gossipsub["foobar"]
+        gossip1.gossipsub.hasPeerID("foobar", gossip2.peerInfo.id)
 
       await allFuturesThrowing(nodes.mapIt(it.stop()))
       await allFuturesThrowing(awaitters)
@@ -236,11 +236,11 @@ suite "GossipSub":
         "foobar" in gossip1.gossipsub
         "foobar" in gossip2.gossipsub
 
-        gossip2.peerInfo.id in gossip1.gossipsub["foobar"] or
-        gossip2.peerInfo.id in gossip1.mesh["foobar"]
+        gossip1.gossipsub.hasPeerID("foobar", gossip2.peerInfo.id) or
+        gossip1.mesh.hasPeerID("foobar", gossip2.peerInfo.id)
 
-        gossip1.peerInfo.id in gossip2.gossipsub["foobar"] or
-        gossip1.peerInfo.id in gossip2.mesh["foobar"]
+        gossip2.gossipsub.hasPeerID("foobar", gossip1.peerInfo.id) or
+        gossip2.mesh.hasPeerID("foobar", gossip1.peerInfo.id)
 
       await allFuturesThrowing(nodes.mapIt(it.stop()))
       await allFuturesThrowing(awaitters)


### PR DESCRIPTION
Remove the excessive use of `string` and `id` in favor of straight using `PubSubPeer` `ref` type.
Removes the need to resolve peers from `g.peers`