### PR TITLE
Rework pubsub

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -121,7 +121,7 @@ proc onClose(c: ConnManager, conn: Connection) {.async.} =
   ## triggers the connections resource cleanup
   ##
 
-  await conn.closeEvent.wait()
+  await conn.join()
   trace "triggering connection cleanup"
   await c.cleanupConn(conn)
 

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -96,7 +96,7 @@ proc newStreamInternal*(m: Mplex,
 proc cleanupChann(m: Mplex, chann: LPChannel) {.async, inline.} =
   ## remove the local channel from the internal tables
   ##
-  await chann.closeEvent.wait()
+  await chann.join()
   if not isNil(chann):
     m.getChannelList(chann.initiator).del(chann.id)
     trace "cleaned up channel", id = chann.id

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -101,7 +101,7 @@ method rpcHandler*(f: FloodSub,
                   trace "exception in message handler", exc = exc.msg
 
         # forward the message to all peers interested in it
-        let published = await f.publishHelper(toSendPeers, m.messages, DefaultSendTimeout)
+        let published = await f.broadcast(toSendPeers, RPCMsg(messages: m.messages), DefaultSendTimeout)
 
         trace "forwared message to peers", peers = published
 
@@ -137,7 +137,7 @@ method publish*(f: FloodSub,
   let msg = Message.init(f.peerInfo, data, topic, f.msgSeqno, f.sign)
 
   # start the future but do not wait yet
-  let published = await f.publishHelper(f.floodsub.getOrDefault(topic), @[msg], timeout)
+  let published = await f.broadcast(f.floodsub.getOrDefault(topic), RPCMsg(messages: @[msg]), timeout)
 
   when defined(libp2p_expensive_metrics):
     libp2p_pubsub_messages_published.inc(labelValues = [topic])

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -101,7 +101,10 @@ method rpcHandler*(f: FloodSub,
                   trace "exception in message handler", exc = exc.msg
 
         # forward the message to all peers interested in it
-        let published = await f.broadcast(toSendPeers, RPCMsg(messages: m.messages), DefaultSendTimeout)
+        let published = await f.broadcast(
+          toSeq(toSendPeers),
+          RPCMsg(messages: m.messages),
+          DefaultSendTimeout)
 
         trace "forwared message to peers", peers = published
 
@@ -137,7 +140,10 @@ method publish*(f: FloodSub,
   let msg = Message.init(f.peerInfo, data, topic, f.msgSeqno, f.sign)
 
   # start the future but do not wait yet
-  let published = await f.broadcast(f.floodsub.getOrDefault(topic), RPCMsg(messages: @[msg]), timeout)
+  let published = await f.broadcast(
+    toSeq(f.floodsub.getOrDefault(topic)),
+    RPCMsg(messages: @[msg]),
+    timeout)
 
   when defined(libp2p_expensive_metrics):
     libp2p_pubsub_messages_published.inc(labelValues = [topic])

--- a/libp2p/protocols/pubsub/peertable.nim
+++ b/libp2p/protocols/pubsub/peertable.nim
@@ -16,7 +16,7 @@ type
 proc hasPeerID*(t: PeerTable, topic: string, peerId: PeerID): bool =
   let peers = toSeq(t.getOrDefault(topic))
   peers.any do (peer: PubSubPeer) -> bool:
-    peerId == peerId
+    peer.peerId == peerId
 
 func addPeer*(table: var PeerTable, topic: string, peer: PubSubPeer): bool =
   # returns true if the peer was added,

--- a/libp2p/protocols/pubsub/peertable.nim
+++ b/libp2p/protocols/pubsub/peertable.nim
@@ -16,7 +16,7 @@ type
 proc hasPeerID*(t: PeerTable, topic: string, peerId: PeerID): bool =
   let peers = toSeq(t.getOrDefault(topic))
   peers.any do (peer: PubSubPeer) -> bool:
-    peer.peer == peerId
+    peerId == peerId
 
 func addPeer*(table: var PeerTable, topic: string, peer: PubSubPeer): bool =
   # returns true if the peer was added,

--- a/libp2p/protocols/pubsub/peertable.nim
+++ b/libp2p/protocols/pubsub/peertable.nim
@@ -13,10 +13,10 @@ import pubsubpeer, ../../peerid
 type
   PeerTable* = Table[string, HashSet[PubSubPeer]] # topic string to peer map
 
-proc hasPeerID*(t: PeerTable, topic, peerId: string): bool =
+proc hasPeerID*(t: PeerTable, topic: string, peerId: PeerID): bool =
   let peers = toSeq(t.getOrDefault(topic))
   peers.any do (peer: PubSubPeer) -> bool:
-    peer.id == peerId
+    peer.peer == peerId
 
 func addPeer*(table: var PeerTable, topic: string, peer: PubSubPeer): bool =
   # returns true if the peer was added,

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -109,8 +109,8 @@ proc sendSubs*(p: PubSub,
                topics: seq[string],
                subscribe: bool) {.async.} =
   ## send subscriptions to remote peer
-  discard await p.broadcast(
-    @[peer],
+  await p.send(
+    peer,
     RPCMsg(
       subscriptions: topics.mapIt(SubOpts(subscribe: subscribe, topic: it))),
     DefaultSendTimeout)

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -59,7 +59,7 @@ proc id*(p: PubSubPeer): string =
   p.peerId.pretty
 
 proc connected*(p: PubSubPeer): bool =
-  not(isNil(p.sendConn)) and not
+  not p.sendConn.isNil and not
     (p.sendConn.closed or p.sendConn.atEof)
 
 proc recvObservers(p: PubSubPeer, msg: var RPCMsg) =

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -190,39 +190,6 @@ proc send*(
 
     raise exc
 
-proc sendSubOpts*(p: PubSubPeer, topics: seq[string], subscribe: bool) {.async.} =
-  trace "sending subscriptions", peer = p.id, subscribe, topicIDs = topics
-
-  try:
-    await p.send(RPCMsg(
-      subscriptions: topics.mapIt(SubOpts(subscribe: subscribe, topic: it))))
-  except CancelledError as exc:
-    raise exc
-  except CatchableError as exc:
-    trace "exception sending subscriptions", exc = exc.msg
-
-proc sendGraft*(p: PubSubPeer, topics: seq[string]) {.async.} =
-  trace "sending graft to peer", peer = p.id, topicIDs = topics
-
-  try:
-    await p.send(RPCMsg(control: some(
-      ControlMessage(graft: topics.mapIt(ControlGraft(topicID: it))))))
-  except CancelledError as exc:
-    raise exc
-  except CatchableError as exc:
-    trace "exception sending grafts", exc = exc.msg
-
-proc sendPrune*(p: PubSubPeer, topics: seq[string]) {.async.} =
-  trace "sending prune to peer", peer = p.id, topicIDs = topics
-
-  try:
-    await p.send(RPCMsg(control: some(
-      ControlMessage(prune: topics.mapIt(ControlPrune(topicID: it))))))
-  except CancelledError as exc:
-    raise exc
-  except CatchableError as exc:
-    trace "exception sending prunes", exc = exc.msg
-
 proc `$`*(p: PubSubPeer): string =
   p.id
 

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -127,6 +127,8 @@ proc send*(
   msg: RPCMsg,
   timeout: Duration = DefaultSendTimeout) {.async.} =
 
+  doAssert(not isNil(p), "pubsubpeer nil!")
+
   logScope:
     peer = p.id
     rpcMsg = shortLog(msg)

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -62,7 +62,7 @@ proc handleConn*(s: Secure,
                  initiator: bool): Future[Connection] {.async, gcsafe.} =
   var sconn = await s.handshake(conn, initiator)
   if not isNil(sconn):
-    conn.closeEvent.wait()
+    conn.join()
       .addCallback do(udata: pointer = nil):
         asyncCheck sconn.close()
 

--- a/libp2p/standard_setup.nim
+++ b/libp2p/standard_setup.nim
@@ -1,16 +1,9 @@
-# compile time options here
-const
-  libp2p_pubsub_sign {.booldefine.} = true
-  libp2p_pubsub_verify {.booldefine.} = true
-
 import
   options, tables, chronos, bearssl,
   switch, peerid, peerinfo, stream/connection, multiaddress,
   crypto/crypto, transports/[transport, tcptransport],
   muxers/[muxer, mplex/mplex, mplex/types],
-  protocols/[identify, secure/secure],
-  protocols/pubsub/[pubsub, gossipsub, floodsub],
-  protocols/pubsub/rpc/message
+  protocols/[identify, secure/secure]
 
 import
   protocols/secure/noise,
@@ -26,17 +19,12 @@ type
 
 proc newStandardSwitch*(privKey = none(PrivateKey),
                         address = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet(),
-                        triggerSelf = false,
-                        gossip = false,
                         secureManagers: openarray[SecureProtocol] = [
                             # array cos order matters
                             SecureProtocol.Secio,
                             SecureProtocol.Noise,
                           ],
-                        verifySignature = libp2p_pubsub_verify,
-                        sign = libp2p_pubsub_sign,
                         transportFlags: set[ServerFlags] = {},
-                        msgIdProvider: MsgIdProvider = defaultMsgIdProvider,
                         rng = newRng(),
                         inTimeout: Duration = 5.minutes,
                         outTimeout: Duration = 5.minutes): Switch =
@@ -66,25 +54,11 @@ proc newStandardSwitch*(privKey = none(PrivateKey),
     of SecureProtocol.Secio:
       secureManagerInstances &= newSecio(rng, seckey).Secure
 
-  let pubSub = if gossip:
-                  newPubSub(GossipSub,
-                            peerInfo = peerInfo,
-                            triggerSelf = triggerSelf,
-                            verifySignature = verifySignature,
-                            sign = sign,
-                            msgIdProvider = msgIdProvider).PubSub
-               else:
-                  newPubSub(FloodSub,
-                            peerInfo = peerInfo,
-                            triggerSelf = triggerSelf,
-                            verifySignature = verifySignature,
-                            sign = sign,
-                            msgIdProvider = msgIdProvider).PubSub
-
-  newSwitch(
+  let switch = newSwitch(
     peerInfo,
     transports,
     identify,
     muxers,
-    secureManagers = secureManagerInstances,
-    pubSub = some(pubSub))
+    secureManagers = secureManagerInstances)
+
+  return switch

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -45,7 +45,7 @@ template withExceptions(body: untyped) =
     raise exc
   except TransportIncompleteError:
     # for all intents and purposes this is an EOF
-    raise newLPStreamEOFError()
+    raise newLPStreamIncompleteError()
   except TransportLimitError:
     raise newLPStreamLimitError()
   except TransportUseClosedError:

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -115,8 +115,12 @@ proc readExactly*(s: LPStream,
     read += await s.readOnce(addr pbuffer[read], nbytes - read)
 
   if read < nbytes:
-    trace "incomplete data received", read
-    raise newLPStreamIncompleteError()
+    if s.atEof:
+      trace "couldn't read all bytes, stream EOF", expected = nbytes, read
+      raise newLPStreamEOFError()
+    else:
+      trace "couldn't read all bytes, incomplete data", expected = nbytes, read
+      raise newLPStreamIncompleteError()
 
 proc readLine*(s: LPStream,
                limit = 0,

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -30,6 +30,9 @@ import stream/connection,
        peerid,
        errors
 
+chronicles.formatIt(PeerInfo): $it
+chronicles.formatIt(PeerID): $it
+
 logScope:
   topics = "switch"
 

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -268,7 +268,8 @@ proc upgradeIncoming(s: Switch, conn: Connection) {.async, gcsafe.} =
 proc internalConnect(s: Switch,
                      peerId: PeerID,
                      addrs: seq[MultiAddress]): Future[Connection] {.async.} =
-  logScope: peer = peerId
+  logScope:
+    peer = peerId
 
   if s.peerInfo.peerId == peerId:
     raise newException(CatchableError, "can't dial self!")
@@ -326,12 +327,12 @@ proc internalConnect(s: Switch,
                 libp2p_failed_upgrade.inc()
               raise exc
 
-          doAssert not isNil(upgraded), "checked in upgradeOutgoing"
+          doAssert not isNil(upgraded), "connection died after upgradeOutgoing"
 
           s.connManager.storeOutgoing(upgraded)
           conn = upgraded
           trace "dial successful",
-            oid = $conn.oid,
+            oid = $upgraded.oid,
             peerInfo = shortLog(upgraded.peerInfo)
           break
   finally:

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -4,6 +4,7 @@ include ../../libp2p/protocols/pubsub/gossipsub
 
 import unittest, bearssl
 import stew/byteutils
+import ../../libp2p/standard_setup
 import ../../libp2p/errors
 import ../../libp2p/crypto/crypto
 import ../../libp2p/stream/bufferstream
@@ -26,7 +27,7 @@ suite "GossipSub internal":
 
   test "`rebalanceMesh` Degree Lo":
     proc testRun(): Future[bool] {.async.} =
-      let gossipSub = newPubSub(TestGossipSub, randomPeerInfo())
+      let gossipSub = TestGossipSub.init(newStandardSwitch())
 
       let topic = "foobar"
       gossipSub.mesh[topic] = initHashSet[PubSubPeer]()
@@ -38,9 +39,8 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo, GossipSubCodec)
-        peer.conn = conn
-        gossipSub.peers[peerInfo.id] = peer
+        let peer = newPubSubPeer(peerInfo.peerId, gossipSub.switch, GossipSubCodec)
+        gossipSub.peers[peerInfo.peerId] = peer
         gossipSub.mesh[topic].incl(peer)
 
       check gossipSub.peers.len == 15
@@ -48,7 +48,7 @@ suite "GossipSub internal":
       check gossipSub.mesh[topic].len == GossipSubD
 
       await allFuturesThrowing(conns.mapIt(it.close()))
-
+      await gossipSub.switch.stop()
       result = true
 
     check:
@@ -56,7 +56,7 @@ suite "GossipSub internal":
 
   test "`rebalanceMesh` Degree Hi":
     proc testRun(): Future[bool] {.async.} =
-      let gossipSub = newPubSub(TestGossipSub, randomPeerInfo())
+      let gossipSub = TestGossipSub.init(newStandardSwitch())
 
       let topic = "foobar"
       gossipSub.mesh[topic] = initHashSet[PubSubPeer]()
@@ -69,9 +69,8 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get())
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo, GossipSubCodec)
-        peer.conn = conn
-        gossipSub.peers[peerInfo.id] = peer
+        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
+        gossipSub.peers[peerInfo.peerId] = peer
         gossipSub.mesh[topic].incl(peer)
 
       check gossipSub.mesh[topic].len == 15
@@ -79,6 +78,7 @@ suite "GossipSub internal":
       check gossipSub.mesh[topic].len == GossipSubD
 
       await allFuturesThrowing(conns.mapIt(it.close()))
+      await gossipSub.switch.stop()
 
       result = true
 
@@ -87,7 +87,7 @@ suite "GossipSub internal":
 
   test "`replenishFanout` Degree Lo":
     proc testRun(): Future[bool] {.async.} =
-      let gossipSub = newPubSub(TestGossipSub, randomPeerInfo())
+      let gossipSub = TestGossipSub.init(newStandardSwitch())
 
       proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
         discard
@@ -101,7 +101,7 @@ suite "GossipSub internal":
         conns &= conn
         var peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo, GossipSubCodec)
+        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
         peer.handler = handler
         gossipSub.gossipsub[topic].incl(peer)
 
@@ -110,6 +110,7 @@ suite "GossipSub internal":
       check gossipSub.fanout[topic].len == GossipSubD
 
       await allFuturesThrowing(conns.mapIt(it.close()))
+      await gossipSub.switch.stop()
 
       result = true
 
@@ -118,7 +119,7 @@ suite "GossipSub internal":
 
   test "`dropFanoutPeers` drop expired fanout topics":
     proc testRun(): Future[bool] {.async.} =
-      let gossipSub = newPubSub(TestGossipSub, randomPeerInfo())
+      let gossipSub = TestGossipSub.init(newStandardSwitch())
 
       proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
         discard
@@ -134,7 +135,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get())
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo, GossipSubCodec)
+        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
         peer.handler = handler
         gossipSub.fanout[topic].incl(peer)
 
@@ -144,6 +145,7 @@ suite "GossipSub internal":
       check topic notin gossipSub.fanout
 
       await allFuturesThrowing(conns.mapIt(it.close()))
+      await gossipSub.switch.stop()
 
       result = true
 
@@ -152,7 +154,7 @@ suite "GossipSub internal":
 
   test "`dropFanoutPeers` leave unexpired fanout topics":
     proc testRun(): Future[bool] {.async.} =
-      let gossipSub = newPubSub(TestGossipSub, randomPeerInfo())
+      let gossipSub = TestGossipSub.init(newStandardSwitch())
 
       proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
         discard
@@ -171,7 +173,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo, GossipSubCodec)
+        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
         peer.handler = handler
         gossipSub.fanout[topic1].incl(peer)
         gossipSub.fanout[topic2].incl(peer)
@@ -184,6 +186,7 @@ suite "GossipSub internal":
       check topic2 in gossipSub.fanout
 
       await allFuturesThrowing(conns.mapIt(it.close()))
+      await gossipSub.switch.stop()
 
       result = true
 
@@ -192,7 +195,7 @@ suite "GossipSub internal":
 
   test "`getGossipPeers` - should gather up to degree D non intersecting peers":
     proc testRun(): Future[bool] {.async.} =
-      let gossipSub = newPubSub(TestGossipSub, randomPeerInfo())
+      let gossipSub = TestGossipSub.init(newStandardSwitch())
 
       proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
         discard
@@ -209,7 +212,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo, GossipSubCodec)
+        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
         peer.handler = handler
         if i mod 2 == 0:
           gossipSub.fanout[topic].incl(peer)
@@ -222,7 +225,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo, GossipSubCodec)
+        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
         peer.handler = handler
         gossipSub.gossipsub[topic].incl(peer)
 
@@ -244,10 +247,11 @@ suite "GossipSub internal":
       let peers = gossipSub.getGossipPeers()
       check peers.len == GossipSubD
       for p in peers.keys:
-        check not gossipSub.fanout.hasPeerID(topic, p)
-        check not gossipSub.mesh.hasPeerID(topic, p)
+        check not gossipSub.fanout.hasPeerID(topic, p.peer)
+        check not gossipSub.mesh.hasPeerID(topic, p.peer)
 
       await allFuturesThrowing(conns.mapIt(it.close()))
+      await gossipSub.switch.stop()
 
       result = true
 
@@ -256,7 +260,7 @@ suite "GossipSub internal":
 
   test "`getGossipPeers` - should not crash on missing topics in mesh":
     proc testRun(): Future[bool] {.async.} =
-      let gossipSub = newPubSub(TestGossipSub, randomPeerInfo())
+      let gossipSub = TestGossipSub.init(newStandardSwitch())
 
       proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
         discard
@@ -270,7 +274,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo, GossipSubCodec)
+        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
         peer.handler = handler
         if i mod 2 == 0:
           gossipSub.fanout[topic].incl(peer)
@@ -292,6 +296,7 @@ suite "GossipSub internal":
       check peers.len == GossipSubD
 
       await allFuturesThrowing(conns.mapIt(it.close()))
+      await gossipSub.switch.stop()
 
       result = true
 
@@ -300,7 +305,7 @@ suite "GossipSub internal":
 
   test "`getGossipPeers` - should not crash on missing topics in fanout":
     proc testRun(): Future[bool] {.async.} =
-      let gossipSub = newPubSub(TestGossipSub, randomPeerInfo())
+      let gossipSub = TestGossipSub.init(newStandardSwitch())
 
       proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
         discard
@@ -314,7 +319,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo, GossipSubCodec)
+        let peer = newPubSubPeer(peerInfo.peerId, gossipSub.switch, GossipSubCodec)
         peer.handler = handler
         if i mod 2 == 0:
           gossipSub.mesh[topic].incl(peer)
