### PR TITLE
Feat/peerstore impl

### DIFF
--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -9,6 +9,7 @@
 
 import
   std/[tables, sets, sequtils],
+  ./crypto/crypto,
   ./peerid,
   ./multiaddress
 
@@ -18,11 +19,16 @@ type
   ##############################
   
   AddrChangeHandler* = proc(peerId: PeerID, multiaddrs: HashSet[MultiAddress])
+  ProtoChangeHandler* = proc(peerId: PeerID, protos: HashSet[string])
+  KeyChangeHandler* = proc(peerId: PeerID, publicKey: PublicKey)
+  MetadataChangeHandler* = proc(peerId: PeerID, metadata: Table[string, seq[byte]])
 
   EventListener* = object
     # Listener object with client-defined handlers for peer store events
     addrChange*: AddrChangeHandler
-    # @TODO add handlers for other event types
+    protoChange*: ProtoChangeHandler
+    keyChange*: KeyChangeHandler
+    metadataChange*: MetadataChangeHandler
   
   #########
   # Books #
@@ -33,23 +39,52 @@ type
     book*: Table[PeerID, HashSet[MultiAddress]]
     addrChange: AddrChangeHandler
   
+  ProtoBook* = object
+    book*: Table[PeerID, HashSet[string]]
+    protoChange: ProtoChangeHandler
+  
+  KeyBook* = object
+    book*: Table[PeerID, PublicKey]
+    keyChange: KeyChangeHandler
+  
+  MetadataBook* = object
+    book*: Table[PeerID, Table[string, seq[byte]]]
+    metadataChange: MetadataChangeHandler
+  
   ####################
   # Peer store types #
   ####################
 
   PeerStore* = ref object of RootObj
     addressBook*: AddressBook
+    protoBook*: ProtoBook
+    keyBook*: KeyBook
+    metadataBook*: MetadataBook
     listeners: seq[EventListener]
   
   StoredInfo* = object
     # Collates stored info about a peer
-    ## @TODO include data from other stores once added
     peerId*: PeerID
     addrs*: HashSet[MultiAddress]
+    protos*: HashSet[string]
+    publicKey*: PublicKey
+    metadata*: Table[string, seq[byte]]
 
 proc init(T: type AddressBook, addrChange: AddrChangeHandler): AddressBook =
   T(book: initTable[PeerId, HashSet[MultiAddress]](),
     addrChange: addrChange)
+
+proc init(T: type ProtoBook, protoChange: ProtoChangeHandler): ProtoBook =
+  T(book: initTable[PeerId, HashSet[string]](),
+    protoChange: protoChange)
+
+proc init(T: type KeyBook, keyChange: KeyChangeHandler): KeyBook =
+  T(book: initTable[PeerId, PublicKey](),
+    keyChange: keyChange)
+
+proc init(T: type MetadataBook, metadataChange: MetadataChangeHandler): MetadataBook =
+  T(book: initTable[PeerId, Table[string, seq[byte]]](),
+    metadataChange: metadataChange)
 
 proc init*(p: PeerStore) =
   p.listeners = newSeq[EventListener]()
@@ -59,7 +94,25 @@ proc init*(p: PeerStore) =
     for listener in p.listeners:
       listener.addrChange(peerId, multiaddrs)
   
+  proc protoChange(peerId: PeerID, protos: HashSet[string]) =
+    # Notify all listeners of change in proto
+    for listener in p.listeners:
+      listener.protoChange(peerId, protos)
+  
+  proc keyChange(peerId: PeerID, publicKey: PublicKey) =
+    # Notify all listeners of change in public key
+    for listener in p.listeners:
+      listener.keyChange(peerId, publicKey)
+  
+  proc metadataChange(peerId: PeerID, metadata: Table[string, seq[byte]]) =
+    # Notify all listeners of change in public key
+    for listener in p.listeners:
+      listener.metadataChange(peerId, metadata)
+  
   p.addressBook = AddressBook.init(addrChange)
