### PR TITLE
[WIP] Test webrtc multiaddr

### DIFF
--- a/tests/testmultiaddress.nim
+++ b/tests/testmultiaddress.nim
@@ -53,6 +53,7 @@ const
     "/ip4/1.2.3.4/tcp/80/unix/a/b/c/d/e/f",
     "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
     "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234/unix/stdio",
+    "/ip4/0.0.0.0/tcp/13579/wss/p2p-webrtc-star",
   ]
 
   FailureVectors = [


### PR DESCRIPTION
Running into a bug where identify protocol can't parse r2 field (addr): `Result: IncorrectBlob [ResultDefect]`

This happens when node is connected from Node JS with the following options: `listen: ['/ip4/0.0.0.0/tcp/0', '/ip4/0.0.0.0/tcp/13579/wss/p2p-webrtc-star']` and means identify information isn't exchanged.

Can't get the nim-libp2p tests to run locally with Nimble, so using CI to test if multiaddr is parsed correctly.

## Output

```
[Suite] MultiAddress test suite

/home/travis/gopath/src/github.com/status-im/nim-libp2p/tests/testmultiaddress.nim(301) testmultiaddress

/home/travis/.nimble/pkgs/stew-0.1.0/stew/results.nim(288) get

/home/travis/.nimble/pkgs/stew-0.1.0/stew/results.nim(279) raiseResultDefect

    Unhandled exception: Trying to access value with err Result: multiaddress: Unsupported protocol 'wss' [ResultDefect]

  [FAILED] go-multiaddr success test vectors
```

Would expect this to be valid and saved, without support for e.g. `wss`.