### PR TITLE
Add logScope to connmanager and pubsubprotobuf

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -13,6 +13,9 @@ import peerinfo,
        stream/connection,
        muxers/muxer
 
+logScope:
+  topics = "connmanager"
+
 declareGauge(libp2p_peers, "total connected peers")
 
 const MaxConnectionsPerPeer = 5

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -14,6 +14,9 @@ import messages,
        ../../../utility,
        ../../../protobuf/minprotobuf
 
+logScope:
+  topics = "pubsubprotobuf"
+
 proc write*(pb: var ProtoBuffer, field: int, graft: ControlGraft) =
   var ipb = initProtoBuffer()
   ipb.write(1, graft.topicID)


### PR DESCRIPTION
Noticed a few missing logscope topics, this makes output such as the following easier to grep etc.

```
TRC 2020-09-15 11:03:48.872+08:00 Pushing readQueue                          topics="bufferstream" tid=31676 s=16*zd2AuE:5f602f14dd0f40441adc6102 len=1
TRC 2020-09-15 11:03:48.872+08:00 pushed data to channel                     topics="mplex" tid=31676 m=16*zd2AuE:5f602f14dd0f40441adc60f5 channel=16*zd2AuE:5f602f14dd0f40441adc6102:5f602f14dd0f4
0441adc6101 msgType=MsgOut id=3 initiator=false size=1                                                                                                                                             
TRC 2020-09-15 11:03:48.872+08:00 waiting for data                           topics="mplex" tid=31676 m=16*zd2AuE:5f602f14dd0f40441adc60f5
TRC 2020-09-15 11:03:48.872+08:00 read data from peer                        topics="pubsubpeer" tid=31676 conn=16*zd2AuE:5f602f14dd0f40441adc6102 peer=16*zd2AuE closed=false data=
TRC 2020-09-15 11:03:48.872+08:00 decodeRpcMsg: decoding message             tid=31676 msg=                                                                                                        
TRC 2020-09-15 11:03:48.872+08:00 decodeMessages: decoding message           tid=31676                                                                                                             
TRC 2020-09-15 11:03:48.872+08:00 decodeMessages: no messages found          tid=31676                                                                                                             
TRC 2020-09-15 11:03:48.873+08:00 decodeSubscriptions: decoding message      tid=31676                                                                                                             
TRC 2020-09-15 11:03:48.873+08:00 decodeControl: decoding message            tid=31676                                                                                                             
TRC 2020-09-15 11:03:48.873+08:00 decoded msg from peer                      topics="pubsubpeer" tid=31676 conn=16*zd2AuE:5f602f14dd0f40441adc6102 peer=16*zd2AuE closed=false msg="(subscriptions:
 @[], messages: @[], control: (ihave: @[], iwant: @[], graft: @[], prune: @[]))"                                                                                                                   
TRC 2020-09-15 11:03:48.873+08:00 processing RPC message                     topics="pubsub" tid=31676 msg="(subscripti
```

PS thanks for renaming topic to topics!