### PR TITLE
avoid send deadlock by not allowing send to block

### DIFF
--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -63,49 +63,38 @@ method unsubscribePeer*(f: FloodSub, peer: PeerID) =
 
 method rpcHandler*(f: FloodSub,
                    peer: PubSubPeer,
-                   rpcMsgs: seq[RPCMsg]) {.async.} =
-  await procCall PubSub(f).rpcHandler(peer, rpcMsgs)
+                   rpcMsg: RPCMsg) {.async.} =
+  await procCall PubSub(f).rpcHandler(peer, rpcMsg)
 
-  for m in rpcMsgs:                                  # for all RPC messages
-    if m.messages.len > 0:                           # if there are any messages
-      var toSendPeers = initHashSet[PubSubPeer]()
-      for msg in m.messages:                         # for every message
-        let msgId = f.msgIdProvider(msg)
-        logScope: msgId
+  if rpcMsg.messages.len > 0:                      # if there are any messages
+    var toSendPeers = initHashSet[PubSubPeer]()
+    for msg in rpcMsg.messages:                         # for every message
+      let msgId = f.msgIdProvider(msg)
+      logScope: msgId
 
-        if msgId notin f.seen:
-          f.seen.put(msgId)                          # add the message to the seen cache
+      if msgId notin f.seen:
+        f.seen.put(msgId)                          # add the message to the seen cache
 
-          if f.verifySignature and not msg.verify(peer.peerId):
-            trace "dropping message due to failed signature verification"
-            continue
+        if f.verifySignature and not msg.verify(peer.peerId):
+          trace "dropping message due to failed signature verification"
+          continue
 
-          if not (await f.validate(msg)):
-            trace "dropping message due to failed validation"
-            continue
+        if not (await f.validate(msg)):
+          trace "dropping message due to failed validation"
+          continue
 
-          for t in msg.topicIDs:                     # for every topic in the message
-            if t in f.floodsub:
-              toSendPeers.incl(f.floodsub[t])        # get all the peers interested in this topic
-            if t in f.topics:                        # check that we're subscribed to it
-              for h in f.topics[t].handler:
-                trace "calling handler for message", topicId = t,
-                                                     localPeer = f.peerInfo.id,
-                                                     fromPeer = msg.fromPeer.pretty
+        for t in msg.topicIDs:                     # for every topic in the message
+          if t in f.floodsub:
+            toSendPeers.incl(f.floodsub[t])        # get all the peers interested in this topic
 
-                try:
-                  await h(t, msg.data)                 # trigger user provided handler
-                except CancelledError as exc:
-                  raise exc
-                except CatchableError as exc:
-                  trace "exception in message handler", exc = exc.msg
+          await handleData(f, t, msg.data)
 
-        # forward the message to all peers interested in it
-        let published = f.broadcast(
-          toSeq(toSendPeers),
-          RPCMsg(messages: m.messages))
+      # forward the message to all peers interested in it
+      f.broadcast(
+        toSeq(toSendPeers),
+        RPCMsg(messages: rpcMsg.messages))
 
-        trace "forwared message to peers", peers = published
+      trace "forwared message to peers", peers = toSendPeers.len
 
 method init*(f: FloodSub) =
   proc handler(conn: Connection, proto: string) {.async.} =
@@ -121,14 +110,13 @@ method init*(f: FloodSub) =
 
 method publish*(f: FloodSub,
                 topic: string,
-                data: seq[byte],
-                timeout: Duration = InfiniteDuration): Future[int] {.async.} =
+                data: seq[byte]): Future[int] {.async.} =
   # base returns always 0
-  discard await procCall PubSub(f).publish(topic, data, timeout)
+  discard await procCall PubSub(f).publish(topic, data)
 
   if data.len <= 0 or topic.len <= 0:
     trace "topic or data missing, skipping publish"
-    return
+    return 0
 
   if topic notin f.floodsub:
     trace "missing peers for topic, skipping publish"
