### PR TITLE
Remove secio usage and cleanup exports

### DIFF
--- a/libp2p.nim
+++ b/libp2p.nim
@@ -8,20 +8,26 @@
 ## those terms.
 
 import
-  libp2p/[daemon/daemonapi,
-          daemon/transpool,
-          protobuf/minprotobuf,
+  libp2p/[protobuf/minprotobuf,
+          muxers/muxer,
+          muxers/mplex/mplex,
+          stream/lpstream,
+          stream/bufferstream,
+          stream/connection,
+          transports/transport,
+          transports/tcptransport,
+          protocols/secure/noise,
           varint,
           switch,
           peerid,
           peerinfo,
-          stream/lpstream,
-          stream/bufferstream,
-          stream/connection,
           multiaddress,
           crypto/crypto]
 
+import bearssl
+
 export
-  daemonapi, transpool, minprotobuf, varint,
-  switch, peerid, peerinfo, connection,
-  multiaddress, crypto, lpstream, bufferstream
+  minprotobuf, varint,switch, peerid, peerinfo,
+  connection, multiaddress, crypto, lpstream,
+  bufferstream, bearssl, muxer, mplex, transport,
+  tcptransport, noise

--- a/libp2p/standard_setup.nim
+++ b/libp2p/standard_setup.nim
@@ -1,10 +1,10 @@
 import options, tables
 import chronos
-import libp2p
-
-import connmanager
+import ../libp2p
 
 export libp2p
+
+import connmanager
 
 type
   SecureProtocol* {.pure.} = enum

--- a/libp2p/standard_setup.nim
+++ b/libp2p/standard_setup.nim
@@ -1,21 +1,15 @@
-import
-  options, tables, chronos, bearssl,
-  switch, peerid, peerinfo, stream/connection, multiaddress,
-  crypto/crypto, transports/[transport, tcptransport],
-  muxers/[muxer, mplex/mplex],
-  protocols/[identify, secure/secure]
+import options, tables
+import chronos
+import libp2p
 
-import
-  protocols/secure/noise,
-  protocols/secure/secio
+import connmanager
 
-export
-  switch, peerid, peerinfo, connection, multiaddress, crypto
+export libp2p
 
 type
   SecureProtocol* {.pure.} = enum
     Noise,
-    Secio
+    Secio # deprecated
 
 proc newStandardSwitch*(privKey = none(PrivateKey),
                         address = MultiAddress.init("/ip4/127.0.0.1/tcp/0").tryGet(),
@@ -54,7 +48,7 @@ proc newStandardSwitch*(privKey = none(PrivateKey),
     of SecureProtocol.Noise:
       secureManagerInstances &= newNoise(rng, seckey).Secure
     of SecureProtocol.Secio:
-      secureManagerInstances &= newSecio(rng, seckey).Secure
+      quit("Secio is deprecated!") # use of secio is unsafe
 
   let switch = newSwitch(
     peerInfo,

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -324,8 +324,7 @@ suite "GossipSub":
     let
       nodes = generateNodes(
         2,
-        gossip = true,
-        secureManagers = [SecureProtocol.Noise])
+        gossip = true)
 
       # start switches
       nodesFut = await allFinished(
@@ -372,8 +371,7 @@ suite "GossipSub":
     let
       nodes = generateNodes(
         2,
-        gossip = true,
-        secureManagers = [SecureProtocol.Secio])
+        gossip = true)
 
       # start switches
       nodesFut = await allFinished(
@@ -437,8 +435,7 @@ suite "GossipSub":
     let
       nodes = generateNodes(
         2,
-        gossip = true,
-        secureManagers = [SecureProtocol.Secio])
+        gossip = true)
 
       # start switches
       nodesFut = await allFinished(
@@ -509,8 +506,7 @@ suite "GossipSub":
     let
       nodes = generateNodes(
         2,
-        gossip = true,
-        secureManagers = [SecureProtocol.Secio])
+        gossip = true)
 
       # start switches
       nodesFut = await allFinished(

--- a/tests/testinterop.nim
+++ b/tests/testinterop.nim
@@ -69,9 +69,7 @@ proc testPubSubDaemonPublish(gossip: bool = false, count: int = 1) {.async.} =
 
   let daemonNode = await newDaemonApi(flags)
   let daemonPeer = await daemonNode.identity()
-  let nativeNode = newStandardSwitch(
-    secureManagers = [SecureProtocol.Noise],
-    outTimeout = 5.minutes)
+  let nativeNode = newStandardSwitch(outTimeout = 5.minutes)
 
   let pubsub = if gossip:
       GossipSub.init(
@@ -135,9 +133,7 @@ proc testPubSubNodePublish(gossip: bool = false, count: int = 1) {.async.} =
 
   let daemonNode = await newDaemonApi(flags)
   let daemonPeer = await daemonNode.identity()
-  let nativeNode = newStandardSwitch(
-    secureManagers = [SecureProtocol.Noise],
-    outTimeout = 5.minutes)
+  let nativeNode = newStandardSwitch(outTimeout = 5.minutes)
 
   let pubsub = if gossip:
       GossipSub.init(

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -466,13 +466,11 @@ suite "Switch":
     let privKey = PrivateKey.random(rng[]).tryGet()
     let switch2 = newStandardSwitch(
       privKey = some(privKey),
-      rng = rng,
-      )
+      rng = rng)
 
     let switch3 = newStandardSwitch(
       privKey = some(privKey),
-      rng = rng,
-      )
+      rng = rng)
 
     var step = 0
     var kinds: set[PeerEventKind]
@@ -548,8 +546,7 @@ suite "Switch":
         done.complete()
 
     switches.add(newStandardSwitch(
-        rng = rng,
-        ))
+        rng = rng))
 
     switches[0].addConnEventHandler(hook, ConnEventKind.Connected)
     switches[0].addConnEventHandler(hook, ConnEventKind.Disconnected)
@@ -557,8 +554,7 @@ suite "Switch":
 
     switches.add(newStandardSwitch(
       privKey = some(peerInfo.privateKey),
-      rng = rng,
-      ))
+      rng = rng))
     onConnect = switches[1].connect(switches[0].peerInfo)
     await onConnect
 
