### PR TITLE
small fixes

### DIFF
--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -160,10 +160,12 @@ method readOnce*(s: LPChannel,
     raise exc
 
 method write*(s: LPChannel, msg: seq[byte]): Future[void] {.async.} =
-  if s.closedLocal:
+  if s.closedLocal or s.conn.closed:
     raise newLPStreamClosedError()
 
-  doAssert msg.len > 0
+  if msg.len == 0:
+    return
+
   try:
     if not s.isOpen:
       await s.open()

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -204,7 +204,7 @@ method handleConn*(p: PubSub,
   except CatchableError as exc:
     trace "exception ocurred in pubsub handle", exc = exc.msg, conn
   finally:
-    await conn.close()
+    await conn.closeWithEOF()
 
 method subscribePeer*(p: PubSub, peer: PeerID) {.base.} =
   ## subscribe to remote peer to receive/send pubsub


### PR DESCRIPTION
* add helper to read EOF marker after closing stream (else stream stay
alive until timeout/reset)
* don't assert on empty channel message
* don't loop when writing to chronos (no need)