### PR TITLE
Change newXXXX procs to XXXX.new

### DIFF
--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -59,7 +59,7 @@ proc createSwitch(ma: MultiAddress): (Switch, PeerInfo) =
   let mplexProvider = newMuxerProvider(createMplex, MplexCodec) # create multiplexer
   let transports = @[Transport(newTransport(TcpTransport))] # add all transports (tcp only for now, but can be anything in the future)
   let muxers = {MplexCodec: mplexProvider}.toTable() # add all muxers
-  let secureManagers = {SecioCodec: Secure(newSecio(seckey))}.toTable() # setup the secio and any other secure provider
+  let secureManagers = {SecioCodec: Secure(Secio.new(seckey))}.toTable() # setup the secio and any other secure provider
 
   # create the switch
   let switch = newSwitch(peerInfo,

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -157,7 +157,7 @@ proc build*(b: SwitchBuilder): Switch
   let
     identify = newIdentify(peerInfo)
     connManager = ConnManager.init(b.maxConnsPerPeer, b.maxConnections, b.maxIn, b.maxOut)
-    ms = newMultistream()
+    ms = MultistreamSelect.new()
     muxedUpgrade = MuxedUpgrade.init(identify, muxers, secureManagerInstances, connManager, ms)
 
   let

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -138,7 +138,7 @@ proc build*(b: SwitchBuilder): Switch
   var
     secureManagerInstances: seq[Secure]
   if SecureProtocol.Noise in b.secureManagers:
-    secureManagerInstances.add(newNoise(b.rng, seckey).Secure)
+    secureManagerInstances.add(Noise.new(b.rng, seckey).Secure)
 
   let
     peerInfo = PeerInfo.init(

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -151,7 +151,7 @@ proc build*(b: SwitchBuilder): Switch
     muxers = block:
       var muxers: Table[string, MuxerProvider]
       if b.mplexOpts.enable:
-        muxers[MplexCodec] = newMuxerProvider(b.mplexOpts.newMuxer, MplexCodec)
+        muxers[MplexCodec] = MuxerProvider.new(b.mplexOpts.newMuxer, MplexCodec)
       muxers
 
   let

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -155,7 +155,7 @@ proc build*(b: SwitchBuilder): Switch
       muxers
 
   let
-    identify = newIdentify(peerInfo)
+    identify = Identify.new(peerInfo)
     connManager = ConnManager.init(b.maxConnsPerPeer, b.maxConnections, b.maxIn, b.maxOut)
     ms = MultistreamSelect.new()
     muxedUpgrade = MuxedUpgrade.init(identify, muxers, secureManagerInstances, connManager, ms)

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -40,9 +40,11 @@ type
     handlers*: seq[HandlerHolder]
     codec*: string
 
-proc newMultistream*(): MultistreamSelect =
-  new result
-  result.codec = MSCodec
+proc new*(T: typedesc[MultistreamSelect]): T =
+  T(codec: MSCodec)
+
+proc newMultistream*(): MultistreamSelect {.deprecated: "use MultistreamSelect.new".} =
+  MultistreamSelect.new()
 
 template validateSuffix(str: string): untyped =
     if str.endsWith("\n"):

--- a/libp2p/muxers/muxer.nim
+++ b/libp2p/muxers/muxer.nim
@@ -48,11 +48,18 @@ method newStream*(m: Muxer, name: string = "", lazy: bool = false):
 method close*(m: Muxer) {.base, async, gcsafe.} = discard
 method handle*(m: Muxer): Future[void] {.base, async, gcsafe.} = discard
 
-proc newMuxerProvider*(creator: MuxerConstructor, codec: string): MuxerProvider {.gcsafe.} =
-  new result
-  result.newMuxer = creator
-  result.codec = codec
-  result.init()
+proc new*(
+  T: typedesc[MuxerProvider],
+  creator: MuxerConstructor,
+  codec: string): T {.gcsafe.} =
+
+  let muxerProvider = T(newMuxer: creator)
+  muxerProvider.codec = codec
+  muxerProvider.init()
+  muxerProvider
+
+proc newMuxerProvider*(creator: MuxerConstructor, codec: string): MuxerProvider {.gcsafe, deprecated: "use MuxerProvider.new".} =
+  MuxerProvider.new(creator, codec)
 
 method init(c: MuxerProvider) =
   proc handler(conn: Connection, proto: string) {.async, gcsafe, closure.} =

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -109,10 +109,13 @@ proc decodeMsg*(buf: seq[byte]): Option[IdentifyInfo] =
     trace "decodeMsg: failed to decode received message"
     none[IdentifyInfo]()
 
-proc newIdentify*(peerInfo: PeerInfo): Identify =
-  new result
-  result.peerInfo = peerInfo
-  result.init()
+proc new*(T: typedesc[Identify], peerInfo: PeerInfo): T =
+  let identify = T(peerInfo: peerInfo)
+  identify.init()
+  identify
+
+proc newIdentify*(peerInfo: PeerInfo): Identify {.deprecated: "use Identify.new".} =
+  Identify.new(peerInfo)
 
 method init*(p: Identify) =
   proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -283,7 +283,7 @@ proc getOrCreatePeer*(
     p.onPubSubPeerEvent(peer, event)
 
   # create new pubsub peer
-  let pubSubPeer = newPubSubPeer(peerId, getConn, dropConn, onEvent, protos[0])
+  let pubSubPeer = PubSubPeer.new(peerId, getConn, dropConn, onEvent, protos[0])
   debug "created new pubsub peer", peerId
 
   p.peers[peerId] = pubSubPeer

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -274,15 +274,33 @@ proc send*(p: PubSubPeer, msg: RPCMsg, anonymize: bool) {.raises: [Defect].} =
 
   p.sendEncoded(encoded)
 
-proc newPubSubPeer*(peerId: PeerID,
-                    getConn: GetConn,
-                    dropConn: DropConn,
-                    onEvent: OnEvent,
-                    codec: string): PubSubPeer =
-  PubSubPeer(
+proc new*(
+  T: typedesc[PubSubPeer],
+  peerId: PeerID,
+  getConn: GetConn,
+  dropConn: DropConn,
+  onEvent: OnEvent,
+  codec: string): T =
+
+  T(
     getConn: getConn,
     dropConn: dropConn,
     onEvent: onEvent,
     codec: codec,
     peerId: peerId,
+  )
+
+proc newPubSubPeer*(
+  peerId: PeerID,
+  getConn: GetConn,
+  dropConn: DropConn,
+  onEvent: OnEvent,
+  codec: string): PubSubPeer {.deprecated: "use PubSubPeer.new".} =
+
+  PubSubPeer.new(
+    peerId,
+    getConn,
+    dropConn,
+    onEvent,
+    codec
   )

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -595,11 +595,12 @@ method init*(p: Noise) {.gcsafe.} =
   procCall Secure(p).init()
   p.codec = NoiseCodec
 
-proc newNoise*(
-    rng: ref BrHmacDrbgContext,
-    privateKey: PrivateKey,
-    outgoing: bool = true,
-    commonPrologue: seq[byte] = @[]): Noise =
+proc new*(
+  T: typedesc[Noise],
+  rng: ref BrHmacDrbgContext,
+  privateKey: PrivateKey,
+  outgoing: bool = true,
+  commonPrologue: seq[byte] = @[]): T =
 
   let pkBytes = privateKey
   .getKey()
@@ -617,4 +618,11 @@ proc newNoise*(
   )
 
   noise.init()
-  return noise
+  noise
+
+proc newNoise*(
+  rng: ref BrHmacDrbgContext,
+  privateKey: PrivateKey,
+  outgoing: bool = true,
+  commonPrologue: seq[byte] = @[]): Noise {.deprecated: "use Noise.new".}=
+  Noise.new(rng, privateKey, outgoing, commonPrologue)

--- a/libp2p/protocols/secure/plaintext.nim
+++ b/libp2p/protocols/secure/plaintext.nim
@@ -25,6 +25,10 @@ method init(p: PlainText) {.gcsafe.} =
   p.codec = PlainTextCodec
   p.handler = handle
 
-proc newPlainText*(): PlainText =
-  new result
-  result.init()
+proc new*(T: typedesc[PlainText]): T =
+  let plainText = T()
+  plainText.init()
+  plainText
+
+proc newPlainText*(): PlainText {.deprecated: "use PlainText.new".} =
+  PlainText.new()

--- a/libp2p/protocols/secure/secio.nim
+++ b/libp2p/protocols/secure/secio.nim
@@ -36,7 +36,7 @@ const
   SecioHashes = "SHA256,SHA512"
 
 type
-  Secio = ref object of Secure
+  Secio* = ref object of Secure
     rng: ref BrHmacDrbgContext
     localPrivateKey: PrivateKey
     localPublicKey: PublicKey
@@ -431,16 +431,23 @@ method init(s: Secio) {.gcsafe.} =
   procCall Secure(s).init()
   s.codec = SecioCodec
 
-proc newSecio*(rng: ref BrHmacDrbgContext, localPrivateKey: PrivateKey): Secio =
+proc new*(
+  T: typedesc[Secio],
+  rng: ref BrHmacDrbgContext,
+  localPrivateKey: PrivateKey): T =
   let pkRes = localPrivateKey.getKey()
   if pkRes.isErr:
     raise newException(Defect, "Can't fetch local private key")
 
-  result = Secio(
+  let secio = Secio(
     rng: rng,
     localPrivateKey: localPrivateKey,
     localPublicKey: localPrivateKey
       .getKey()
       .expect("Can't fetch local private key"),
   )
-  result.init()
+  secio.init()
+  secio
+
+proc newSecio*(rng: ref BrHmacDrbgContext, localPrivateKey: PrivateKey): Secio {.deprecated: "use Secio.new".} =
+  Secio.new(rng, localPrivateKey)

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -58,10 +58,17 @@ method initStream*(s: BufferStream) =
 
   trace "BufferStream created", s
 
-proc newBufferStream*(timeout: Duration = DefaultConnectionTimeout): BufferStream =
-  new result
-  result.timeout = timeout
-  result.initStream()
+proc new*(
+  T: typedesc[BufferStream],
+  timeout: Duration = DefaultConnectionTimeout): T =
+
+  let bufferStream = T(timeout: timeout)
+  bufferStream.initStream()
+  bufferStream
+
+proc newBufferStream*(
+  timeout: Duration = DefaultConnectionTimeout): BufferStream {.deprecated: "use BufferStream.new".} =
+  return BufferStream.new(timeout)
 
 method pushData*(s: BufferStream, data: seq[byte]) {.base, async.} =
   ## Write bytes to internal read buffer, use this to fill up the

--- a/libp2p/upgrademngrs/muxedupgrade.nim
+++ b/libp2p/upgrademngrs/muxedupgrade.nim
@@ -109,7 +109,7 @@ method upgradeIncoming*(
   self: MuxedUpgrade,
   incomingConn: Connection) {.async, gcsafe.} = # noraises
   trace "Upgrading incoming connection", incomingConn
-  let ms = newMultistream()
+  let ms = MultistreamSelect.new()
 
   # secure incoming connections
   proc securedHandler(conn: Connection,

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -74,10 +74,13 @@ type
 method write*(s: TestBufferStream, msg: seq[byte]): Future[void] =
   s.writeHandler(msg)
 
-proc newBufferStream*(writeHandler: WriteHandler): TestBufferStream =
-  new result
-  result.writeHandler = writeHandler
-  result.initStream()
+proc new*(T: typedesc[TestBufferStream], writeHandler: WriteHandler): T =
+  let testBufferStream = T(writeHandler: writeHandler)
+  testBufferStream.initStream()
+  testBufferStream
+
+proc newBufferStream*(writeHandler: WriteHandler): TestBufferStream {.deprecated: "use TestBufferStream.new".}=
+  TestBufferStream.new(writeHandler)
 
 proc checkExpiringInternal(cond: proc(): bool {.raises: [Defect].} ): Future[bool] {.async, gcsafe.} =
   {.gcsafe.}:

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -25,7 +25,7 @@ proc getPubSubPeer(p: TestGossipSub, peerId: PeerID): PubSubPeer =
   proc dropConn(peer: PubSubPeer) =
     discard # we don't care about it here yet
 
-  let pubSubPeer = newPubSubPeer(peerId, getConn, dropConn, nil, GossipSubCodec)
+  let pubSubPeer = PubSubPeer.new(peerId, getConn, dropConn, nil, GossipSubCodec)
   debug "created new pubsub peer", peerId
 
   p.peers[peerId] = pubSubPeer

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -56,7 +56,7 @@ suite "GossipSub internal":
     var conns = newSeq[Connection]()
     gossipSub.gossipsub[topic] = initHashSet[PubSubPeer]()
     for i in 0..<15:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -97,7 +97,7 @@ suite "GossipSub internal":
     var conns = newSeq[Connection]()
     gossipSub.gossipsub[topic] = initHashSet[PubSubPeer]()
     for i in 0..<15:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -123,7 +123,7 @@ suite "GossipSub internal":
     gossipSub.gossipsub[topic] = initHashSet[PubSubPeer]()
     var scoreLow = -11'f64
     for i in 0..<15:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -153,7 +153,7 @@ suite "GossipSub internal":
     var conns = newSeq[Connection]()
     gossipSub.gossipsub[topic] = initHashSet[PubSubPeer]()
     for i in 0..<15:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get())
       conn.peerInfo = peerInfo
@@ -180,7 +180,7 @@ suite "GossipSub internal":
 
     var conns = newSeq[Connection]()
     for i in 0..<15:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       var peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -209,7 +209,7 @@ suite "GossipSub internal":
 
     var conns = newSeq[Connection]()
     for i in 0..<6:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get())
       conn.peerInfo = peerInfo
@@ -243,7 +243,7 @@ suite "GossipSub internal":
 
     var conns = newSeq[Connection]()
     for i in 0..<6:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -277,7 +277,7 @@ suite "GossipSub internal":
 
     # generate mesh and fanout peers
     for i in 0..<30:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -291,7 +291,7 @@ suite "GossipSub internal":
 
     # generate gossipsub (free standing) peers
     for i in 0..<15:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -302,7 +302,7 @@ suite "GossipSub internal":
     # generate messages
     var seqno = 0'u64
     for i in 0..5:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -335,7 +335,7 @@ suite "GossipSub internal":
     gossipSub.gossipsub[topic] = initHashSet[PubSubPeer]()
     var conns = newSeq[Connection]()
     for i in 0..<30:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -349,7 +349,7 @@ suite "GossipSub internal":
     # generate messages
     var seqno = 0'u64
     for i in 0..5:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -375,7 +375,7 @@ suite "GossipSub internal":
     gossipSub.gossipsub[topic] = initHashSet[PubSubPeer]()
     var conns = newSeq[Connection]()
     for i in 0..<30:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -390,7 +390,7 @@ suite "GossipSub internal":
     # generate messages
     var seqno = 0'u64
     for i in 0..5:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -416,7 +416,7 @@ suite "GossipSub internal":
     gossipSub.fanout[topic] = initHashSet[PubSubPeer]()
     var conns = newSeq[Connection]()
     for i in 0..<30:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -431,7 +431,7 @@ suite "GossipSub internal":
     # generate messages
     var seqno = 0'u64
     for i in 0..5:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -454,7 +454,7 @@ suite "GossipSub internal":
     let topic = "foobar"
     var conns = newSeq[Connection]()
     for i in 0..<30:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -464,7 +464,7 @@ suite "GossipSub internal":
     # generate messages
     var seqno = 0'u64
     for i in 0..5:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -488,7 +488,7 @@ suite "GossipSub internal":
     let topic = "foobar"
     var conns = newSeq[Connection]()
     for i in 0..<30:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -521,7 +521,7 @@ suite "GossipSub internal":
       tooManyTopics &= "topic" & $i
     let lotOfSubs = RPCMsg.withSubs(tooManyTopics, true)
 
-    let conn = newBufferStream(noop)
+    let conn = TestBufferStream.new(noop)
     let peerInfo = randomPeerInfo()
     conn.peerInfo = peerInfo
     let peer = gossipSub.getPubSubPeer(peerInfo.peerId)
@@ -544,7 +544,7 @@ suite "GossipSub internal":
     var conns = newSeq[Connection]()
     gossipSub.gossipsub[topic] = initHashSet[PubSubPeer]()
     for i in 0..<15:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -575,7 +575,7 @@ suite "GossipSub internal":
     var conns = newSeq[Connection]()
     gossipSub.gossipsub[topic] = initHashSet[PubSubPeer]()
     for i in 0..<15:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -617,7 +617,7 @@ suite "GossipSub internal":
     var conns = newSeq[Connection]()
     gossipSub.gossipsub[topic] = initHashSet[PubSubPeer]()
     for i in 0..<6:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conn.transportDir = Direction.In
       conns &= conn
       let peerInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get())
@@ -629,7 +629,7 @@ suite "GossipSub internal":
       gossipSub.mesh[topic].incl(peer)
 
     for i in 0..<7:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conn.transportDir = Direction.Out
       conns &= conn
       let peerInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get())
@@ -665,7 +665,7 @@ suite "GossipSub internal":
     gossipSub.gossipsub[topic] = initHashSet[PubSubPeer]()
     gossipSub.mesh[topic] = initHashSet[PubSubPeer]()
     for i in 0..<30:
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -676,7 +676,7 @@ suite "GossipSub internal":
 
     block:
       # should ignore no budget peer
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -692,7 +692,7 @@ suite "GossipSub internal":
 
     block:
       # given duplicate ihave should generate only one iwant
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo
@@ -707,7 +707,7 @@ suite "GossipSub internal":
 
     block:
       # given duplicate iwant should generate only one message
-      let conn = newBufferStream(noop)
+      let conn = TestBufferStream.new(noop)
       conns &= conn
       let peerInfo = randomPeerInfo()
       conn.peerInfo = peerInfo

--- a/tests/testbufferstream.nim
+++ b/tests/testbufferstream.nim
@@ -13,7 +13,7 @@ suite "BufferStream":
     check getTracker(BufferStreamTrackerName).isLeaked() == false
 
   asyncTest "push data to buffer":
-    let buff = newBufferStream()
+    let buff = BufferStream.new()
     check buff.len == 0
     var data = "12345"
     await buff.pushData(data.toBytes())
@@ -21,7 +21,7 @@ suite "BufferStream":
     await buff.close()
 
   asyncTest "push and wait":
-    let buff = newBufferStream()
+    let buff = BufferStream.new()
     check buff.len == 0
 
     let fut0 = buff.pushData("1234".toBytes())
@@ -38,7 +38,7 @@ suite "BufferStream":
     await buff.close()
 
   asyncTest "read with size":
-    let buff = newBufferStream()
+    let buff = BufferStream.new()
     check buff.len == 0
 
     await buff.pushData("12345".toBytes())
@@ -48,7 +48,7 @@ suite "BufferStream":
     await buff.close()
 
   asyncTest "readExactly":
-    let buff = newBufferStream()
+    let buff = BufferStream.new()
     check buff.len == 0
 
     await buff.pushData("12345".toBytes())
@@ -59,7 +59,7 @@ suite "BufferStream":
     await buff.close()
 
   asyncTest "readExactly raises":
-    let buff = newBufferStream()
+    let buff = BufferStream.new()
     check buff.len == 0
 
     await buff.pushData("123".toBytes())
@@ -71,7 +71,7 @@ suite "BufferStream":
       await readFut
 
   asyncTest "readOnce":
-    let buff = newBufferStream()
+    let buff = BufferStream.new()
     check buff.len == 0
 
     var data: array[3, byte]
@@ -84,7 +84,7 @@ suite "BufferStream":
     await buff.close()
 
   asyncTest "reads should happen in order":
-    let buff = newBufferStream()
+    let buff = BufferStream.new()
     check buff.len == 0
 
     proc writer1() {.async.} =
@@ -126,7 +126,7 @@ suite "BufferStream":
     await writerFut2
 
   asyncTest "small reads":
-    let buff = newBufferStream()
+    let buff = BufferStream.new()
     check buff.len == 0
 
     var str: string
@@ -152,7 +152,7 @@ suite "BufferStream":
     await buff.close()
 
   asyncTest "read all data after eof":
-    let buff = newBufferStream()
+    let buff = BufferStream.new()
     check buff.len == 0
 
     await buff.pushData("12345".toBytes())
@@ -176,7 +176,7 @@ suite "BufferStream":
     await buff.close() # all data should still be read after close
 
   asyncTest "read more data after eof":
-    let buff = newBufferStream()
+    let buff = BufferStream.new()
     check buff.len == 0
 
     await buff.pushData("12345".toBytes())
@@ -200,7 +200,7 @@ suite "BufferStream":
     await buff.close() # all data should still be read after close
 
   asyncTest "shouldn't get stuck on close":
-    var stream = newBufferStream()
+    var stream = BufferStream.new()
     var
       fut = stream.pushData(toBytes("hello"))
       fut2 = stream.pushData(toBytes("again"))
@@ -214,7 +214,7 @@ suite "BufferStream":
     await stream.close()
 
   asyncTest "no push after close":
-    var stream = newBufferStream()
+    var stream = BufferStream.new()
     await stream.pushData("123".toBytes())
     var data: array[3, byte]
     await stream.readExactly(addr data[0], data.len)
@@ -224,7 +224,7 @@ suite "BufferStream":
       await stream.pushData("123".toBytes())
 
   asyncTest "no concurrent pushes":
-    var stream = newBufferStream()
+    var stream = BufferStream.new()
     await stream.pushData("123".toBytes())
     let push = stream.pushData("123".toBytes())
 

--- a/tests/testconnection.nim
+++ b/tests/testconnection.nim
@@ -6,13 +6,13 @@ import ./helpers
 
 suite "Connection":
   asyncTest "close":
-    var conn = newBufferStream()
+    var conn = BufferStream.new()
     await conn.close()
     check:
       conn.closed == true
 
   asyncTest "parent close":
-    var buf = newBufferStream()
+    var buf = BufferStream.new()
     var conn = buf
 
     await conn.close()
@@ -21,7 +21,7 @@ suite "Connection":
       buf.closed == true
 
   asyncTest "child close":
-    var buf = newBufferStream()
+    var buf = BufferStream.new()
     var conn = buf
 
     await buf.close()

--- a/tests/testidentify.nim
+++ b/tests/testidentify.nim
@@ -45,8 +45,8 @@ suite "Identify":
       identifyProto1 = newIdentify(remotePeerInfo)
       identifyProto2 = newIdentify(remotePeerInfo)
 
-      msListen = newMultistream()
-      msDial = newMultistream()
+      msListen = MultistreamSelect.new()
+      msDial = MultistreamSelect.new()
 
     asyncTeardown:
       await conn.close()

--- a/tests/testidentify.nim
+++ b/tests/testidentify.nim
@@ -42,8 +42,8 @@ suite "Identify":
       transport1 = TcpTransport.init(upgrade = Upgrade())
       transport2 = TcpTransport.init(upgrade = Upgrade())
 
-      identifyProto1 = newIdentify(remotePeerInfo)
-      identifyProto2 = newIdentify(remotePeerInfo)
+      identifyProto1 = Identify.new(remotePeerInfo)
+      identifyProto2 = Identify.new(remotePeerInfo)
 
       msListen = MultistreamSelect.new()
       msDial = MultistreamSelect.new()

--- a/tests/testmultistream.nim
+++ b/tests/testmultistream.nim
@@ -172,13 +172,13 @@ suite "Multistream select":
     checkTrackers()
 
   asyncTest "test select custom proto":
-    let ms = newMultistream()
+    let ms = MultistreamSelect.new()
     let conn = newTestSelectStream()
     check (await ms.select(conn, @["/test/proto/1.0.0"])) == "/test/proto/1.0.0"
     await conn.close()
 
   asyncTest "test handle custom proto":
-    let ms = newMultistream()
+    let ms = MultistreamSelect.new()
     let conn = newTestSelectStream()
 
     var protocol: LPProtocol = new LPProtocol
@@ -193,7 +193,7 @@ suite "Multistream select":
     await ms.handle(conn)
 
   asyncTest "test handle `ls`":
-    let ms = newMultistream()
+    let ms = MultistreamSelect.new()
 
     proc testLsHandler(proto: seq[byte]) {.async, gcsafe.} # forward declaration
     let conn = Connection(newTestLsStream(testLsHandler))
@@ -214,7 +214,7 @@ suite "Multistream select":
     await done.wait(5.seconds)
 
   asyncTest "test handle `na`":
-    let ms = newMultistream()
+    let ms = MultistreamSelect.new()
 
     proc testNaHandler(msg: string): Future[void] {.async, gcsafe.}
     let conn = newTestNaStream(testNaHandler)
@@ -245,7 +245,7 @@ suite "Multistream select":
       await conn.close()
 
     protocol.handler = testHandler
-    let msListen = newMultistream()
+    let msListen = MultistreamSelect.new()
     msListen.addHandler("/test/proto/1.0.0", protocol)
 
     let transport1 = TcpTransport.init(upgrade = Upgrade())
@@ -258,7 +258,7 @@ suite "Multistream select":
 
     let handlerWait = acceptHandler()
 
-    let msDial = newMultistream()
+    let msDial = MultistreamSelect.new()
     let transport2 = TcpTransport.init(upgrade = Upgrade())
     let conn = await transport2.dial(transport1.ma)
 
@@ -279,7 +279,7 @@ suite "Multistream select":
     let
       handlerWait = newFuture[void]()
 
-    let msListen = newMultistream()
+    let msListen = MultistreamSelect.new()
     var protocol: LPProtocol = new LPProtocol
     protocol.handler = proc(conn: Connection, proto: string) {.async, gcsafe.} =
       # never reached
@@ -310,7 +310,7 @@ suite "Multistream select":
         await conn.close()
 
     let acceptFut = acceptHandler()
-    let msDial = newMultistream()
+    let msDial = MultistreamSelect.new()
     let transport2: TcpTransport = TcpTransport.init(upgrade = Upgrade())
     let conn = await transport2.dial(transport1.ma)
 
@@ -337,7 +337,7 @@ suite "Multistream select":
       await conn.close()
 
     protocol.handler = testHandler
-    let msListen = newMultistream()
+    let msListen = MultistreamSelect.new()
     msListen.addHandler("/test/proto/1.0.0", protocol)
 
     let transport1: TcpTransport = TcpTransport.init(upgrade = Upgrade())
@@ -348,7 +348,7 @@ suite "Multistream select":
       await msListen.handle(conn)
 
     let acceptFut = acceptHandler()
-    let msDial = newMultistream()
+    let msDial = MultistreamSelect.new()
     let transport2: TcpTransport = TcpTransport.init(upgrade = Upgrade())
     let conn = await transport2.dial(transport1.ma)
 
@@ -374,7 +374,7 @@ suite "Multistream select":
       await conn.close()
 
     protocol.handler = testHandler
-    let msListen = newMultistream()
+    let msListen = MultistreamSelect.new()
     msListen.addHandler("/test/proto1/1.0.0", protocol)
     msListen.addHandler("/test/proto2/1.0.0", protocol)
 
@@ -386,7 +386,7 @@ suite "Multistream select":
       await msListen.handle(conn)
 
     let acceptFut = acceptHandler()
-    let msDial = newMultistream()
+    let msDial = MultistreamSelect.new()
     let transport2: TcpTransport = TcpTransport.init(upgrade = Upgrade())
     let conn = await transport2.dial(transport1.ma)
 

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -66,7 +66,7 @@ proc createSwitch(ma: MultiAddress; outgoing: bool, secio: bool = false): (Switc
     else:
       [Secure(newNoise(rng, peerInfo.privateKey, outgoing = outgoing))]
     connManager = ConnManager.init()
-    ms = newMultistream()
+    ms = MultistreamSelect.new()
     muxedUpgrade = MuxedUpgrade.init(identify, muxers, secureManagers, connManager, ms)
     transports = @[Transport(TcpTransport.init(upgrade = muxedUpgrade))]
 

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -64,7 +64,7 @@ proc createSwitch(ma: MultiAddress; outgoing: bool, secio: bool = false): (Switc
     secureManagers = if secio:
       [Secure(Secio.new(rng, peerInfo.privateKey))]
     else:
-      [Secure(newNoise(rng, peerInfo.privateKey, outgoing = outgoing))]
+      [Secure(Noise.new(rng, peerInfo.privateKey, outgoing = outgoing))]
     connManager = ConnManager.init()
     ms = MultistreamSelect.new()
     muxedUpgrade = MuxedUpgrade.init(identify, muxers, secureManagers, connManager, ms)
@@ -88,7 +88,7 @@ suite "Noise":
     let
       server = Multiaddress.init("/ip4/0.0.0.0/tcp/0").tryGet()
       serverInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get(), [server])
-      serverNoise = newNoise(rng, serverInfo.privateKey, outgoing = false)
+      serverNoise = Noise.new(rng, serverInfo.privateKey, outgoing = false)
 
     let transport1: TcpTransport = TcpTransport.init(upgrade = Upgrade())
     asyncCheck transport1.start(server)
@@ -106,7 +106,7 @@ suite "Noise":
       acceptFut = acceptHandler()
       transport2: TcpTransport = TcpTransport.init(upgrade = Upgrade())
       clientInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get(), [transport1.ma])
-      clientNoise = newNoise(rng, clientInfo.privateKey, outgoing = true)
+      clientNoise = Noise.new(rng, clientInfo.privateKey, outgoing = true)
       conn = await transport2.dial(transport1.ma)
       sconn = await clientNoise.secure(conn, true)
 
@@ -125,7 +125,7 @@ suite "Noise":
     let
       server = Multiaddress.init("/ip4/0.0.0.0/tcp/0").tryGet()
       serverInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get(), [server])
-      serverNoise = newNoise(rng, serverInfo.privateKey, outgoing = false)
+      serverNoise = Noise.new(rng, serverInfo.privateKey, outgoing = false)
 
     let
       transport1: TcpTransport = TcpTransport.init(upgrade = Upgrade())
@@ -146,7 +146,7 @@ suite "Noise":
       handlerWait = acceptHandler()
       transport2: TcpTransport = TcpTransport.init(upgrade = Upgrade())
       clientInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get(), [transport1.ma])
