### PR TITLE
A minimal patch ensuring local finalization with Lighthouse

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -153,10 +153,13 @@ proc selectMuxer*(c: ConnManager, conn: Connection): Muxer =
   ##
 
   if isNil(conn):
+    trace "Nil connection in selectMuxer"
     return
 
   if conn in c.muxed:
     return c.muxed[conn].muxer
+  else:
+    trace "No entry in c.muxed"
 
 proc storeConn*(c: ConnManager, conn: Connection) =
   ## store a connection

--- a/libp2p/muxers/muxer.nim
+++ b/libp2p/muxers/muxer.nim
@@ -41,7 +41,8 @@ method newStream*(m: Muxer, name: string = "", lazy: bool = false):
 method close*(m: Muxer) {.base, async, gcsafe.} = discard
 method handle*(m: Muxer): Future[void] {.base, async, gcsafe.} = discard
 
-proc newMuxerProvider*(creator: MuxerConstructor, codec: string): MuxerProvider {.gcsafe.} =
+proc newMuxerProvider*(creator: MuxerConstructor,
+                       codec: string): MuxerProvider {.gcsafe.} =
   new result
   result.newMuxer = creator
   result.codec = codec
@@ -65,6 +66,7 @@ method init(c: MuxerProvider) =
         futs &= c.muxerHandler(muxer)
 
       checkFutures(await allFinished(futs))
+
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -114,7 +114,6 @@ method init*(f: FloodSub) =
     ## connection for a protocol string
     ## e.g. ``/floodsub/1.0.0``, etc...
     ##
-
     await f.handleConn(conn, proto)
 
   f.handler = handler

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -185,7 +185,7 @@ proc send*(
           libp2p_pubsub_sent_messages.inc(labelValues = [p.id, t])
 
   except CatchableError as exc:
-    trace "unable to send to remote", exc = exc.msg
+    debug "unable to send to remote", exc = exc.msg
     if not(isNil(p.sendConn)):
       await p.sendConn.close()
       p.sendConn = nil

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -124,6 +124,15 @@ proc timeoutMonitor(s: Connection) {.async, gcsafe.} =
         s.activity = false
         continue
 
+      if true:
+        # TODO:
+        # The inactivity check is currently triggered even for
+        # active connection and leads to premature disconnects.
+        # ("active" here means "sending gossip traffic")
+        trace "Ignoring long inactivity"
+        s.activity = false
+        continue
+
       break
 
     # reset channel on innactivity timeout


### PR DESCRIPTION
This is the minimal set of changes that lead to deterministic finalization with Lighthouse in a local testnet driven by the multinet scripts. I'm calling them "changes" because I don't claim this is a proper way to address the underlying problems.

1) Fixes a race during gossip initialization

2) Disables the connection inactivity monitor because the connection
   with Lighthouse is being flagged as inactive even when it delivers
   Gossip traffic.

3) Logs more events of interest