### PR TITLE
reencode gossipsub messages with anonymization

### DIFF
--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -83,7 +83,7 @@ proc send*(p: PubSub, peer: PubSubPeer, msg: RPCMsg) =
   ##
 
   trace "sending pubsub message to peer", peer, msg = shortLog(msg)
-  peer.send(msg)
+  peer.send(msg, p.anonymize)
 
 proc broadcast*(
   p: PubSub,


### PR DESCRIPTION
This helps protect against clients sending more data than they should
and thus getting penalized on topics that require anonymity