@@ -597,8 +593,7 @@ suite "Switch":
         conns.dec
 
     switches.add(newStandardSwitch(
-        rng = rng,
-        ))
+        rng = rng))
 
     switches[0].addConnEventHandler(hook, ConnEventKind.Connected)
     switches[0].addConnEventHandler(hook, ConnEventKind.Disconnected)
@@ -607,8 +602,7 @@ suite "Switch":
     for i in 1..5:
       switches.add(newStandardSwitch(
         privKey = some(peerInfo.privateKey),
-        rng = rng,
-        ))
+        rng = rng))
       onConnect = switches[i].connect(switches[0].peerInfo)
       await onConnect
 

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -140,10 +140,10 @@ suite "Switch":
     testProto.codec = TestCodec
     testProto.handler = handle
 
-    let switch1 = newStandardSwitch(secureManagers = [SecureProtocol.Secio])
+    let switch1 = newStandardSwitch()
     switch1.mount(testProto)
 
-    let switch2 = newStandardSwitch(secureManagers = [SecureProtocol.Secio])
+    let switch2 = newStandardSwitch()
     var awaiters: seq[Future[void]]
     awaiters.add(await switch1.start())
     awaiters.add(await switch2.start())
@@ -215,8 +215,8 @@ suite "Switch":
   asyncTest "e2e should not leak on peer disconnect":
     var awaiters: seq[Future[void]]
 
-    let switch1 = newStandardSwitch(secureManagers = [SecureProtocol.Secio])
-    let switch2 = newStandardSwitch(secureManagers = [SecureProtocol.Secio])
+    let switch1 = newStandardSwitch()
+    let switch2 = newStandardSwitch()
     awaiters.add(await switch1.start())
     awaiters.add(await switch2.start())
 
@@ -241,8 +241,8 @@ suite "Switch":
   asyncTest "e2e should trigger connection events (remote)":
     var awaiters: seq[Future[void]]
 
