### PR TITLE
avoid verbose EOF messages in readOnce(secure)

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -58,7 +58,6 @@ task testpubsub, "Runs pubsub tests":
 task testpubsub_slim, "Runs pubsub tests":
   runTest("pubsub/testgossipinternal", sign = false, verify = false, moreoptions = "-d:pubsub_internal_testing")
   runTest("pubsub/testpubsub")
-  runTest("pubsub/testpubsub", sign = false, verify = false, moreoptions = "-d:libp2p_pubsub_anonymize=true")
 
 task testfilter, "Run PKI filter test":
   runTest("testpkifilter",
@@ -80,7 +79,6 @@ task test, "Runs the test suite":
 task test_slim, "Runs the test suite":
   exec "nimble testnative"
   exec "nimble testpubsub_slim"
-  exec "nimble testdaemon"
   exec "nimble testinterop"
   exec "nimble testfilter"
 

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -126,9 +126,11 @@ method readOnce*(s: SecureConn,
         (@[], exc)
 
     if not isNil(err):
-      warn "error while reading message from secure connection, closing.",  error=err.name, 
-                                                                            message=err.msg, 
-                                                                            connection=s
+      if not (err of LPStreamEOFError):
+        warn "error while reading message from secure connection, closing.",  
+          error=err.name, 
+          message=err.msg, 
+          connection=s
       await s.close()
       raise err
       


### PR DESCRIPTION
@dryajov As discussed in the call, this is mostly temporary, I will review where to handle the exception better.