+  p.protoBook = ProtoBook.init(protoChange)
+  p.keyBook = KeyBook.init(keyChange)
+  p.metadataBook = MetadataBook.init(metadataChange)
 
 proc init*(T: type PeerStore): PeerStore =
   var p: PeerStore
@@ -109,6 +162,139 @@ proc set*(addressBook: var AddressBook,
   addressBook.book[peerId] = addrs
   addressBook.addrChange(peerId, addressBook.get(peerId)) # Notify clients
 
+#####################
+# Protocol Book API #
+#####################
+
+proc get*(protoBook: ProtoBook,
+          peerId: PeerID): HashSet[string] =
+  ## Get the known protocols of a provided peer.
+  
+  protoBook.book.getOrDefault(peerId,
+                              initHashSet[string]())
+
+proc add*(protoBook: var ProtoBook,
+          peerId: PeerID,
+          protocol: string) = 
+  ## Adds known protocol codec for a given peer. If the peer is not known, 
+  ## it will be set with the provided protocol.
+  
+  protoBook.book.mgetOrPut(peerId,
+                           initHashSet[string]()).incl(protocol)
+  protoBook.protoChange(peerId, protoBook.get(peerId)) # Notify clients
+  
+proc delete*(protoBook: var ProtoBook,
+             peerId: PeerID): bool =
+  ## Delete the provided peer from the book.
+  
+  if not protoBook.book.hasKey(peerId):
+    return false
+  else:
+    protoBook.book.del(peerId)
+    return true
+
+proc set*(protoBook: var ProtoBook,
+          peerId: PeerID,
+          protocols: HashSet[string]) =
+  ## Set known protocol codecs for a given peer. This will replace previously
+  ## stored protocols.
+  
+  protoBook.book[peerId] = protocols
+  protoBook.protoChange(peerId, protoBook.get(peerId)) # Notify clients
+
+################
+# Key Book API #
+################
+
+proc get*(keyBook: KeyBook,
+          peerId: PeerID): PublicKey =
+  ## Get the known public key of a provided peer.
+  
+  keyBook.book.getOrDefault(peerId,
+                            PublicKey())
+  
+proc delete*(keyBook: var KeyBook,
+             peerId: PeerID): bool =
+  ## Delete the provided peer from the book.
+  
+  if not keyBook.book.hasKey(peerId):
+    return false
+  else:
+    keyBook.book.del(peerId)
+    return true
+
+proc set*(keyBook: var KeyBook,
+          peerId: PeerID,
+          publicKey: PublicKey) =
+  ## Set known public key for a given peer. This will replace any
+  ## previously stored keys.
+  
+  keyBook.book[peerId] = publicKey
+  keyBook.keyChange(peerId, keyBook.get(peerId)) # Notify clients
+
+#####################
+# Metadata Book API #
+#####################
+
+proc get*(metadataBook: MetadataBook,
+          peerId: PeerID): Table[string, seq[byte]] =
+  ## Get all the known metadata of a provided peer.
+  
+  metadataBook.book.getOrDefault(peerId,
+                                 initTable[string, seq[byte]]())
+
+proc getValue*(metadataBook: MetadataBook,
+               peerId: PeerID,
+               key: string): seq[byte] =
+  ## Get metadata for a provided peer corresponding to a specific key.
+  
+  metadataBook.book.getOrDefault(peerId,
+                                 initTable[string, seq[byte]]())
+                   .getOrDefault(key,
+                                 newSeq[byte]())
+
+proc set*(metadataBook: var MetadataBook,
+          peerId: PeerID,
+          metadata: Table[string, seq[byte]]) =
+  ## Set metadata for a given peerId. This will replace any
+  ## previously stored metadata.
+  
+  metadataBook.book[peerId] = metadata
+  metadataBook.metadataChange(peerId, metadataBook.get(peerId))
+
+proc setValue*(metadataBook: var MetadataBook,
+               peerId: PeerID,
+               key: string,
+               value: seq[byte]) =
+  ## Set a metadata key-value pair for a given peerId. This will replace
+  ## any metadata previously stored against this key.
+  
+  metadataBook.book.mgetOrPut(peerId,
+                              initTable[string, seq[byte]]())[key] = value
+  metadataBook.metadataChange(peerId, metadataBook.get(peerId))
+
+proc delete*(metadataBook: var MetadataBook,
+             peerId: PeerID): bool =
+  ## Delete the provided peer from the book.
+  
+  if not metadataBook.book.hasKey(peerId):
+    return false
+  else:
+    metadataBook.book.del(peerId)
+    return true
+
+proc deleteValue*(metadataBook: var MetadataBook,
+                  peerId: PeerID,
+                  key: string): bool =
+  ## Delete the metadata for a provided peer corresponding to a specific key.
+  
+  if not metadataBook.book.hasKey(peerId) or not metadataBook.book[peerId].hasKey(key):
+    return false
+  else:
+    metadataBook.book[peerId].del(key)
+    metadataBook.metadataChange(peerId, metadataBook.get(peerId))
+    return true    
+
 ##################  
 # Peer Store API #
 ##################
@@ -123,7 +309,10 @@ proc delete*(peerStore: PeerStore,
              peerId: PeerID): bool =
   ## Delete the provided peer from every book.
   
-  peerStore.addressBook.delete(peerId)
+  peerStore.addressBook.delete(peerId) and
+  peerStore.protoBook.delete(peerId) and
+  peerStore.keyBook.delete(peerId) and
+  peerStore.metadataBook.delete(peerId)
 
 proc get*(peerStore: PeerStore,
           peerId: PeerID): StoredInfo =
@@ -131,12 +320,18 @@ proc get*(peerStore: PeerStore,
   
   StoredInfo(
     peerId: peerId,
-    addrs: peerStore.addressBook.get(peerId)
+    addrs: peerStore.addressBook.get(peerId),
+    protos: peerStore.protoBook.get(peerId),
+    publicKey: peerStore.keyBook.get(peerId),
+    metadata: peerStore.metadataBook.get(peerId)
   )
 
 proc peers*(peerStore: PeerStore): seq[StoredInfo] =
   ## Get all the stored information of every peer.
   
-  let allKeys = toSeq(keys(peerStore.addressBook.book)) # @TODO concat keys from other books
+  let allKeys = concat(toSeq(keys(peerStore.addressBook.book)),
+                       toSeq(keys(peerStore.protoBook.book)),
+                       toSeq(keys(peerStore.keyBook.book)),
+                       toSeq(keys(peerStore.metadataBook.book))).toHashSet()
 
   return allKeys.mapIt(peerStore.get(it))

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -63,20 +63,16 @@ type
     metadata*: Table[string, seq[byte]]
 
 proc init(T: type AddressBook): AddressBook =
-  T(book: initTable[PeerId, HashSet[MultiAddress]](),
-    changeHandlers: newSeq[AddrChangeHandler]())
+  T(book: initTable[PeerId, HashSet[MultiAddress]]())
 
 proc init(T: type ProtoBook): ProtoBook =
-  T(book: initTable[PeerId, HashSet[string]](),
-    changeHandlers: newSeq[ProtoChangeHandler]())
+  T(book: initTable[PeerId, HashSet[string]]())
 
 proc init(T: type KeyBook): KeyBook =
-  T(book: initTable[PeerId, PublicKey](),
-    changeHandlers: newSeq[KeyChangeHandler]())
+  T(book: initTable[PeerId, PublicKey]())
 
 proc init(T: type MetadataBook): MetadataBook =
-  T(book: initTable[PeerId, Table[string, seq[byte]]](),
-    changeHandlers: newSeq[MetadataChangeHandler]())
+  T(book: initTable[PeerId, Table[string, seq[byte]]]())
 
 proc init*(p: PeerStore) =
   p.addressBook = AddressBook.init()

--- a/tests/testpeerstore.nim
+++ b/tests/testpeerstore.nim
@@ -100,13 +100,11 @@ suite "PeerStore":
     
     proc metadataChange(peerId: PeerID, metadata: Table[string, seq[byte]]) =
       metadataChanged = true
-    
-    let listener = EventListener(addrChange: addrChange,
-                                 protoChange: protoChange,
-                                 keyChange: keyChange,
-                                 metadataChange: metadataChange)
 
-    peerStore.addListener(listener)
+    peerStore.addHandlers(addrChangeHandler = addrChange,
+                          protoChangeHandler = protoChange,
+                          keyChangeHandler = keyChange,
+                          metadataChangeHandler = metadataChange)
 
     # Test listener triggered on adding multiaddr
     peerStore.addressBook.add(peerId1, multiaddr1)

--- a/tests/testpeerstore.nim
+++ b/tests/testpeerstore.nim
@@ -10,15 +10,21 @@ suite "PeerStore":
   # Testvars
   let
     # Peer 1
-    seckey1 = PrivateKey.random(ECDSA, rng[]).get()
-    peerId1 = PeerID.init(seckey1).get()
+    keyPair1 = KeyPair.random(ECDSA, rng[]).get()
+    peerId1 = PeerID.init(keyPair1.secKey).get()
     multiaddrStr1 = "/ip4/127.0.0.1/udp/1234/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"
     multiaddr1 = MultiAddress.init(multiaddrStr1).get()
+    testcodec1 = "/nim/libp2p/test/0.0.1-beta1"
+    metadataKey1 = "key1"
+    metadataValue1 = cast[seq[byte]]("value1")
     # Peer 2
-    seckey2 = PrivateKey.random(ECDSA, rng[]).get()
-    peerId2 = PeerID.init(seckey2).get()
+    keyPair2 = KeyPair.random(ECDSA, rng[]).get()
+    peerId2 = PeerID.init(keyPair2.secKey).get()
     multiaddrStr2 = "/ip4/0.0.0.0/tcp/1234/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"
     multiaddr2 = MultiAddress.init(multiaddrStr2).get()
+    testcodec2 = "/nim/libp2p/test/0.0.2-beta1"
+    metadataKey2 = "key2"
+    metadataValue2 = cast[seq[byte]]("value2")
   
   test "PeerStore API":
     # Set up peer store
@@ -27,6 +33,12 @@ suite "PeerStore":
     
     peerStore.addressBook.add(peerId1, multiaddr1)
     peerStore.addressBook.add(peerId2, multiaddr2)
+    peerStore.protoBook.add(peerId1, testcodec1)
+    peerStore.protoBook.add(peerId2, testcodec2)
+    peerStore.keyBook.set(peerId1, keyPair1.pubKey)
+    peerStore.keyBook.set(peerId2, keyPair2.pubKey)
+    peerStore.metadataBook.set(peerId1, {metadataKey1: metadataValue1}.toTable)
+    peerStore.metadataBook.set(peerId2, {metadataKey2: metadataValue2}.toTable)
 
     # Test PeerStore::get
     let
@@ -35,16 +47,30 @@ suite "PeerStore":
     check:
       peer1Stored.peerId == peerId1
       peer1Stored.addrs == toHashSet([multiaddr1])
+      peer1Stored.protos == toHashSet([testcodec1])
+      peer1Stored.publicKey == keyPair1.pubkey
+      peer1Stored.metadata == {metadataKey1: metadataValue1}.toTable
       peer2Stored.peerId == peerId2
       peer2Stored.addrs == toHashSet([multiaddr2])
+      peer2Stored.protos == toHashSet([testcodec2])
+      peer2Stored.publicKey == keyPair2.pubkey
+      peer2Stored.metadata == {metadataKey2: metadataValue2}.toTable
     
     # Test PeerStore::peers
     let peers = peerStore.peers()
     check:
       peers.len == 2
-      peers.anyIt(it.peerId == peerId1 and it.addrs == toHashSet([multiaddr1]))
-      peers.anyIt(it.peerId == peerId2 and it.addrs == toHashSet([multiaddr2]))
-    
+      peers.anyIt(it.peerId == peerId1 and
+                  it.addrs == toHashSet([multiaddr1]) and
+                  it.protos == toHashSet([testcodec1]) and
+                  it.publicKey == keyPair1.pubkey and
+                  it.metadata == {metadataKey1: metadataValue1}.toTable)
+      peers.anyIt(it.peerId == peerId2 and
+                  it.addrs == toHashSet([multiaddr2]) and
+                  it.protos == toHashSet([testcodec2]) and
+                  it.publicKey == keyPair2.pubkey and
+                  it.metadata == {metadataKey2: metadataValue2}.toTable)
+
     # Test PeerStore::delete
     check:
       # Delete existing peerId
@@ -59,11 +85,26 @@ suite "PeerStore":
     var
       peerStore = PeerStore.init()
       addrChanged = false
+      protoChanged = false
+      keyChanged = false
+      metadataChanged = false
     
     proc addrChange(peerId: PeerID, addrs: HashSet[MultiAddress]) =
       addrChanged = true
     
-    let listener = EventListener(addrChange: addrChange)
+    proc protoChange(peerId: PeerID, protos: HashSet[string]) =
+      protoChanged = true
+    
+    proc keyChange(peerId: PeerID, publicKey: PublicKey) =
+      keyChanged = true
+    
+    proc metadataChange(peerId: PeerID, metadata: Table[string, seq[byte]]) =
+      metadataChanged = true
+    
+    let listener = EventListener(addrChange: addrChange,
+                                 protoChange: protoChange,
+                                 keyChange: keyChange,
+                                 metadataChange: metadataChange)
 
     peerStore.addListener(listener)
 
@@ -77,7 +118,53 @@ suite "PeerStore":
     peerStore.addressBook.set(peerId2,
                               toHashSet([multiaddr1, multiaddr2]))
     check:
-      addrChanged == true    
+      addrChanged == true
+  
+    # Test listener triggered on adding proto
+    peerStore.protoBook.add(peerId1, testcodec1)
+    check:
+      protoChanged == true
+    
+    # Test listener triggered on setting protos
+    protoChanged = false
+    peerStore.protoBook.set(peerId2,
+                            toHashSet([testcodec1, testcodec2]))
+    check:
+      protoChanged == true
+    
+    # Test listener triggered on setting public key
+    peerStore.keyBook.set(peerId1,
+                          keyPair1.pubkey)
+    check:
+      keyChanged == true
+    
+    # Test listener triggered on changing public key
+    keyChanged = false
+    peerStore.keyBook.set(peerId1,
+                          keyPair2.pubkey)
+    check:
+      keyChanged == true
+    
+    # Test listener triggered on setting metadata value
+    peerStore.metadataBook.setValue(peerId1,
+                                    metadataKey1,
+                                    metadataValue1)
+    check:
+      metadataChanged == true
+    
+    # Test listener triggered on setting metadata
+    metadataChanged = false
+    peerStore.metadataBook.set(peerId1,
+                               {metadataKey1: metadataValue1, metadataKey2: metadataValue2}.toTable)
+    check:
+      metadataChanged == true
+    
+    # Test listener triggered on deleting metadata value
+    metadataChanged = false
+    check:
+      peerStore.metadataBook.deleteValue(peerId1,
+                                         metadataKey1) == true
+      metadataChanged == true
 
   test "AddressBook API":
     # Set up address book
@@ -112,3 +199,111 @@ suite "PeerStore":
     check:
       toSeq(keys(addressBook.book))[0] == peerId2
       toSeq(values(addressBook.book))[0] == toHashSet([multiaddr1, multiaddr2])
+  
+  test "ProtoBook API":
+    # Set up protocol book
+    var
+      protoBook = PeerStore.init().protoBook
+    
+    # Test ProtoBook::add
+    protoBook.add(peerId1, testcodec1)
+    
+    check:
+      toSeq(keys(protoBook.book))[0] == peerId1
+      toSeq(values(protoBook.book))[0] == toHashSet([testcodec1])
+    
+    # Test ProtoBook::get
+    check:
+      protoBook.get(peerId1) == toHashSet([testcodec1])
+    
+    # Test ProtoBook::delete
+    check:
+      # Try to delete peerId that doesn't exist
+      protoBook.delete(peerId2) == false
+
+      # Delete existing peerId
+      protoBook.book.len == 1 # sanity
+      protoBook.delete(peerId1) == true
+      protoBook.book.len == 0
+    
+    # Test ProtoBook::set
+    # Set peerId2 with multiple protocols
+    protoBook.set(peerId2,
+                  toHashSet([testcodec1, testcodec2]))
+    check:
+      toSeq(keys(protoBook.book))[0] == peerId2
+      toSeq(values(protoBook.book))[0] == toHashSet([testcodec1, testcodec2])
+
+  test "KeyBook API":
+    # Set up key book
+    var
+      keyBook = PeerStore.init().keyBook
+    
+    # Test KeyBook::set
+    keyBook.set(peerId1,
+                keyPair1.pubkey)
+    check:
+      toSeq(keys(keyBook.book))[0] == peerId1
+      toSeq(values(keyBook.book))[0] == keyPair1.pubkey
+    
+    # Test KeyBook::get
+    check:
+      keyBook.get(peerId1) == keyPair1.pubkey
+    
+    # Test KeyBook::delete
+    check:
+      # Try to delete peerId that doesn't exist
+      keyBook.delete(peerId2) == false
+
+      # Delete existing peerId
+      keyBook.book.len == 1 # sanity
+      keyBook.delete(peerId1) == true
+      keyBook.book.len == 0
+
+  test "MetadataBook API":
+    # Set up metadata book
+    var
+      metadataBook = PeerStore.init().metadataBook
+    
+    # Test MetadataBook::setValue
+    metadataBook.setValue(peerId1, metadataKey1, metadataValue1)
+    
+    check:
+      toSeq(keys(metadataBook.book))[0] == peerId1
+      toSeq(values(metadataBook.book))[0] == {metadataKey1: metadataValue1}.toTable
+    
+    # Test MetadataBook::getValue
+    check:
+      metadataBook.getValue(peerId1, metadataKey1) == metadataValue1
+    
+    # Test MetadataBook::deleteValue
+    check:
+      # Try to delete key-value pair that does not exist
+      metadataBook.deleteValue(peerId1, metadataKey2) == false
+
+      # Delete existing key-value pair
+      metadataBook.book[peerId1].len == 1 # sanity
+      metadataBook.deleteValue(peerId1, metadataKey1) == true
+      metadataBook.book[peerId1].len == 0
+
+    # Test MetadataBook::set
+    # Set peerId1 with multiple metadata key-value pairs
+    metadataBook.set(peerId1,
+                     {metadataKey1: metadataValue1, metadataKey2: metadataValue2}.toTable)
+    check:
+      toSeq(keys(metadataBook.book))[0] == peerId1
+      toSeq(values(metadataBook.book))[0] == {metadataKey1: metadataValue1, metadataKey2: metadataValue2}.toTable
+    
+    # Test MetadataBook::get
+    check:
+      metadataBook.get(peerId1) == {metadataKey1: metadataValue1, metadataKey2: metadataValue2}.toTable
+    
+    # Test MetadataBook::delete
+    check:
+      # Try to delete peerId entry that does not exist
+      metadataBook.delete(peerId2) == false
+
+      # Delete existing peerId entry
+      metadataBook.book.len == 1 # sanity
+      metadataBook.delete(peerId1) == true
+      metadataBook.book.len == 0

--- a/tests/testpeerstore.nim
+++ b/tests/testpeerstore.nim
@@ -15,23 +15,17 @@ suite "PeerStore":
     multiaddrStr1 = "/ip4/127.0.0.1/udp/1234/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"
     multiaddr1 = MultiAddress.init(multiaddrStr1).get()
     testcodec1 = "/nim/libp2p/test/0.0.1-beta1"
-    metadataKey1 = "key1"
-    metadataValue1 = "value1"
     # Peer 2
     keyPair2 = KeyPair.random(ECDSA, rng[]).get()
     peerId2 = PeerID.init(keyPair2.secKey).get()
     multiaddrStr2 = "/ip4/0.0.0.0/tcp/1234/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC"
     multiaddr2 = MultiAddress.init(multiaddrStr2).get()
     testcodec2 = "/nim/libp2p/test/0.0.2-beta1"
-    metadataKey2 = "key2"
-    metadataValue2 = "value2"
-  var
-    metadataType: typedesc[Table[string,string]]
   
   test "PeerStore API":
     # Set up peer store
     var
-      peerStore = PeerStore.new(metadataType)
+      peerStore = PeerStore.new()
     
     peerStore.addressBook.add(peerId1, multiaddr1)
     peerStore.addressBook.add(peerId2, multiaddr2)
@@ -39,8 +33,6 @@ suite "PeerStore":
     peerStore.protoBook.add(peerId2, testcodec2)
     peerStore.keyBook.set(peerId1, keyPair1.pubKey)
     peerStore.keyBook.set(peerId2, keyPair2.pubKey)
-    peerStore.metadataBook.set(peerId1, {metadataKey1: metadataValue1}.toTable)
-    peerStore.metadataBook.set(peerId2, {metadataKey2: metadataValue2}.toTable)
 
     # Test PeerStore::get
     let
@@ -51,12 +43,10 @@ suite "PeerStore":
       peer1Stored.addrs == toHashSet([multiaddr1])
       peer1Stored.protos == toHashSet([testcodec1])
       peer1Stored.publicKey == keyPair1.pubkey
-      peer1Stored.metadata == {metadataKey1: metadataValue1}.toTable
       peer2Stored.peerId == peerId2
       peer2Stored.addrs == toHashSet([multiaddr2])
       peer2Stored.protos == toHashSet([testcodec2])
       peer2Stored.publicKey == keyPair2.pubkey
-      peer2Stored.metadata == {metadataKey2: metadataValue2}.toTable
     
     # Test PeerStore::peers
     let peers = peerStore.peers()
@@ -65,13 +55,11 @@ suite "PeerStore":
       peers.anyIt(it.peerId == peerId1 and
                   it.addrs == toHashSet([multiaddr1]) and
                   it.protos == toHashSet([testcodec1]) and
-                  it.publicKey == keyPair1.pubkey and
-                  it.metadata == {metadataKey1: metadataValue1}.toTable)
+                  it.publicKey == keyPair1.pubkey)
       peers.anyIt(it.peerId == peerId2 and
                   it.addrs == toHashSet([multiaddr2]) and
                   it.protos == toHashSet([testcodec2]) and
-                  it.publicKey == keyPair2.pubkey and
-                  it.metadata == {metadataKey2: metadataValue2}.toTable)
+                  it.publicKey == keyPair2.pubkey)
 
     # Test PeerStore::delete
     check:
