### PR TITLE
xxx-2

### DIFF
--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -43,7 +43,7 @@ logScope:
   topics = "bufferstream"
 
 const
-  DefaultBufferSize* = 102400
+  DefaultBufferSize* = 10
 
 const
   BufferStreamTrackerName* = "libp2p.bufferstream"


### PR DESCRIPTION
This shows another way in which the deadlock can be resolved: by queueing messages in send until the send connection is ready, thus avoiding the deadlock when the send connection is being set up.

It fails tests for the same reason as #342 but finalizes in NBC: https://github.com/status-im/nim-beacon-chain/tree/xxx-2

Just like in #342, there's more to do here.
