### PR TITLE
Mplex slow readers

### DIFF
--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -120,8 +120,12 @@ proc list*(m: MultistreamSelect,
   result = list
 
 proc handle*(m: MultistreamSelect, conn: Connection, active: bool = false) {.async, gcsafe.} =
+  logScope:
+    oid = $conn.oid
+
   trace "handle: starting multistream handling", handshaked = active
   var handshaked = active
+
   try:
     while not conn.atEof:
       var ms = string.fromBytes(await conn.readLp(1024))

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -43,6 +43,10 @@ logScope:
 # more formal approach.
 #
 
+const
+  # DefaultChannelSize* = 1024 * 1024 # 1MB
+  DefaultChannelSize* = 1024 # TODO: for debugging only
+
 type
   LPChannel* = ref object of BufferStream
     id*: uint64                   # channel id
@@ -238,7 +242,7 @@ proc init*(
   conn: Connection,
   initiator: bool,
   name: string = "",
-  size: int = DefaultBufferSize,
+  size: int = DefaultChannelSize,
   lazy: bool = false,
   timeout: Duration = DefaultChanTimeout): LPChannel =
 

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -79,12 +79,14 @@ proc sendObservers(p: PubSubPeer, msg: var RPCMsg) =
 proc handle*(p: PubSubPeer, conn: Connection) {.async.} =
   logScope:
     peer = p.id
+    connId = $conn.oid
+    closed = conn.closed
 
-  debug "starting pubsub read loop for peer", closed = conn.closed
+  debug "starting pubsub read loop for peer"
   try:
     try:
       while not conn.atEof:
-        trace "waiting for data", closed = conn.closed
+        trace "waiting for data"
         let data = await conn.readLp(64 * 1024)
         let digest = $(sha256.digest(data))
         trace "read data from peer", data = data.shortLog

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -43,7 +43,7 @@ logScope:
   topics = "bufferstream"
 
 const
-  DefaultBufferSize* = 102400
+  DefaultBufferSize* = 1024
 
 const
   BufferStreamTrackerName* = "libp2p.bufferstream"


### PR DESCRIPTION
This PR adds a protection mechanism to prevent slow readers from hogging the entire mplex read loop. 

This situation can happen when the `BufferStream`'s buffer has been topped and no reader is consuming data from it or it isn't being consumed fast enough. When this happens, the back pressure mechanism in `BufferStream` kicks in and `pushTo` will await until enough room has been made to finish pushing the remaining data, thus blocking the entire mplex read loop. Sadly, mplex doesn't have an elegant mitigation mechanism for this and the recommended approach is to reset the channel after a timeout. Quoting the spec here https://github.com/libp2p/specs/blob/master/mplex/README.md#implementation-notes:

```
If a stream is being actively written to, the reader must take care to keep up with inbound data. Due to the lack of back pressure at the protocol level, the implementation must handle slow readers by doing one or both of:

Blocking the entire connection until the offending stream is read.
Resetting the offending stream.
For example, the go-mplex implementation blocks for a short period of time and then resets the stream if necessary.
```

### Bonus:

This should also help identifying slow readers and/or deadlocks in the consuming application.