@@ -85,11 +73,10 @@ suite "PeerStore":
   test "PeerStore listeners":
     # Set up peer store with listener
     var
-      peerStore = PeerStore.new(metadataType)
+      peerStore = PeerStore.new()
       addrChanged = false
       protoChanged = false
       keyChanged = false
-      metadataChanged = false
     
     proc addrChange(peerId: PeerID, addrs: HashSet[MultiAddress]) =
       addrChanged = true
@@ -99,14 +86,10 @@ suite "PeerStore":
     
     proc keyChange(peerId: PeerID, publicKey: PublicKey) =
       keyChanged = true
-    
-    proc metadataChange(peerId: PeerID, metadata: Table[string, string]) =
-      metadataChanged = true
 
     peerStore.addHandlers(addrChangeHandler = addrChange,
                           protoChangeHandler = protoChange,
-                          keyChangeHandler = keyChange,
-                          metadataChangeHandler = metadataChange)
+                          keyChangeHandler = keyChange)
 
     # Test listener triggered on adding multiaddr
     peerStore.addressBook.add(peerId1, multiaddr1)
@@ -144,18 +127,11 @@ suite "PeerStore":
                           keyPair2.pubkey)
     check:
       keyChanged == true
-      
-    # Test listener triggered on setting metadata
-    metadataChanged = false
-    peerStore.metadataBook.set(peerId1,
-                               {metadataKey1: metadataValue1, metadataKey2: metadataValue2}.toTable)
-    check:
-      metadataChanged == true
 
   test "AddressBook API":
     # Set up address book
     var
