### PR TITLE
`msg` is a reserved property name in Chronicles

### DIFF
--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -132,7 +132,7 @@ proc send*(
   timeout: Duration = DefaultSendTimeout) {.async.} =
   logScope:
     peer = p.id
-    msg = shortLog(msg)
+    rpcMsg = shortLog(msg)
 
   trace "sending msg to peer"
 
@@ -158,7 +158,7 @@ proc send*(
   proc sendToRemote() {.async.} =
     logScope:
       peer = p.id
-      msg = shortLog(msg)
+      rpcMsg = shortLog(msg)
 
     trace "about to send message"
 


### PR DESCRIPTION
Every Chronicles log record has an existing `msg` property matching
the static string supplied in the log statement. Thus, it's currently
not possible to use `msg` as the name of a user property:

https://github.com/status-im/nim-chronicles/issues/86