### PR TITLE
limit write queue length

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -530,7 +530,7 @@ proc rebalanceMesh(g: GossipSub, topic: string) {.async.} =
         if g.mesh.addPeer(topic, peer):
           g.grafted(peer, topic)
           grafting &= peer
-          trace "opportunistic grafting", peer = $peer
+          trace "opportunistic grafting", peer
 
   when defined(libp2p_expensive_metrics):
     libp2p_gossipsub_peers_per_topic_gossipsub
@@ -977,9 +977,9 @@ proc handleIHave(g: GossipSub,
                  peer: PubSubPeer,
                  ihaves: seq[ControlIHave]): ControlIWant =
   if peer.score < g.parameters.gossipThreshold:
-    trace "ihave: ignoring low score peer", peer = $peer, score = peer.score
+    trace "ihave: ignoring low score peer", peer, score = peer.score
   elif peer.iHaveBudget == 0:
-    trace "ihave: ignoring out of budget peer", peer = $peer, score = peer.score
+    trace "ihave: ignoring out of budget peer", peer, score = peer.score
   else:
     dec peer.iHaveBudget
     for ihave in ihaves:
@@ -995,7 +995,7 @@ proc handleIWant(g: GossipSub,
                  peer: PubSubPeer,
                  iwants: seq[ControlIWant]): seq[Message] =
   if peer.score < g.parameters.gossipThreshold:
-    trace "iwant: ignoring low score peer", peer = $peer, score = peer.score
+    trace "iwant: ignoring low score peer", peer, score = peer.score
   else:
     for iwant in iwants:
       for mid in iwant.messageIDs:
@@ -1178,7 +1178,7 @@ method publish*(g: GossipSub,
     # but a peer's own messages will always be published to all known peers in the topic.
     for peer in g.gossipsub.getOrDefault(topic):
       if peer.score >= g.parameters.publishThreshold:
-        trace "publish: including flood/high score peer", peer = $peer
+        trace "publish: including flood/high score peer", peer
         peers.incl(peer)
 
   # add always direct peers

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -14,6 +14,8 @@ import messages,
        ../../../utility,
        ../../../protobuf/minprotobuf
 
+{.push raises: [Defect].}
+
 logScope:
   topics = "pubsubprotobuf"
 

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -165,6 +165,7 @@ method readOnce*(s: BufferStream,
 
     if buf.len == 0 or s.isEof: # Another task might have set EOF!
       # No more data will arrive on read queue
+      trace "EOF", s
       s.isEof = true
     else:
       let remaining = min(buf.len, nbytes - rbytes)


### PR DESCRIPTION
To break a potential read/write deadlock, gossipsub uses an unbounded
queue for writes - when peers are too slow to process this queue, it may
end up growing without bounds causing high memory usage.

Here, we introduce a maximum write queue length after which the peer is
disconnected - the queue is generous enough that any "normal" usage
should be fine - writes that are `await`:ed are not affected, only
writes that are launched in an `asyncSpawn` task or similar.

* avoid unnecessary copy of message when there are no send observers
* release message memory earlier in gossipsub
* simplify pubsubpeer logging