### PR TITLE
fix invalid README hyperlink by adding https prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1 align="center">
-  <a href="libp2p.io"><img width="250" src="https://github.com/libp2p/libp2p/blob/master/logo/black-bg-2.png?raw=true" alt="libp2p hex logo" /></a>
+  <a href="https://libp2p.io"><img width="250" src="https://github.com/libp2p/libp2p/blob/master/logo/black-bg-2.png?raw=true" alt="libp2p hex logo" /></a>
 </h1>
 
 <h3 align="center">The Nim implementation of the libp2p Networking Stack.</h3>


### PR DESCRIPTION
Currently, if you try clicking on the image in the README, it acts as though `libp2p.io` is some local url relative to the GitHub README url.