### PR TITLE
small cleanups & docs

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -54,7 +54,6 @@ type
     mcache*: MCache                            # messages cache
     heartbeatFut: Future[void]                 # cancellation future for heartbeat interval
     heartbeatRunning: bool
-    heartbeatLock: AsyncLock                   # heartbeat lock to prevent two consecutive concurrent heartbeats
 
 when defined(libp2p_expensive_metrics):
   declareGauge(libp2p_gossipsub_peers_per_topic_mesh,
@@ -238,7 +237,7 @@ proc heartbeat(g: GossipSub) {.async.} =
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
-      trace "exception ocurred in gossipsub heartbeat", exc = exc.msg
+      warn "exception ocurred in gossipsub heartbeat", exc = exc.msg
 
     await sleepAsync(GossipSubHeartbeatInterval)
 
@@ -521,25 +520,18 @@ method publish*(g: GossipSub,
 method start*(g: GossipSub) {.async.} =
   trace "gossipsub start"
 
-  ## start pubsub
-  ## start long running/repeating procedures
+  if not g.heartbeatFut.isNil:
+    warn "Starting gossipsub twice"
+    return
 
-  # interlock start to to avoid overlapping to stops
-  await g.heartbeatLock.acquire()
-
-  # setup the heartbeat interval
   g.heartbeatRunning = true
   g.heartbeatFut = g.heartbeat()
 
-  g.heartbeatLock.release()
-
 method stop*(g: GossipSub) {.async.} =
   trace "gossipsub stop"
-
-  ## stop pubsub
-  ## stop long running tasks
-
-  await g.heartbeatLock.acquire()
+  if g.heartbeatFut.isNil:
+    warn "Stopping gossipsub without starting it"
+    return
 
   # stop heartbeat interval
   g.heartbeatRunning = false
@@ -547,8 +539,8 @@ method stop*(g: GossipSub) {.async.} =
     trace "awaiting last heartbeat"
     await g.heartbeatFut
     trace "heartbeat stopped"
+    g.heartbeatFut = nil
 
-  g.heartbeatLock.release()
 
 method initPubSub*(g: GossipSub) =
   procCall FloodSub(g).initPubSub()
@@ -561,4 +553,3 @@ method initPubSub*(g: GossipSub) =
   g.lastFanoutPubSub = initTable[string, Moment]()  # last publish time for fanout topics
   g.gossip = initTable[string, seq[ControlIHave]]() # pending gossip
   g.control = initTable[string, ControlMessage]()   # pending control messages
-  g.heartbeatLock = newAsyncLock()

--- a/libp2p/protocols/pubsub/peertable.nim
+++ b/libp2p/protocols/pubsub/peertable.nim
@@ -14,9 +14,11 @@ type
   PeerTable* = Table[string, HashSet[PubSubPeer]] # topic string to peer map
 
 proc hasPeerID*(t: PeerTable, topic: string, peerId: PeerID): bool =
-  let peers = toSeq(t.getOrDefault(topic))
-  peers.any do (peer: PubSubPeer) -> bool:
-    peer.peerId == peerId
+  if topic in t:
+    for peer in t[topic]:
+      if peer.peerId == peerId:
+        return true
+  false
 
 func addPeer*(table: var PeerTable, topic: string, peer: PubSubPeer): bool =
   # returns true if the peer was added,


### PR DESCRIPTION
* simplify gossipsub heartbeat start / stop
* avoid alloc in peerid check
* stop iterating over seq after unsubscribing item (could crash)
* don't crash on missing private key with enabled sigs (shouldn't happen
but...)