@@ -136,19 +124,21 @@ method publish*(f: FloodSub,
 
   trace "publishing on topic", name = topic
   inc f.msgSeqno
-  let msg = Message.init(f.peerInfo, data, topic, f.msgSeqno, f.sign)
+  let
+    msg = Message.init(f.peerInfo, data, topic, f.msgSeqno, f.sign)
+    peers = toSeq(f.floodsub.getOrDefault(topic))
 
   # start the future but do not wait yet
-  let published = f.broadcast(
-    toSeq(f.floodsub.getOrDefault(topic)),
+  f.broadcast(
+    peers,
     RPCMsg(messages: @[msg]))
 
   when defined(libp2p_expensive_metrics):
     libp2p_pubsub_messages_published.inc(labelValues = [topic])
 
-  trace "published message to peers", peers = published,
+  trace "published message to peers", peers = peers.len,
                                       msg = msg.shortLog()
-  return published
+  return peers.len
 
 method unsubscribe*(f: FloodSub,
                     topics: seq[TopicPair]) {.async.} =

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -50,6 +50,11 @@ type
       messages*: seq[Message]
       control*: Option[ControlMessage]
 
+func withSubs*(
+    T: type RPCMsg, topics: openArray[string], subscribe: bool): T =
+  T(
+    subscriptions: topics.mapIt(SubOpts(subscribe: subscribe, topic: it)))
+
 func shortLog*(s: ControlIHave): auto =
   (
     topicID: s.topicID.shortLog,

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -43,7 +43,7 @@ logScope:
   topics = "bufferstream"
 
 const
-  DefaultBufferSize* = 102400
+  DefaultBufferSize* = 128
 
 const
   BufferStreamTrackerName* = "libp2p.bufferstream"

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -16,6 +16,13 @@ type
 
 proc noop(data: seq[byte]) {.async, gcsafe.} = discard
 
+proc getPubSubPeer(p: TestGossipSub, peerId: PeerID): auto =
+  proc getConn(): Future[(Connection, RPCMsg)] {.async.} =
+    let conn =  await p.switch.dial(peerId, GossipSubCodec)
+    return (conn, RPCMsg.withSubs(toSeq(p.topics.keys), true))
+
+  newPubSubPeer(peerId, getConn, GossipSubCodec)
+
 proc randomPeerInfo(): PeerInfo =
   PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get())
 
@@ -39,7 +46,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo.peerId, gossipSub.switch, GossipSubCodec)
+        let peer = gossipSub.getPubSubPeer(peerInfo.peerId)
         gossipSub.peers[peerInfo.peerId] = peer
         gossipSub.mesh[topic].incl(peer)
 
@@ -69,7 +76,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get())
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
+        let peer = gossipSub.getPubSubPeer(peerInfo.peerId)
         gossipSub.peers[peerInfo.peerId] = peer
         gossipSub.mesh[topic].incl(peer)
 
@@ -101,7 +108,7 @@ suite "GossipSub internal":
         conns &= conn
         var peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
+        let peer = gossipSub.getPubSubPeer(peerInfo.peerId)
         peer.handler = handler
         gossipSub.gossipsub[topic].incl(peer)
 
@@ -135,7 +142,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get())
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
+        let peer = gossipSub.getPubSubPeer(peerInfo.peerId)
         peer.handler = handler
         gossipSub.fanout[topic].incl(peer)
 
@@ -173,7 +180,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
+        let peer = gossipSub.getPubSubPeer(peerInfo.peerId)
         peer.handler = handler
         gossipSub.fanout[topic1].incl(peer)
         gossipSub.fanout[topic2].incl(peer)
@@ -212,7 +219,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
+        let peer = gossipSub.getPubSubPeer(peerInfo.peerId)
         peer.handler = handler
         if i mod 2 == 0:
           gossipSub.fanout[topic].incl(peer)
@@ -225,7 +232,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
+        let peer = gossipSub.getPubSubPeer(peerInfo.peerId)
         peer.handler = handler
         gossipSub.gossipsub[topic].incl(peer)
 
@@ -274,7 +281,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo.peerId, gossipsub.switch, GossipSubCodec)
+        let peer = gossipSub.getPubSubPeer(peerInfo.peerId)
         peer.handler = handler
         if i mod 2 == 0:
           gossipSub.fanout[topic].incl(peer)
