### PR TITLE
fix connection event order when connection dies early

### DIFF
--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -86,7 +86,7 @@ func shortLog*(c: ControlMessage): auto =
 
 func shortLog*(msg: Message): auto =
   (
-    fromPeer: msg.fromPeer,
+    fromPeer: msg.fromPeer.pretty,
     data: msg.data.shortLog,
     seqno: msg.seqno.shortLog,
     topicIDs: $msg.topicIDs,


### PR DESCRIPTION
if the connection is already closed (because the remote closes during
identfiy for example), an exception would be raised which would leave
the connection in limbo, beacuse it would not go through the rest of
internalConnect.

Also, if the connection is already closed, the disconnect event would be
scheduled before the connect event :/