@@ -336,6 +341,7 @@ suite "GossipSub internal":
       check peers.len == GossipSubD
 
       await allFuturesThrowing(conns.mapIt(it.close()))
+      await gossipSub.switch.stop()
 
       result = true
 
@@ -344,7 +350,7 @@ suite "GossipSub internal":
 
   test "`getGossipPeers` - should not crash on missing topics in gossip":
     proc testRun(): Future[bool] {.async.} =
-      let gossipSub = newPubSub(TestGossipSub, randomPeerInfo())
+      let gossipSub = TestGossipSub.init(newStandardSwitch())
 
       proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
         discard
@@ -358,7 +364,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo, GossipSubCodec)
+        let peer = newPubSubPeer(peerInfo.peerId, gossipSub.switch, GossipSubCodec)
         peer.handler = handler
         if i mod 2 == 0:
           gossipSub.mesh[topic].incl(peer)
@@ -380,6 +386,7 @@ suite "GossipSub internal":
       check peers.len == 0
 
       await allFuturesThrowing(conns.mapIt(it.close()))
+      await gossipSub.switch.stop()
 
       result = true
 

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -247,8 +247,8 @@ suite "GossipSub internal":
       let peers = gossipSub.getGossipPeers()
       check peers.len == GossipSubD
       for p in peers.keys:
