### PR TITLE
work around bufferstream deadlock

### DIFF
--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -43,7 +43,7 @@ logScope:
   topics = "bufferstream"
 
 const
-  DefaultBufferSize* = 1024
+  DefaultBufferSize* = 102400
 
 const
   BufferStreamTrackerName* = "libp2p.bufferstream"


### PR DESCRIPTION
mplex backpressure handling deadlocks with something, this works around it for NBC's purposes - next step would be to reduce bufferstream size to 1 and continue digging