### PR TITLE
add ping protocol

### DIFF
--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -7,8 +7,7 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import std/random
-import chronos, chronicles
+import chronos, chronicles, bearssl
 import ../protobuf/minprotobuf,
        ../peerinfo,
        ../stream/connection,
@@ -36,9 +35,10 @@ type
 
   Ping* = ref object of LPProtocol
     pingHandler*: PingHandler
+    rng: ref BrHmacDrbgContext
 
 proc newPing*(handler: PingHandler = nil): Ping =
-  let ping = Ping(pinghandler: handler)
+  let ping = Ping(pinghandler: handler, rng: newRng())
   ping.init()
   ping
 
@@ -73,8 +73,7 @@ proc ping*(
     randomBuf: array[PingSize, byte]
     resultBuf: array[PingSize, byte]
 
-  for i in 0..<PingSize:
-    randomBuf[i] = byte.rand()
+  p.rng[].brHmacDrbgGenerate(randomBuf)
 
   let startTime = Moment.now()
 

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -37,7 +37,7 @@ type
     pingHandler*: PingHandler
     rng: ref BrHmacDrbgContext
 
-proc init*(T: typedesc[Ping], handler: PingHandler = nil, rng: ref BrHmacDrbgContext = newRng()): T =
+proc new*(T: typedesc[Ping], handler: PingHandler = nil, rng: ref BrHmacDrbgContext = newRng()): T =
   let ping = Ping(pinghandler: handler, rng: rng)
   ping.init()
   ping
@@ -48,6 +48,7 @@ method init*(p: Ping) =
       trace "handling ping", conn
       var buf: array[PingSize, byte]
       await conn.readExactly(addr buf[0], PingSize)
+      trace "echoing ping", conn
       await conn.write(addr buf[0], PingSize)
       if not isNil(p.pingHandler):
         await p.pingHandler(conn.peerInfo)

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -59,9 +59,14 @@ method init*(p: Ping) =
   p.handler = handle
   p.codec = PingCodec
 
-proc ping*(p: Ping,
-           conn: Connection,
-           ): Future[Duration] {.async, gcsafe.} =
+proc ping*(
+  p: Ping,
+  conn: Connection,
+  ): Future[Duration] {.async, gcsafe.} =
+  ## Sends ping to `conn`
+  ## Returns the delay
+  ##
+
   trace "initiating ping", conn
 
   var

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -37,8 +37,8 @@ type
     pingHandler*: PingHandler
     rng: ref BrHmacDrbgContext
 
-proc newPing*(handler: PingHandler = nil): Ping =
-  let ping = Ping(pinghandler: handler, rng: newRng())
+proc init*(T: typedesc[Ping], handler: PingHandler = nil, rng: ref BrHmacDrbgContext = newRng()): T =
+  let ping = Ping(pinghandler: handler, rng: rng)
   ping.init()
   ping
 

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -1,0 +1,81 @@
+## Nim-LibP2P
+## Copyright (c) 2021 Status Research & Development GmbH
+## Licensed under either of
+##  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+##  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+## at your option.
+## This file may not be copied, modified, or distributed except according to
+## those terms.
+
+import options, random
+import chronos, chronicles
+import ../protobuf/minprotobuf,
+       ../peerinfo,
+       ../stream/connection,
+       ../peerid,
+       ../crypto/crypto,
+       ../multiaddress,
+       ../protocols/protocol,
+       ../errors
+
+logScope:
+  topics = "libp2p ping"
+
+const
+  PingCodec* = "/ipfs/ping/1.0.0"
+  PingSize = 32
+
+type
+  PingError* = object of LPError
+  WrongPingAckError* = object of LPError
+
+  Ping* = ref object of LPProtocol
+
+proc newPing*(): Ping =
+  new result
+  result.init()
+
+method init*(p: Ping) =
+  proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
+    try:
+      trace "handling ping", conn
+      var buf: array[PingSize, byte]
+      await conn.readExactly(addr buf[0], PingSize)
+      await conn.write(addr buf[0], PingSize)
+    except CancelledError as exc:
+      raise exc
+    except CatchableError as exc:
+      trace "exception in ping handler", exc = exc.msg, conn
+
+  p.handler = handle
+  p.codec = PingCodec
+
+proc ping*(p: Ping,
+           conn: Connection,
+           ): Future[Duration] {.async, gcsafe.} =
+  trace "initiating ping", conn
+
+  var
+    randomBuf: array[PingSize, byte]
+    resultBuf: array[PingSize, byte]
+
+  for i in 0..<PingSize:
+    randomBuf[i] = byte.rand()
+
+  let startTime = Moment.now()
+
+  trace "sending ping", conn
+  await conn.write(addr randomBuf[0], randomBuf.len)
+
+  await conn.readExactly(addr resultBuf[0], PingSize)
+
+  let responseTime = Moment.now() - startTime
+
+  trace "got ping response", conn, responseTime
+
+  for i in 0..<randomBuf.len:
+    if randomBuf[i] != resultBuf[i]:
+      raise newException(WrongPingAckError, "Incorrect ping data from peer!")
+
+  trace "valid ping response", conn
+  return responseTime

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -7,7 +7,7 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-import options, random
+import std/random
 import chronos, chronicles
 import ../protobuf/minprotobuf,
        ../peerinfo,
@@ -38,9 +38,9 @@ type
     pingHandler*: PingHandler
 
 proc newPing*(handler: PingHandler = nil): Ping =
-  new result
-  result.pingHandler = handler
-  result.init()
+  let ping = Ping(pinghandler: handler)
+  ping.init()
+  ping
 
 method init*(p: Ping) =
   proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
@@ -83,13 +83,13 @@ proc ping*(
 
   await conn.readExactly(addr resultBuf[0], PingSize)
 
-  let responseTime = Moment.now() - startTime
+  let responseDur = Moment.now() - startTime
 
-  trace "got ping response", conn, responseTime
+  trace "got ping response", conn, responseDur
 
   for i in 0..<randomBuf.len:
     if randomBuf[i] != resultBuf[i]:
       raise newException(WrongPingAckError, "Incorrect ping data from peer!")
 
   trace "valid ping response", conn
-  return responseTime
+  return responseDur

--- a/tests/testping.nim
+++ b/tests/testping.nim
@@ -42,8 +42,8 @@ suite "Ping":
 
       proc handlePing(peer: PeerInfo) {.async, gcsafe, closure.} =
         inc pingReceivedCount
-      pingProto1 = newPing()
-      pingProto2 = newPing(handlePing)
+      pingProto1 = Ping.init()
+      pingProto2 = Ping.init(handlePing)
 
       msListen = newMultistream()
       msDial = newMultistream()

--- a/tests/testping.nim
+++ b/tests/testping.nim
@@ -1,0 +1,72 @@
+import options, bearssl
+import chronos, strutils
+import ../libp2p/[protocols/identify,
+                  protocols/ping,
+                  multiaddress,
+                  peerinfo,
+                  peerid,
+                  stream/connection,
+                  multistream,
+                  transports/transport,
+                  transports/tcptransport,
+                  crypto/crypto,
+                  upgrademngrs/upgrade]
+import ./helpers
+
+when defined(nimHasUsed): {.used.}
+
+suite "Ping":
+  teardown:
+    checkTrackers()
+
+  suite "handle ping message":
+    var
+      ma {.threadvar.}: MultiAddress
+      remoteSecKey {.threadvar.}: PrivateKey
+      remotePeerInfo {.threadvar.}: PeerInfo
+      serverFut {.threadvar.}: Future[void]
+      acceptFut {.threadvar.}: Future[void]
+      pingProto1 {.threadvar.}: Ping
+      pingProto2 {.threadvar.}: Ping
+      transport1 {.threadvar.}: Transport
+      transport2 {.threadvar.}: Transport
+      msListen {.threadvar.}: MultistreamSelect
+      msDial {.threadvar.}: MultistreamSelect
+      conn {.threadvar.}: Connection
+
+    asyncSetup:
+      ma = Multiaddress.init("/ip4/0.0.0.0/tcp/0").tryGet()
+      remoteSecKey = PrivateKey.random(ECDSA, rng[]).get()
+      remotePeerInfo = PeerInfo.init(
+        remoteSecKey, [ma], ["/test/proto1/1.0.0", "/test/proto2/1.0.0"])
+
+      transport1 = TcpTransport.init(upgrade = Upgrade())
+      transport2 = TcpTransport.init(upgrade = Upgrade())
+
+      pingProto1 = newPing()
+      pingProto2 = newPing()
+
+      msListen = newMultistream()
+      msDial = newMultistream()
+
+    asyncTeardown:
+      await conn.close()
+      await acceptFut
+      await transport1.stop()
+      await serverFut
+      await transport2.stop()
+
+    asyncTest "simple ping":
+      msListen.addHandler(PingCodec, pingProto1)
+      serverFut = transport1.start(ma)
+      proc acceptHandler(): Future[void] {.async, gcsafe.} =
+        let c = await transport1.accept()
+        await msListen.handle(c)
+
+      acceptFut = acceptHandler()
+      conn = await transport2.dial(transport1.ma)
+
+      discard await msDial.select(conn, PingCodec)
+      let time = await pingProto2.ping(conn)
+
+      check not time.isZero()


### PR DESCRIPTION
closes #567 

Simple ping protocol implemented.
This is a low level version (eg, you can launch a ping using the `ping` proc, and it will reply to ping), like the JS one

It would be possible to add more functionality :
- Waku keepalive seems to use a handler, the `newPing` function could take a handler without much issue if required EDIT: done
- In rust, it looks like the libp2p bundles a Handler which ping automatically