### PR TITLE
fix gossipsub memory leak on disconnected peer

### DIFF
--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -17,11 +17,10 @@ type
 proc noop(data: seq[byte]) {.async, gcsafe.} = discard
 
 proc getPubSubPeer(p: TestGossipSub, peerId: PeerID): auto =
-  proc getConn(): Future[(Connection, RPCMsg)] {.async.} =
-    let conn =  await p.switch.dial(peerId, GossipSubCodec)
-    return (conn, RPCMsg.withSubs(toSeq(p.topics.keys), true))
+  proc getConn(): Future[Connection] =
+    p.switch.dial(peerId, GossipSubCodec)
 
-  newPubSubPeer(peerId, getConn, GossipSubCodec)
+  newPubSubPeer(peerId, getConn, nil, GossipSubCodec)
 
 proc randomPeerInfo(): PeerInfo =
   PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get())
@@ -56,6 +55,7 @@ suite "GossipSub internal":
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
         let peer = gossipSub.getPubSubPeer(peerInfo.peerId)
+        peer.sendConn = conn
         gossipSub.onNewPeer(peer)
         gossipSub.peers[peerInfo.peerId] = peer
         gossipSub.gossipsub[topic].incl(peer)

--- a/tests/pubsub/testgossipinternal10.nim
+++ b/tests/pubsub/testgossipinternal10.nim
@@ -17,11 +17,10 @@ type
 proc noop(data: seq[byte]) {.async, gcsafe.} = discard
 
 proc getPubSubPeer(p: TestGossipSub, peerId: PeerID): auto =
-  proc getConn(): Future[(Connection, RPCMsg)] {.async.} =
-    let conn =  await p.switch.dial(peerId, GossipSubCodec)
-    return (conn, RPCMsg.withSubs(toSeq(p.topics.keys), true))
+  proc getConn(): Future[Connection] =
+    p.switch.dial(peerId, GossipSubCodec)
 
-  newPubSubPeer(peerId, getConn, GossipSubCodec)
+  newPubSubPeer(peerId, getConn, nil, GossipSubCodec)
 
 proc randomPeerInfo(): PeerInfo =
   PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get())
@@ -47,6 +46,7 @@ suite "GossipSub internal":
         let peerInfo = randomPeerInfo()
         conn.peerInfo = peerInfo
         let peer = gossipSub.getPubSubPeer(peerInfo.peerId)
+        peer.sendConn = conn
         gossipSub.peers[peerInfo.peerId] = peer
         gossipSub.mesh[topic].incl(peer)
 


### PR DESCRIPTION
When messages can't be sent to peer, we try to establish a send
connection - this causes messages to stack up as more and more unsent
messages are blocked on the dial lock.

* remove dial lock
* run reconnection loop in background task