-        check not gossipSub.fanout.hasPeerID(topic, p.peer)
-        check not gossipSub.mesh.hasPeerID(topic, p.peer)
+        check not gossipSub.fanout.hasPeerID(topic, p.peerId)
+        check not gossipSub.mesh.hasPeerID(topic, p.peerId)
 
       await allFuturesThrowing(conns.mapIt(it.close()))
       await gossipSub.switch.stop()

--- a/tests/pubsub/testmessage.nim
+++ b/tests/pubsub/testmessage.nim
@@ -16,4 +16,4 @@ suite "Message":
       peer = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get())
       msg = Message.init(peer, @[], "topic", seqno, sign = true)
 
-    check verify(msg, peer)
+    check verify(msg, peer.peerId)

--- a/tests/pubsub/utils.nim
+++ b/tests/pubsub/utils.nim
@@ -1,22 +1,61 @@
+# compile time options here
+const
+  libp2p_pubsub_sign {.booldefine.} = true
+  libp2p_pubsub_verify {.booldefine.} = true
+
 import random
 import chronos
-import ../../libp2p/standard_setup
+import ../../libp2p/[standard_setup,
+                     protocols/pubsub/pubsub,
+                     protocols/pubsub/floodsub,
+                     protocols/pubsub/gossipsub,
+                     protocols/secure/secure]
+
 export standard_setup
 
 randomize()
 
