### PR TITLE
fix poor performance in LRU cache

### DIFF
--- a/tests/pubsub/testtimedcache.nim
+++ b/tests/pubsub/testtimedcache.nim
@@ -32,3 +32,7 @@ suite "TimedCache":
       2 in cache
       3 notin cache
       4 in cache
+
+    check:
+      not cache.put(100, now + 100.seconds) # expires everything
+      100 in cache


### PR DESCRIPTION
it turns out (in NBC) a heap is sufficiently slow becuase of all the
deletes that it makes more sense to go with a linked list