-      addressBook = PeerStore.new(metadataType).addressBook
+      addressBook = PeerStore.new().addressBook
     
     # Test AddressBook::add
     addressBook.add(peerId1, multiaddr1)
@@ -189,7 +165,7 @@ suite "PeerStore":
   test "ProtoBook API":
     # Set up protocol book
     var
-      protoBook = PeerStore.new(metadataType).protoBook
+      protoBook = PeerStore.new().protoBook
     
     # Test ProtoBook::add
     protoBook.add(peerId1, testcodec1)
@@ -223,7 +199,7 @@ suite "PeerStore":
   test "KeyBook API":
     # Set up key book
     var
-      keyBook = PeerStore.new(metadataType).keyBook
+      keyBook = PeerStore.new().keyBook
     
     # Test KeyBook::set
     keyBook.set(peerId1,
@@ -245,30 +221,3 @@ suite "PeerStore":
       keyBook.book.len == 1 # sanity
       keyBook.delete(peerId1) == true
       keyBook.book.len == 0
-
-  test "MetadataBook API":
-    # Set up metadata book
-    var
-      metadataBook = PeerStore.new(metadataType).metadataBook
-
-    # Test MetadataBook::set
-    # Set peerId1 with multiple metadata key-value pairs
-    metadataBook.set(peerId1,
-                     {metadataKey1: metadataValue1, metadataKey2: metadataValue2}.toTable)
-    check:
-      toSeq(keys(metadataBook.book))[0] == peerId1
-      toSeq(values(metadataBook.book))[0] == {metadataKey1: metadataValue1, metadataKey2: metadataValue2}.toTable
-    
-    # Test MetadataBook::get
-    check:
-      metadataBook.get(peerId1) == {metadataKey1: metadataValue1, metadataKey2: metadataValue2}.toTable
-    
-    # Test MetadataBook::delete
-    check:
-      # Try to delete peerId entry that does not exist
-      metadataBook.delete(peerId2) == false
-
-      # Delete existing peerId entry
-      metadataBook.book.len == 1 # sanity
-      metadataBook.delete(peerId1) == true
-      metadataBook.book.len == 0


### PR DESCRIPTION
This PR closes #504.

It adds a `KeyBook`, `ProtoBook` and `MetadataBook` to the [PoC Peer Store implementation](https://github.com/status-im/nim-libp2p/issues/498).

#### Miscellaneous changes
- Extracted handlers from an encapsulating `EventListener` object (as per [this conversation](https://github.com/status-im/nim-libp2p/pull/499#discussion_r556651834))

#### Suggested next steps:
- Coordinate on best way to provide rudimentary peer management using the Peer Store. `WakuRelay` will specifically benefit from something like a `dialer` interface from where dialed peers can be added to a store, reconnected when connection dropped, etc. Parts of this may overlap with efforts elsewhere in `nim-libp2p`, so proper coordination is necessary. I will therefore propose any next steps as PoC features in the libp2p repo to gain consensus before proceeding.