-proc generateNodes*(num: Natural, gossip: bool = false): seq[Switch] =
-  for i in 0..<num:
-    result.add(newStandardSwitch(gossip = gossip))
+proc generateNodes*(
+  num: Natural,
+  secureManagers: openarray[SecureProtocol] = [
+    # array cos order matters
+    SecureProtocol.Secio,
+    SecureProtocol.Noise,
+  ],
+  msgIdProvider: MsgIdProvider = nil,
+  gossip: bool = false,
+  triggerSelf: bool = false,
+  verifySignature: bool = libp2p_pubsub_verify,
+  sign: bool = libp2p_pubsub_sign): seq[PubSub] =
 
-proc subscribeNodes*(nodes: seq[Switch]): Future[seq[Future[void]]] {.async.} =
+  for i in 0..<num:
+    let switch = newStandardSwitch(secureManagers = secureManagers)
+    let pubsub = if gossip:
+      GossipSub.init(
+        switch = switch,
+        triggerSelf = triggerSelf,
+        verifySignature = verifySignature,
+        sign = sign,
+        msgIdProvider = msgIdProvider).PubSub
+    else:
+      FloodSub.init(
+        switch = switch,
+        triggerSelf = triggerSelf,
+        verifySignature = verifySignature,
+        sign = sign,
+        msgIdProvider = msgIdProvider).PubSub
+
+    switch.mount(pubsub)
+    result.add(pubsub)
+
+proc subscribeNodes*(nodes: seq[PubSub]) {.async.} =
   for dialer in nodes:
     for node in nodes:
