### PR TITLE
Update README to display correct nim version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <p align="center">
 <a href="https://opensource.org/licenses/Apache-2.0"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" /></a>
 <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-blue.svg" /></a>
-<a href=""><img src="https://img.shields.io/badge/nim-%3E%3D1.0.6-orange.svg?style=flat-square" /></a>
+<img src="https://img.shields.io/badge/nim-%3E%3D1.2.0-orange.svg?style=flat-square" />
 </p>
 
 ## Introduction


### PR DESCRIPTION
Going off the [libp2p.nimble](https://github.com/status-im/nim-libp2p/blob/master/libp2p.nimble) file, it seems that nim version 1.2.0 is now being used, so I adjusted the README according, and removed the broken `<a>` tag.