### PR TITLE
Don't allow concurrent pushdata

### DIFF
--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -90,20 +90,23 @@ proc reset*(s: LPChannel) {.async, gcsafe.} =
   s.readBuf = StreamSeq()
   s.pushedEof = true
 
-  let pushing = s.pushing # s.pushing changes while iterating
-  for i in 0..<pushing:
-    # Make sure to drain any ongoing pushes - there's already at least one item
-    # more in the queue already so any ongoing reads shouldn't interfere
-    # Notably, popFirst is not fair - which reader/writer gets woken up depends
-    discard await s.readQueue.popFirst()
-
-  if s.readQueue.len == 0 and s.reading:
-    # There is an active reader - we just grabbed all pushes so we need to push
-    # an EOF marker to wake it up
-    try:
-      s.readQueue.addLastNoWait(@[])
-    except CatchableError:
-      raiseAssert "We just checked the queue is empty"
+  # Took me some time to get this right.
+  # I'll leave this here in case we stumble
+  # on it again.
+  #
+  # State       | Q Empty  | Q Full
+  # ------------|----------|-------
+  # Reading     | Push Eof | Na
+  # Pushing     | Na       | Pop
+  #
+  if not(s.reading and s.pushing): # if either a reader or pusher is missing
+    if s.reading:
+      if s.readQueue.empty():
+        # There is an active reader
+        s.readQueue.addLastNoWait(Eof)
+    elif s.pushing:
+      if not s.readQueue.empty():
+        discard s.readQueue.popFirstNoWait()
 
   if not s.conn.isClosed:
     # If the connection is still active, notify the other end

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -28,7 +28,7 @@ type
   BufferStream* = ref object of Connection
     readQueue*: AsyncQueue[seq[byte]] # read queue for managing backpressure
     readBuf*: StreamSeq               # overflow buffer for readOnce
-    pushing*: int                     # number of ongoing push operations
+    pushing*: bool                    # number of ongoing push operations
     reading*: bool                    # is there an ongoing read? (only allow one)
     pushedEof*: bool                  # eof marker has been put on readQueue
     returnedEof*: bool                # 0-byte readOnce has been completed
@@ -63,6 +63,8 @@ method pushData*(s: BufferStream, data: seq[byte]) {.base, async.} =
   ##
   ## `pushTo` will block if the queue is full, thus maintaining backpressure.
   ##
+
+  doAssert(not s.pushing, "Only one concurrent push allowed")
   if s.isClosed or s.pushedEof:
     raise newLPStreamEOFError()
 
@@ -71,12 +73,12 @@ method pushData*(s: BufferStream, data: seq[byte]) {.base, async.} =
 
   # We will block here if there is already data queued, until it has been
   # processed
-  inc s.pushing
   try:
+    s.pushing = true
     trace "Pushing data", s, data = data.len
     await s.readQueue.addLast(data)
   finally:
-    dec s.pushing
+    s.pushing = false
 
 method pushEof*(s: BufferStream) {.base, async.} =
   if s.pushedEof:
@@ -85,12 +87,12 @@ method pushEof*(s: BufferStream) {.base, async.} =
 
   # We will block here if there is already data queued, until it has been
   # processed
-  inc s.pushing
   try:
+    s.pushing = true
     trace "Pushing EOF", s
-    await s.readQueue.addLast(@[])
+    await s.readQueue.addLast(Eof)
   finally:
-    dec s.pushing
+    s.pushing = false
 
 method atEof*(s: BufferStream): bool =
   s.isEof and s.readBuf.len == 0

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -83,6 +83,9 @@ method pushData*(s: BufferStream, data: seq[byte]) {.base, async.} =
 method pushEof*(s: BufferStream) {.base, async.} =
   if s.pushedEof:
     return
+
+  doAssert(not s.pushing, "Only one concurrent push allowed")
+
   s.pushedEof = true
 
   # We will block here if there is already data queued, until it has been

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -25,6 +25,7 @@ logScope:
 
 const
   LPStreamTrackerName* = "LPStream"
+  Eof* = @[]
 
 type
   Direction* {.pure.} = enum

--- a/tests/testbufferstream.nim
+++ b/tests/testbufferstream.nim
@@ -206,9 +206,11 @@ suite "BufferStream":
       fut = stream.pushData(toBytes("hello"))
       fut2 = stream.pushData(toBytes("again"))
     await stream.close()
-    expect AsyncTimeoutError:
-      await wait(fut, 100.milliseconds)
-      await wait(fut2, 100.milliseconds)
+
+    # Both writes should be completed on close (technically, the should maybe
+    # be cancelled, at least the second one...
+    check await fut.withTimeout(100.milliseconds)
+    check await fut2.withTimeout(100.milliseconds)
 
     await stream.close()
 


### PR DESCRIPTION
This PR does two things:

1. Disables concurrent `pushData` calls, which 1) break backpressure because at that point the async subsystem acts as a boundless buffer 2) adds unneeded complexity to the implementation, which has been a source of multiple issues that attempt to handle corner cases introduced by a  useless/faulty requirement.
2. Corrects the reset flow to handle the following cases:

- If a push was in progress but no reader is attached we need to pop the queue
- If a read was in progress without a push/data we need to push the Eof marker to notify the reader that the channel closed
- In all other cases, there should be a data to complete a read or enough room in the queue/buffer to complete a
push.

Here is a quick truth table to illustrate the cases:

State       | Q Empty  | Q Full
------------|----------|-------
Reading     | Push Eof | Na
Pushing     | Na       | Pop

