### PR TITLE
Concurrent upgrades

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -240,7 +240,10 @@ proc cleanupConn(c: ConnManager, conn: Connection) {.async.} =
 proc onConnUpgraded(c: ConnManager, conn: Connection) {.async.} =
   try:
     trace "Triggering connect events", conn
+    doAssert(not isNil(conn.upgraded),
+      "The `upgraded` event hasn't been properly initialized!")
     conn.upgraded.complete()
+
     let peerId = conn.peerInfo.peerId
     await c.triggerPeerEvents(
       peerId, PeerEvent(kind: PeerEventKind.Joined, initiator: conn.dir == Direction.Out))

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -240,9 +240,6 @@ proc cleanupConn(c: ConnManager, conn: Connection) {.async.} =
 proc onConnUpgraded(c: ConnManager, conn: Connection) {.async.} =
   try:
     trace "Triggering connect events", conn
-    # NOTE: make sure the upgrade event
-    # happens *before* any other events
-    # are triggered
     conn.upgraded.complete()
     let peerId = conn.peerInfo.peerId
     await c.triggerPeerEvents(

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -46,6 +46,7 @@ proc init*(T: type SecureConn,
              peerInfo: peerInfo,
              observedAddr: observedAddr,
              closeEvent: conn.closeEvent,
+             upgraded: conn.upgraded,
              timeout: timeout,
              dir: conn.dir)
   result.initStream()

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -65,9 +65,14 @@ method initStream*(s: Connection) =
 method closeImpl*(s: Connection): Future[void] =
   # Cleanup timeout timer
   trace "Closing connection", s
+
   if not isNil(s.timerTaskFut) and not s.timerTaskFut.finished:
     s.timerTaskFut.cancel()
     s.timerTaskFut = nil
+
+  if not isNil(s.upgraded) and not s.upgraded.finished:
+    s.upgraded.cancel()
+    s.upgraded = nil
 
   trace "Closed connection", s
 

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -32,6 +32,7 @@ type
     timeoutHandler*: TimeoutHandler # timeout handler
     peerInfo*: PeerInfo
     observedAddr*: Multiaddress
+    upgraded*: Future[void]
 
 proc timeoutMonitor(s: Connection) {.async, gcsafe.}
 
@@ -48,6 +49,9 @@ method initStream*(s: Connection) =
   procCall LPStream(s).initStream()
 
   doAssert(isNil(s.timerTaskFut))
+
+  if isNil(s.upgraded):
+    s.upgraded = newFuture[void]()
 
   if s.timeout > 0.millis:
     trace "Monitoring for timeout", s, timeout = s.timeout

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -125,7 +125,7 @@ method initStream*(s: LPStream) {.base.} =
 
   libp2p_open_streams.inc(labelValues = [s.objName, $s.dir])
   inc getStreamTracker(s.objName).opened
-  debug "Stream created", s, objName = s.objName, dir = $s.dir
+  trace "Stream created", s, objName = s.objName, dir = $s.dir
 
 proc join*(s: LPStream): Future[void] =
   s.closeEvent.wait()
@@ -258,7 +258,7 @@ method closeImpl*(s: LPStream): Future[void] {.async, base.} =
   s.closeEvent.fire()
   libp2p_open_streams.dec(labelValues = [s.objName, $s.dir])
   inc getStreamTracker(s.objName).closed
-  debug "Closed stream", s, objName = s.objName, dir = $s.dir
+  trace "Closed stream", s, objName = s.objName, dir = $s.dir
 
 method close*(s: LPStream): Future[void] {.base, async.} = # {.raises [Defect].}
   ## close the stream - this may block, but will not raise exceptions

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -443,7 +443,9 @@ proc accept(s: Switch, transport: Transport) {.async.} = # noraises
         # be careful to not end up in a thigh loop that
         # will starve the main event loop, thus we sleep
         # here before retrying.
+        trace "Unable to get a connection, sleeping"
         await sleepAsync(100.millis) # TODO: should be configurable?
+        upgrades.release()
         continue
 
       debug "Accepted an incoming connection", conn
@@ -454,7 +456,7 @@ proc accept(s: Switch, transport: Transport) {.async.} = # noraises
           await conn.upgraded.wait(30.seconds) # wait for connection to by upgraded
           trace "Connection upgrade succeeded"
         except CatchableError as exc:
-          trace "Exception awaiting connection upgrade", exc = exc.msg
+          trace "Exception awaiting connection upgrade", exc = exc.msg, conn
           if not(isNil(conn)) and not(conn.closed):
             await conn.close()
         finally:

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -455,11 +455,10 @@ proc accept(s: Switch, transport: Transport) {.async.} = # noraises
           trace "Connection upgrade succeeded"
         except CatchableError as exc:
           trace "Exception awaiting connection upgrade", exc = exc.msg
-
           if not(isNil(conn)) and not(conn.closed):
             await conn.close()
-
-        upgrades.release()
+        finally:
+          upgrades.release()
 
       asyncSpawn upgradeMonitor()
       asyncSpawn s.upgradeIncoming(conn)

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -510,8 +510,12 @@ proc stop*(s: Switch) {.async.} =
     except CatchableError as exc:
       warn "error cleaning up transports", msg = exc.msg
 
-  let stopped = await allFuturesThrowing(s.acceptFuts)
-    .withTimeout(1.seconds)
+  var stopped: bool
+  try:
+    stopped = await allFuturesThrowing(s.acceptFuts)
+      .withTimeout(1.seconds)
+  except CatchableError as exc:
+    trace "error waiting for accept loops to stop"
 
   if not stopped:
     for a in s.acceptFuts:

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -142,6 +142,8 @@ method stop*(t: TcpTransport) {.async, gcsafe.} =
   ## stop the transport
   ##
 
+  t.running = false # mark stopped as soon as possible
+
   try:
     trace "Stopping TCP transport"
     await procCall Transport(t).stop() # call base
@@ -160,8 +162,6 @@ method stop*(t: TcpTransport) {.async, gcsafe.} =
     inc getTcpTransportTracker().closed
   except CatchableError as exc:
     trace "Error shutting down tcp transport", exc = exc.msg
-  finally:
-    t.running = false
 
 method accept*(t: TcpTransport): Future[Connection] {.async, gcsafe.} =
   ## accept a new TCP connection

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -71,7 +71,7 @@ proc connHandler*(t: TcpTransport,
       await client.closeWait()
       raise exc
 
-  debug "Handling tcp connection", address = $observedAddr,
+  trace "Handling tcp connection", address = $observedAddr,
                                    dir = $dir,
                                    clients = t.clients[Direction.In].len +
                                    t.clients[Direction.Out].len
@@ -182,12 +182,12 @@ method accept*(t: TcpTransport): Future[Connection] {.async, gcsafe.} =
     # that can't.
     debug "OS Error", exc = exc.msg
   except TransportTooManyError as exc:
-    warn "Too many files opened", exc = exc.msg
+    debug "Too many files opened", exc = exc.msg
   except TransportUseClosedError as exc:
-    info "Server was closed", exc = exc.msg
+    debug "Server was closed", exc = exc.msg
     raise newTransportClosedError(exc)
   except CatchableError as exc:
-    trace "Unexpected error creating connection", exc = exc.msg
+    warn "Unexpected error creating connection", exc = exc.msg
     raise exc
 
 method dial*(t: TcpTransport,

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -130,7 +130,10 @@ method start*(t: TcpTransport, ma: MultiAddress) {.async.} =
   await procCall Transport(t).start(ma)
   trace "Starting TCP transport"
 
-  t.server = createStreamServer(t.ma, t.flags, t)
+  t.server = createStreamServer(
+    ma = t.ma,
+    flags = t.flags,
+    udata = t)
 
   # always get the resolved address in case we're bound to 0.0.0.0:0
   t.ma = MultiAddress.init(t.server.sock.getLocalAddress()).tryGet()

--- a/libp2p/utils/semaphore.nim
+++ b/libp2p/utils/semaphore.nim
@@ -1,0 +1,76 @@
+## Nim-Libp2p
+## Copyright (c) 2020 Status Research & Development GmbH
+## Licensed under either of
+##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+## at your option.
+## This file may not be copied, modified, or distributed except according to
+## those terms.
+
+import sequtils
+import chronos, chronicles
+
+# TODO: this should probably go in chronos
+
+logScope:
+  topics = "semaphore"
+
+type
+  AsyncSemaphore* = ref object of RootObj
+    size*: int
+    count*: int
+    queue*: seq[Future[void]]
+
+proc init*(T: type AsyncSemaphore, size: int): T =
+  T(size: size, count: size)
+
+proc tryAcquire*(s: AsyncSemaphore): bool =
+  ## Attempts to acquire a resource, if successful
+  ## returns true, otherwise false
+  ##
+
+  if s.count > 0 and s.queue.len == 0:
+    s.count.dec
+    trace "Acquired slot", available = s.count, queue = s.queue.len
+    return true
+
+proc acquire*(s: AsyncSemaphore): Future[void] =
+  ## Acquire a resource and decrement the resource
+  ## counter. If no more resources are available,
+  ## the returned future will not complete until
+  ## the resource count goes above 0 again.
+  ##
+
+  let fut = newFuture[void]("AsyncSemaphore.acquire")
+  if s.tryAcquire():
+    fut.complete()
+    return fut
+
+  s.queue.add(fut)
+  s.count.dec
+  trace "Queued slot", available = s.count, queue = s.queue.len
+  return fut
+
+proc release*(s: AsyncSemaphore) =
+  ## Release a resource from the semaphore,
+  ## by picking the first future from the queue
+  ## and completing it and incrementing the
+  ## internal resource count
+  ##
+
+  doAssert(s.count <= s.size)
+
+  if s.count < s.size:
+    trace "Releasing slot", available = s.count,
+                            queue = s.queue.len
+
+    if s.queue.len > 0:
+      var fut = s.queue.pop()
+      if not fut.finished():
+        fut.complete()
+
+    s.count.inc # increment the resource count
+    trace "Released slot", available = s.count,
+                           queue = s.queue.len
+                          #  stack = getStackTrace()
+    return

--- a/libp2p/utils/semaphore.nim
+++ b/libp2p/utils/semaphore.nim
@@ -13,7 +13,7 @@ import chronos, chronicles
 # TODO: this should probably go in chronos
 
 logScope:
-  topics = "semaphore"
+  topics = "libp2p semaphore"
 
 type
   AsyncSemaphore* = ref object of RootObj

--- a/libp2p/utils/semaphore.nim
+++ b/libp2p/utils/semaphore.nim
@@ -72,5 +72,4 @@ proc release*(s: AsyncSemaphore) =
     s.count.inc # increment the resource count
     trace "Released slot", available = s.count,
                            queue = s.queue.len
-                          #  stack = getStackTrace()
     return

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -9,6 +9,8 @@ import ../libp2p/stream/lpstream
 import ../libp2p/muxers/mplex/lpchannel
 import ../libp2p/protocols/secure/secure
 
+export unittest
+
 const
   StreamTransportTrackerName = "stream.transport"
   StreamServerTrackerName = "stream.server"

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -1,6 +1,7 @@
 import testvarint,
        testminprotobuf,
-       teststreamseq
+       teststreamseq,
+       testsemaphore
 
 import testminasn1,
        testrsa,

--- a/tests/testsemaphore.nim
+++ b/tests/testsemaphore.nim
@@ -1,0 +1,103 @@
+import random
+import chronos
+import ../libp2p/utils/semaphore
+
+import ./helpers
+
+randomize()
+
+suite "AsyncSemaphore":
+  asyncTest "should acquire":
+    let sema = AsyncSemaphore.init(3)
+
+    await sema.acquire()
+    await sema.acquire()
+    await sema.acquire()
+
+    check sema.count == 0
+
+  asyncTest "should release":
+    let sema = AsyncSemaphore.init(3)
+
+    await sema.acquire()
+    await sema.acquire()
+    await sema.acquire()
+
+    check sema.count == 0
+    sema.release()
+    sema.release()
+    sema.release()
+    check sema.count == 3
+
+  asyncTest "should queue acquire":
+    let sema = AsyncSemaphore.init(1)
+
+    await sema.acquire()
+    let fut = sema.acquire()
+
+    check sema.count == -1
+    check sema.queue.len == 1
+    sema.release()
+    sema.release()
+    check sema.count == 1
+
+    await sleepAsync(10.millis)
+    check fut.finished()
+
+  asyncTest "should keep count == size":
+    let sema = AsyncSemaphore.init(1)
+    sema.release()
+    sema.release()
+    sema.release()
+    check sema.count == 1
+
+  asyncTest "should tryAcquire":
+    let sema = AsyncSemaphore.init(1)
+    await sema.acquire()
+    check sema.tryAcquire() == false
+
+  asyncTest "should tryAcquire and acquire":
+    let sema = AsyncSemaphore.init(4)
+    check sema.tryAcquire() == true
+    check sema.tryAcquire() == true
+    check sema.tryAcquire() == true
+    check sema.tryAcquire() == true
+    check sema.count == 0
+
+    let fut = sema.acquire()
+    check fut.finished == false
+    check sema.count == -1
+    # queue is only used when count is < 0
+    check sema.queue.len == 1
+
+    sema.release()
+    sema.release()
+    sema.release()
+    sema.release()
+    sema.release()
+
+    check fut.finished == true
+    check sema.count == 4
+    check sema.queue.len == 0
+
+  asyncTest "should restrict resource access":
+    let sema = AsyncSemaphore.init(3)
+    var resource = 0
+
+    proc task() {.async.} =
+      try:
+        await sema.acquire()
+        resource.inc()
+        check resource > 0 and resource <= 3
+        let sleep = rand(0..10).millis
+        # echo sleep
+        await sleepAsync(sleep)
+      finally:
+        resource.dec()
+        sema.release()
+
+    var tasks: seq[Future[void]]
+    for i in 0..<10:
+      tasks.add(task())
+
+    await allFutures(tasks)


### PR DESCRIPTION
This PR adds inflight connection throttling for incoming connections. 

It includes:

- Adds an `upgraded` event to connections to signal when it has been upgraded/failed
  - This is needed for incoming connections because the initiator controls the upgrade flow
- Incoming connection upgrade throttling to match how dial works and prevent them from taking up all the available slots