### PR TITLE
Use Travis only for ARM64

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,23 +16,28 @@ go: "1.14.x"
 
 matrix:
   include:
-    - os: linux
-      arch: amd64
-      env:
-        - NPROC=2
-      before_install:
-        - export GOPATH=$HOME/go
-    ## arm64 is very unreliable and slow, disabled for now
+    # Due to Travis new pricing we want to dedicate the resources we have
+    # for ARM64 testing, hence Linux/Mac on AMD are commented out
+    # https://blog.travis-ci.com/2020-11-02-travis-ci-new-billing
+
     # - os: linux
-    #   arch: arm64
+    #   arch: amd64
     #   env:
-    #     - NPROC=6 # Worth trying more than 2 parallel jobs: https://travis-ci.community/t/no-cache-support-on-arm64/5416/8
-    #     # (also used to get a different cache key than the amd64 one)
+    #     - NPROC=2
     #   before_install:
     #     - export GOPATH=$HOME/go
-    - os: osx
+    # - os: osx
+    #   env:
+    #     - NPROC=2
+    #   before_install:
+    #     - export GOPATH=$HOME/go
+
+    - os: linux
+      dist: bionic
+      arch: arm64
       env:
-        - NPROC=2
+        - NPROC=6 # Worth trying more than 2 parallel jobs: https://travis-ci.community/t/no-cache-support-on-arm64/5416/8
+        # (also used to get a different cache key than the amd64 one)
       before_install:
         - export GOPATH=$HOME/go
 
@@ -51,4 +56,3 @@ script:
   - nimble install -y --depsOnly
   - nimble test
   - nimble examples_build
-


### PR DESCRIPTION
 See https://github.com/status-im/nimbus-eth2/pull/2167

Trying to revivie ARM64 on Travis and we will reserve our Travis credits for that.