### PR TITLE
cleanups

### DIFF
--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -108,15 +108,14 @@ method init*(s: Secure) {.gcsafe.} =
 method secure*(s: Secure,
                conn: Connection,
                initiator: bool):
-               Future[Connection] {.async, base, gcsafe.} =
-  result = await s.handleConn(conn, initiator)
+               Future[Connection] {.base, gcsafe.} =
+  s.handleConn(conn, initiator)
 
 method readOnce*(s: SecureConn,
                  pbytes: pointer,
                  nbytes: int):
                  Future[int] {.async, gcsafe.} =
-  if nbytes == 0:
-    return 0
+  doAssert(nbytes > 0, "nbytes must be positive integer")
 
   if s.buf.data().len() == 0:
     let buf = await s.readMessage()

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -128,6 +128,8 @@ method readOnce*(s: BufferStream,
                  pbytes: pointer,
                  nbytes: int):
                  Future[int] {.async.} =
+  doAssert(nbytes > 0, "nbytes must be positive integer")
+
   if s.isEof and s.readBuf.len() == 0:
     raise newLPStreamEOFError()
 


### PR DESCRIPTION
* reuse connection timeout for noise handshake (avoid extra timer)
* enforce nbytes > 0 for readOnce
* avoid some unnecessary memory zeroing
* simplify noise
* fix dumping when noise splits message