### PR TITLE
channel close race and deadlock fixes

### DIFF
--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -27,19 +27,9 @@ logScope:
 ## | Read     | Yes (until EOF)   | No
 ## | Write    | No                | Yes
 ##
-
-# TODO: this is one place where we need to use
-# a proper state machine, but I've opted out of
-# it for now for two reasons:
-#
-# 1) we don't have that many states to manage
-# 2) I'm not sure if adding the state machine
-# would have simplified or complicated the code
-#
-# But now that this is in place, we should perhaps
-# reconsider reworking it again, this time with a
-# more formal approach.
-#
+## Channels are considered fully closed when both outgoing and incoming
+## directions are closed and when the reader of the channel has read the
+## EOF marker
 
 type
   LPChannel* = ref object of BufferStream
@@ -77,7 +67,7 @@ proc closeUnderlying(s: LPChannel): Future[void] {.async.} =
   if s.closedLocal and s.isEof:
     await procCall BufferStream(s).close()
 
-method reset*(s: LPChannel) {.base, async, gcsafe.} =
+proc reset*(s: LPChannel) {.async, gcsafe.} =
   if s.isClosed:
     trace "Already closed", s
     return

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -90,16 +90,15 @@ method closed*(s: ChronosStream): bool {.inline.} =
 method atEof*(s: ChronosStream): bool {.inline.} =
   s.client.atEof()
 
-method close*(s: ChronosStream) {.async.} =
+method closeImpl*(s: ChronosStream) {.async.} =
   try:
-    if not s.isClosed:
-      trace "shutting down chronos stream", address = $s.client.remoteAddress(),
-                                            s
-      if not s.client.closed():
-        await s.client.closeWait()
-
-      await procCall Connection(s).close()
+    trace "shutting down chronos stream", address = $s.client.remoteAddress(),
+                                          s
+    if not s.client.closed():
+      await s.client.closeWait()
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    trace "error closing chronosstream", exc = exc.msg, s
+    trace "error closing chronosstream", s, msg = exc.msg
+
+  await procCall Connection(s).closeImpl()

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -89,14 +89,16 @@ method initStream*(s: Connection) =
 
   inc getConnectionTracker().opened
 
-method close*(s: Connection) {.async.} =
-  ## cleanup timers
+method closeImpl*(s: Connection): Future[void] =
+  # Cleanup timeout timer
+  trace "Closing connection", s
   if not isNil(s.timerTaskFut) and not s.timerTaskFut.finished:
     s.timerTaskFut.cancel()
 
-  if not s.isClosed:
-    await procCall LPStream(s).close()
-    inc getConnectionTracker().closed
+  inc getConnectionTracker().closed
+  trace "Closed connection"
+
+  procCall LPStream(s).closeImpl()
 
 func hash*(p: Connection): Hash =
   cast[pointer](p).hash

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -1,3 +1,5 @@
+import std/unittest
+
 import chronos, bearssl
 
 import ../libp2p/transports/tcptransport
@@ -10,7 +12,7 @@ const
   StreamServerTrackerName = "stream.server"
 
   trackerNames = [
-    # ConnectionTrackerName,
+    ConnectionTrackerName,
     BufferStreamTrackerName,
     TcpTransportTrackerName,
     StreamTransportTrackerName,
@@ -24,6 +26,12 @@ iterator testTrackers*(extras: openArray[string] = []): TrackerBase =
   for name in extras:
     let t = getTracker(name)
     if not isNil(t): yield t
+
+template checkTrackers*() =
+  for tracker in testTrackers():
+    if tracker.isLeaked():
+      checkpoint tracker.dump()
+      fail()
 
 type RngWrap = object
   rng: ref BrHmacDrbgContext

--- a/tests/pubsub/testfloodsub.nim
+++ b/tests/pubsub/testfloodsub.nim
@@ -36,9 +36,7 @@ proc waitSub(sender, receiver: auto; key: string) {.async, gcsafe.} =
 
 suite "FloodSub":
   teardown:
-    for tracker in testTrackers():
-      # echo tracker.dump()
-      check tracker.isLeaked() == false
+    checkTrackers()
 
   test "FloodSub basic publish/subscribe A -> B":
     proc runTests() {.async.} =

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -28,9 +28,7 @@ proc randomPeerInfo(): PeerInfo =
 
 suite "GossipSub internal":
   teardown:
-    for tracker in testTrackers():
-      # echo tracker.dump()
-      check tracker.isLeaked() == false
+    checkTrackers()
 
   test "`rebalanceMesh` Degree Lo":
     proc testRun(): Future[bool] {.async.} =

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -58,9 +58,7 @@ template tryPublish(call: untyped, require: int, wait: Duration = 1.seconds, tim
 
 suite "GossipSub":
   teardown:
-    for tracker in testTrackers():
-      # echo tracker.dump()
-      check tracker.isLeaked() == false
+    checkTrackers()
 
   test "GossipSub validation should succeed":
     proc runTests() {.async.} =

--- a/tests/testconnmngr.nim
+++ b/tests/testconnmngr.nim
@@ -21,9 +21,7 @@ method newStream*(
 
 suite "Connection Manager":
   teardown:
-    for tracker in testTrackers():
-      # echo tracker.dump()
-      check tracker.isLeaked() == false
+    checkTrackers()
 
   test "add and retrive a connection":
     let connMngr = ConnManager.init()

--- a/tests/testidentify.nim
+++ b/tests/testidentify.nim
@@ -15,9 +15,7 @@ when defined(nimHasUsed): {.used.}
 
 suite "Identify":
   teardown:
-    for tracker in testTrackers():
-      # echo tracker.dump()
-      check tracker.isLeaked() == false
+    checkTrackers()
 
   test "handle identify message":
     proc testHandle(): Future[bool] {.async.} =

--- a/tests/testmultistream.nim
+++ b/tests/testmultistream.nim
@@ -168,9 +168,7 @@ proc newTestNaStream(na: NaHandler): TestNaStream =
 
 suite "Multistream select":
   teardown:
-    for tracker in testTrackers():
-      # echo tracker.dump()
-      check tracker.isLeaked() == false
+    checkTrackers()
 
   test "test select custom proto":
     proc testSelect(): Future[bool] {.async.} =

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -68,9 +68,7 @@ proc createSwitch(ma: MultiAddress; outgoing: bool): (Switch, PeerInfo) =
 
 suite "Noise":
   teardown:
-    for tracker in testTrackers():
-      # echo tracker.dump()
-      check tracker.isLeaked() == false
+    checkTrackers()
 
   test "e2e: handle write + noise":
     proc testListenerDialer(): Future[bool] {.async.} =

--- a/tests/testtransport.nim
+++ b/tests/testtransport.nim
@@ -11,9 +11,7 @@ import ./helpers
 
 suite "TCP transport":
   teardown:
-    for tracker in testTrackers():
-      # echo tracker.dump()
-      check tracker.isLeaked() == false
+    checkTrackers()
 
   test "test listener: handle write":
     proc testListener(): Future[bool] {.async, gcsafe.} =


### PR DESCRIPTION
* remove send lock, write chunks in one go
* push some of half-closed implementation to BufferStream
* fix some hangs where LPChannel readers and writers would not always
wake up
* simplify lazy channels
* fix close happening more than once in some orderings
* reenable connection tracking tests
* close channels first on mplex close such that consumers can read bytes

A notable difference is that BufferedStream is no longer considered EOF
until someone has actually read the EOF marker.