-    let switch1 = newStandardSwitch(secureManagers = [SecureProtocol.Secio])
-    let switch2 = newStandardSwitch(secureManagers = [SecureProtocol.Secio])
+    let switch1 = newStandardSwitch()
+    let switch2 = newStandardSwitch()
 
     var step = 0
     var kinds: set[ConnEventKind]
@@ -296,8 +296,8 @@ suite "Switch":
   asyncTest "e2e should trigger connection events (local)":
     var awaiters: seq[Future[void]]
 
-    let switch1 = newStandardSwitch(secureManagers = [SecureProtocol.Secio])
-    let switch2 = newStandardSwitch(secureManagers = [SecureProtocol.Secio])
+    let switch1 = newStandardSwitch()
+    let switch2 = newStandardSwitch()
 
     var step = 0
     var kinds: set[ConnEventKind]
@@ -351,8 +351,8 @@ suite "Switch":
   asyncTest "e2e should trigger peer events (remote)":
     var awaiters: seq[Future[void]]
 
-    let switch1 = newStandardSwitch(secureManagers = [SecureProtocol.Secio])
-    let switch2 = newStandardSwitch(secureManagers = [SecureProtocol.Secio])
+    let switch1 = newStandardSwitch()
+    let switch2 = newStandardSwitch()
 
     var step = 0
     var kinds: set[PeerEventKind]
@@ -405,8 +405,8 @@ suite "Switch":
   asyncTest "e2e should trigger peer events (local)":
     var awaiters: seq[Future[void]]
 
-    let switch1 = newStandardSwitch(secureManagers = [SecureProtocol.Secio])
-    let switch2 = newStandardSwitch(secureManagers = [SecureProtocol.Secio])
+    let switch1 = newStandardSwitch()
+    let switch2 = newStandardSwitch()
 
     var step = 0
     var kinds: set[PeerEventKind]
@@ -459,7 +459,7 @@ suite "Switch":
   asyncTest "e2e should trigger peer events only once per peer":
     var awaiters: seq[Future[void]]
 
-    let switch1 = newStandardSwitch(secureManagers = [SecureProtocol.Secio])
+    let switch1 = newStandardSwitch()
 
     let rng = newRng()
     # use same private keys to emulate two connection from same peer
@@ -467,12 +467,12 @@ suite "Switch":
     let switch2 = newStandardSwitch(
       privKey = some(privKey),
       rng = rng,
-      secureManagers = [SecureProtocol.Secio])
+      )
 
     let switch3 = newStandardSwitch(
       privKey = some(privKey),
       rng = rng,
-      secureManagers = [SecureProtocol.Secio])
+      )
 
     var step = 0
     var kinds: set[PeerEventKind]
@@ -549,7 +549,7 @@ suite "Switch":
 
     switches.add(newStandardSwitch(
         rng = rng,
-        secureManagers = [SecureProtocol.Secio]))
+        ))
 
     switches[0].addConnEventHandler(hook, ConnEventKind.Connected)
     switches[0].addConnEventHandler(hook, ConnEventKind.Disconnected)
@@ -558,7 +558,7 @@ suite "Switch":
     switches.add(newStandardSwitch(
       privKey = some(peerInfo.privateKey),
       rng = rng,
-      secureManagers = [SecureProtocol.Secio]))
+      ))
     onConnect = switches[1].connect(switches[0].peerInfo)
     await onConnect
 
@@ -598,7 +598,7 @@ suite "Switch":
 
     switches.add(newStandardSwitch(
         rng = rng,
-        secureManagers = [SecureProtocol.Secio]))
+        ))
 
     switches[0].addConnEventHandler(hook, ConnEventKind.Connected)
     switches[0].addConnEventHandler(hook, ConnEventKind.Disconnected)
@@ -608,7 +608,7 @@ suite "Switch":
       switches.add(newStandardSwitch(
         privKey = some(peerInfo.privateKey),
         rng = rng,
-        secureManagers = [SecureProtocol.Secio]))
+        ))
       onConnect = switches[i].connect(switches[0].peerInfo)
       await onConnect
 


### PR DESCRIPTION
Note, as the title state, this removes secio usage and would `quit` if it's attempted to be used with `newStandardSwitch` - maybe quitting is a bit too drastic?