-      clientNoise = newNoise(rng, clientInfo.privateKey, outgoing = true, commonPrologue = @[1'u8, 2'u8, 3'u8])
+      clientNoise = Noise.new(rng, clientInfo.privateKey, outgoing = true, commonPrologue = @[1'u8, 2'u8, 3'u8])
       conn = await transport2.dial(transport1.ma)
     var sconn: Connection = nil
     expect(NoiseDecryptTagError):
@@ -161,7 +161,7 @@ suite "Noise":
     let
       server = Multiaddress.init("/ip4/0.0.0.0/tcp/0").tryGet()
       serverInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get(), [server])
-      serverNoise = newNoise(rng, serverInfo.privateKey, outgoing = false)
+      serverNoise = Noise.new(rng, serverInfo.privateKey, outgoing = false)
       readTask = newFuture[void]()
 
     let transport1: TcpTransport = TcpTransport.init(upgrade = Upgrade())
@@ -182,7 +182,7 @@ suite "Noise":
       acceptFut = acceptHandler()
       transport2: TcpTransport = TcpTransport.init(upgrade = Upgrade())
       clientInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get(), [transport1.ma])
-      clientNoise = newNoise(rng, clientInfo.privateKey, outgoing = true)
+      clientNoise = Noise.new(rng, clientInfo.privateKey, outgoing = true)
       conn = await transport2.dial(transport1.ma)
       sconn = await clientNoise.secure(conn, true)
 
@@ -197,7 +197,7 @@ suite "Noise":
     let
       server = Multiaddress.init("/ip4/0.0.0.0/tcp/0").tryGet()
       serverInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get(), [server])
-      serverNoise = newNoise(rng, serverInfo.privateKey, outgoing = false)
+      serverNoise = Noise.new(rng, serverInfo.privateKey, outgoing = false)
       readTask = newFuture[void]()
 
     var hugePayload = newSeq[byte](0xFFFFF)
@@ -221,7 +221,7 @@ suite "Noise":
       acceptFut = acceptHandler()
       transport2: TcpTransport = TcpTransport.init(upgrade = Upgrade())
       clientInfo = PeerInfo.init(PrivateKey.random(ECDSA, rng[]).get(), [transport1.ma])
-      clientNoise = newNoise(rng, clientInfo.privateKey, outgoing = true)
+      clientNoise = Noise.new(rng, clientInfo.privateKey, outgoing = true)
       conn = await transport2.dial(transport1.ma)
       sconn = await clientNoise.secure(conn, true)
 

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -58,7 +58,7 @@ proc createSwitch(ma: MultiAddress; outgoing: bool, secio: bool = false): (Switc
     result = Mplex.init(conn)
 
   let
-    identify = newIdentify(peerInfo)
+    identify = Identify.new(peerInfo)
     mplexProvider = newMuxerProvider(createMplex, MplexCodec)
     muxers = [(MplexCodec, mplexProvider)].toTable()
     secureManagers = if secio:

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -59,7 +59,7 @@ proc createSwitch(ma: MultiAddress; outgoing: bool, secio: bool = false): (Switc
 
   let
     identify = Identify.new(peerInfo)
-    mplexProvider = newMuxerProvider(createMplex, MplexCodec)
+    mplexProvider = MuxerProvider.new(createMplex, MplexCodec)
     muxers = [(MplexCodec, mplexProvider)].toTable()
     secureManagers = if secio:
       [Secure(Secio.new(rng, peerInfo.privateKey))]

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -62,7 +62,7 @@ proc createSwitch(ma: MultiAddress; outgoing: bool, secio: bool = false): (Switc
     mplexProvider = newMuxerProvider(createMplex, MplexCodec)
     muxers = [(MplexCodec, mplexProvider)].toTable()
     secureManagers = if secio:
-      [Secure(newSecio(rng, peerInfo.privateKey))]
+      [Secure(Secio.new(rng, peerInfo.privateKey))]
     else:
       [Secure(newNoise(rng, peerInfo.privateKey, outgoing = outgoing))]
     connManager = ConnManager.init()


### PR DESCRIPTION
A commit per function, easy to revert if needed. Deprecated old procs.

I'll update the examples more thoroughly in an other PR

My apologies to everybody using the libp2p :bowing_man: 

I've left a few newXXX :
- newRng
- newSwitch
- newStandardSwitch
- all new Errors