@@ -319,7 +326,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo.peerId, gossipSub.switch, GossipSubCodec)
+        let peer = gossipSub.getPubSubPeer(peerInfo.peerId)
         peer.handler = handler
         if i mod 2 == 0:
           gossipSub.mesh[topic].incl(peer)
@@ -364,7 +371,7 @@ suite "GossipSub internal":
         conns &= conn
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
-        let peer = newPubSubPeer(peerInfo.peerId, gossipSub.switch, GossipSubCodec)
+        let peer = gossipSub.getPubSubPeer(peerInfo.peerId)
         peer.handler = handler
         if i mod 2 == 0:
           gossipSub.mesh[topic].incl(peer)

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -96,7 +96,7 @@ suite "GossipSub internal":
     proc testRun(): Future[bool] {.async.} =
       let gossipSub = TestGossipSub.init(newStandardSwitch())
 
-      proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
+      proc handler(peer: PubSubPeer, msg: RPCMsg) {.async.} =
         discard
 
       let topic = "foobar"
@@ -128,7 +128,7 @@ suite "GossipSub internal":
     proc testRun(): Future[bool] {.async.} =
       let gossipSub = TestGossipSub.init(newStandardSwitch())
 
-      proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
+      proc handler(peer: PubSubPeer, msg: RPCMsg) {.async.} =
         discard
 
       let topic = "foobar"
@@ -163,7 +163,7 @@ suite "GossipSub internal":
     proc testRun(): Future[bool] {.async.} =
       let gossipSub = TestGossipSub.init(newStandardSwitch())
 
-      proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
+      proc handler(peer: PubSubPeer, msg: RPCMsg) {.async.} =
         discard
 
       let topic1 = "foobar1"
@@ -204,7 +204,7 @@ suite "GossipSub internal":
     proc testRun(): Future[bool] {.async.} =
       let gossipSub = TestGossipSub.init(newStandardSwitch())
 
-      proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
+      proc handler(peer: PubSubPeer, msg: RPCMsg) {.async.} =
         discard
 
       let topic = "foobar"
@@ -269,7 +269,7 @@ suite "GossipSub internal":
     proc testRun(): Future[bool] {.async.} =
       let gossipSub = TestGossipSub.init(newStandardSwitch())
 
-      proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
+      proc handler(peer: PubSubPeer, msg: RPCMsg) {.async.} =
         discard
 
       let topic = "foobar"
@@ -314,7 +314,7 @@ suite "GossipSub internal":
     proc testRun(): Future[bool] {.async.} =
       let gossipSub = TestGossipSub.init(newStandardSwitch())
 
-      proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
+      proc handler(peer: PubSubPeer, msg: RPCMsg) {.async.} =
         discard
 
       let topic = "foobar"
@@ -359,7 +359,7 @@ suite "GossipSub internal":
     proc testRun(): Future[bool] {.async.} =
       let gossipSub = TestGossipSub.init(newStandardSwitch())
 
-      proc handler(peer: PubSubPeer, msg: seq[RPCMsg]) {.async.} =
+      proc handler(peer: PubSubPeer, msg: RPCMsg) {.async.} =
         discard
 
       let topic = "foobar"


### PR DESCRIPTION
This is one example of how the deadlock in gossipsub can be avoided:

by making send a non-failing operation and dealing with send errors inside send. In particular, since `send` and `PubSubPeer` is responsible for setting up the send connection, it's also reasonable that it should be responsible for sending the initial subscription message to the other peer: this would likely resolve the problem that @zah was experiencing. To do that, `PubSub` needs to become aware that a new send connection has been opened over which the list of subscribed topics must be sent - for example through a callback or event.

It would then be natural that PubSubPeer also cleans up after itself - this would make gossipsub more independent in general and it wouldn't have to rely on connection events and NBC (or other application) to remember to call this function for every connection event (it's quite weird that NBC has to do this)

The test cases are failing because they are written under the assumption that bufferstream behaves like a datagram transport when in fact it is a stream whose readOnce may return fewer bytes than requested (here, we set the limit to 10 to stress it a bit).

This branch finalizes in NBC: https://github.com/status-im/nim-beacon-chain/tree/xxxx1