-      if dialer.peerInfo.peerId != node.peerInfo.peerId:
-        await dialer.connect(node.peerInfo)
-        result.add(dialer.subscribePeer(node.peerInfo))
+      if dialer.switch.peerInfo.peerId != node.switch.peerInfo.peerId:
+        await dialer.switch.connect(node.peerInfo.peerId, node.peerInfo.addrs)
+        dialer.subscribePeer(node.peerInfo.peerId)
 
-proc subscribeSparseNodes*(nodes: seq[Switch], degree: int = 2): Future[seq[Future[void]]] {.async.} =
+proc subscribeSparseNodes*(nodes: seq[PubSub], degree: int = 2) {.async.} =
   if nodes.len < degree:
     raise (ref CatchableError)(msg: "nodes count needs to be greater or equal to degree!")
 
@@ -25,17 +64,17 @@ proc subscribeSparseNodes*(nodes: seq[Switch], degree: int = 2): Future[seq[Futu
       continue
 
     for node in nodes:
-      if dialer.peerInfo.peerId != node.peerInfo.peerId:
-        await dialer.connect(node.peerInfo)
-        result.add(dialer.subscribePeer(node.peerInfo))
+      if dialer.switch.peerInfo.peerId != node.peerInfo.peerId:
+        await dialer.switch.connect(node.peerInfo.peerId, node.peerInfo.addrs)
+        dialer.subscribePeer(node.peerInfo.peerId)
 
-proc subscribeRandom*(nodes: seq[Switch]): Future[seq[Future[void]]] {.async.} =
+proc subscribeRandom*(nodes: seq[PubSub]) {.async.} =
   for dialer in nodes:
-    var dialed: seq[string]
+    var dialed: seq[PeerID]
     while dialed.len < nodes.len - 1:
       let node = sample(nodes)
-      if node.peerInfo.id notin dialed:
-        if dialer.peerInfo.id != node.peerInfo.id:
-          await dialer.connect(node.peerInfo)
-          result.add(dialer.subscribePeer(node.peerInfo))
-          dialed.add(node.peerInfo.id)
+      if node.peerInfo.peerId notin dialed:
+        if dialer.peerInfo.peerId != node.peerInfo.peerId:
+          await dialer.switch.connect(node.peerInfo.peerId, node.peerInfo.addrs)
+          dialer.subscribePeer(node.peerInfo.peerId)
+          dialed.add(node.peerInfo.peerId)

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -118,7 +118,7 @@ suite "Switch":
 
       # plus 4 for the pubsub streams
       check (BufferStreamTracker(bufferTracker).opened ==
-        (BufferStreamTracker(bufferTracker).closed + 4.uint64))
+        (BufferStreamTracker(bufferTracker).closed))
 
       var connTracker = getTracker(ConnectionTrackerName)
       # echo connTracker.dump()
@@ -127,7 +127,7 @@ suite "Switch":
       # and the pubsub streams that won't clean up until
       # `disconnect()` or `stop()`
       check (ConnectionTracker(connTracker).opened ==
-        (ConnectionTracker(connTracker).closed + 8.uint64))
+        (ConnectionTracker(connTracker).closed + 4.uint64))
 
       await allFuturesThrowing(
         done.wait(5.seconds),

--- a/tests/testtransport.nim
+++ b/tests/testtransport.nim
@@ -97,7 +97,7 @@ suite "TCP transport":
 
       server.stop()
       server.close()
-      await server.closeEvent.wait()
+      await server.join()
 
     check:
       waitFor(testDialer(initTAddress("0.0.0.0:0"))) == true
@@ -133,7 +133,7 @@ suite "TCP transport":
 
       server.stop()
       server.close()
-      await server.closeEvent.wait()
+      await server.join()
     check:
       waitFor(testDialer(initTAddress("0.0.0.0:0"))) == true
 

--- a/tests/testtransport.nim
+++ b/tests/testtransport.nim
@@ -97,7 +97,7 @@ suite "TCP transport":
 
       server.stop()
       server.close()
-      await server.join()
+      await server.closeEvent.wait()
 
     check:
       waitFor(testDialer(initTAddress("0.0.0.0:0"))) == true
@@ -133,7 +133,7 @@ suite "TCP transport":
 
       server.stop()
       server.close()
-      await server.join()
+      await server.closeEvent.wait()
     check:
       waitFor(testDialer(initTAddress("0.0.0.0:0"))) == true
 


### PR DESCRIPTION
Move pubsub out of switch and pass the switch into pubsub to allow it manage connections internally

TODO:

- peer lifetime events to properly trigger `subscribePeer`/`unsubscribePeer`