### PR TITLE
Peer Store implement part II

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -64,8 +64,7 @@ proc new*(T: type[SwitchBuilder]): T =
     maxOut: -1,
     maxConnsPerPeer: MaxConnectionsPerPeer,
     protoVersion: ProtoVersion,
-    agentVersion: AgentVersion,
-  )
+    agentVersion: AgentVersion)
 
 proc withPrivateKey*(b: SwitchBuilder, privateKey: PrivateKey): SwitchBuilder =
   b.privKey = some(privateKey)
@@ -181,8 +180,7 @@ proc build*(b: SwitchBuilder): Switch
     muxers = muxers,
     secureManagers = secureManagerInstances,
     connManager = connManager,
-    ms = ms
-  )
+    ms = ms)
 
   return switch
 

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -34,9 +34,11 @@ type
   PeerBook*[T] = object of RootObj
     book*: Table[PeerID, T]
     changeHandlers: seq[PeerBookChangeHandler[T]]
+
+  SetPeerBook*[T] = object of PeerBook[HashSet[T]]
   
-  AddressBook* = object of PeerBook[HashSet[MultiAddress]]
-  ProtoBook* = object of PeerBook[HashSet[string]]
+  AddressBook* = object of SetPeerBook[MultiAddress]
+  ProtoBook* = object of SetPeerBook[string]
   KeyBook* = object of PeerBook[PublicKey]
   
   ####################
@@ -50,7 +52,7 @@ type
   
   StoredInfo* = object
     # Collates stored info about a peer
-    peerId*: PeerID    
+    peerId*: PeerID
     addrs*: HashSet[MultiAddress]
     protos*: HashSet[string]
     publicKey*: PublicKey
@@ -93,39 +95,23 @@ proc delete*[T](peerBook: var PeerBook[T],
     peerBook.book.del(peerId)
     return true
 
-####################
-# Address Book API #
-####################
+################
+# Set Book API #
+################
 
-proc add*(addressBook: var AddressBook,
-          peerId: PeerID,
-          multiaddr: MultiAddress) = 
-  ## Add known multiaddr of a given peer. If the peer is not known, 
-  ## it will be set with the provided multiaddr.
+proc add*[T](
+  peerBook: var SetPeerBook[T],
+  peerId: PeerID,
+  entry: T) =
+  ## Add entry to a given peer. If the peer is not known,
+  ## it will be set with the provided entry.
   
-  addressBook.book.mgetOrPut(peerId,
-                             initHashSet[MultiAddress]()).incl(multiaddr)
+  peerBook.book.mgetOrPut(peerId,
+                          initHashSet[T]()).incl(entry)
   
   # Notify clients
-  for handler in addressBook.changeHandlers:
-    handler(peerId, addressBook.get(peerId))
-
-#####################
-# Protocol Book API #
-#####################
-
-proc add*(protoBook: var ProtoBook,
-          peerId: PeerID,
-          protocol: string) = 
-  ## Adds known protocol codec for a given peer. If the peer is not known, 
-  ## it will be set with the provided protocol.
-  
-  protoBook.book.mgetOrPut(peerId,
-                           initHashSet[string]()).incl(protocol)
-  
-  # Notify clients
-  for handler in protoBook.changeHandlers:
-    handler(peerId, protoBook.get(peerId))
+  for handler in peerBook.changeHandlers:
+    handler(peerId, peerBook.get(peerId))
 
 ##################  
 # Peer Store API #

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -45,7 +45,7 @@ type
   # Peer store types #
   ####################
 
-  PeerStore* = ref object of RootObj
+  PeerStore* = ref object
     addressBook*: AddressBook
     protoBook*: ProtoBook
     keyBook*: KeyBook

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -568,11 +568,11 @@ proc init*[PubParams: object | bool](
         parameters: parameters,
         topicsHigh: int.high)
 
-  proc peerEventHandler(peerId: PeerID, event: PeerEvent) {.async.} =
+  proc peerEventHandler(peerInfo: PeerInfo, event: PeerEvent) {.async.} =
     if event.kind == PeerEventKind.Joined:
-      pubsub.subscribePeer(peerId)
+      pubsub.subscribePeer(peerInfo.peerId)
     else:
-      pubsub.unsubscribePeer(peerId)
+      pubsub.unsubscribePeer(peerInfo.peerId)
 
   switch.addPeerEventHandler(peerEventHandler, PeerEventKind.Joined)
   switch.addPeerEventHandler(peerEventHandler, PeerEventKind.Left)

--- a/libp2p/upgrademngrs/upgrade.nim
+++ b/libp2p/upgrademngrs/upgrade.nim
@@ -91,4 +91,5 @@ proc identify*(
     if info.protos.len > 0:
       conn.peerInfo.protocols = info.protos
 
+    await self.connManager.triggerPeerEvents(conn.peerInfo, PeerEvent(kind: PeerEventKind.Identified))
     trace "identified remote peer", conn, peerInfo = shortLog(conn.peerInfo)

--- a/tests/testpeerstore.nim
+++ b/tests/testpeerstore.nim
@@ -1,5 +1,6 @@
 import
-  std/[unittest2, tables, sequtils, sets],
+  unittest2,
+  std/[tables, sequtils, sets],
   ../libp2p/crypto/crypto,
   ../libp2p/multiaddress,
   ../libp2p/peerid,

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -246,18 +246,18 @@ suite "Switch":
 
     var step = 0
     var kinds: set[ConnEventKind]
-    proc hook(peerId: PeerID, event: ConnEvent) {.async, gcsafe.} =
+    proc hook(peerInfo: PeerInfo, event: ConnEvent) {.async, gcsafe.} =
       kinds = kinds + {event.kind}
       case step:
       of 0:
         check:
           event.kind == ConnEventKind.Connected
-          peerId == switch1.peerInfo.peerId
+          peerInfo.peerId == switch1.peerInfo.peerId
       of 1:
         check:
           event.kind == ConnEventKind.Disconnected
 
-        check peerId == switch1.peerInfo.peerId
+        check peerInfo.peerId == switch1.peerInfo.peerId
       else:
         check false
 
@@ -301,18 +301,18 @@ suite "Switch":
 
     var step = 0
     var kinds: set[ConnEventKind]
-    proc hook(peerId: PeerID, event: ConnEvent) {.async, gcsafe.} =
+    proc hook(peerInfo: PeerInfo, event: ConnEvent) {.async, gcsafe.} =
       kinds = kinds + {event.kind}
       case step:
       of 0:
         check:
           event.kind == ConnEventKind.Connected
-          peerId == switch2.peerInfo.peerId
+          peerInfo.peerId == switch2.peerInfo.peerId
       of 1:
         check:
           event.kind == ConnEventKind.Disconnected
 
-        check peerId == switch2.peerInfo.peerId
+        check peerInfo.peerId == switch2.peerInfo.peerId
       else:
         check false
 
@@ -356,17 +356,17 @@ suite "Switch":
 
     var step = 0
     var kinds: set[PeerEventKind]
-    proc handler(peerId: PeerID, event: PeerEvent) {.async, gcsafe.} =
+    proc handler(peerInfo: PeerInfo, event: PeerEvent) {.async, gcsafe.} =
       kinds = kinds + {event.kind}
       case step:
       of 0:
         check:
           event.kind == PeerEventKind.Joined
-          peerId == switch2.peerInfo.peerId
+          peerInfo.peerId == switch2.peerInfo.peerId
       of 1:
         check:
           event.kind == PeerEventKind.Left
-          peerId == switch2.peerInfo.peerId
+          peerInfo.peerId == switch2.peerInfo.peerId
       else:
         check false
 
@@ -410,17 +410,17 @@ suite "Switch":
 
     var step = 0
     var kinds: set[PeerEventKind]
-    proc handler(peerId: PeerID, event: PeerEvent) {.async, gcsafe.} =
+    proc handler(peerInfo: PeerInfo, event: PeerEvent) {.async, gcsafe.} =
       kinds = kinds + {event.kind}
       case step:
       of 0:
         check:
           event.kind == PeerEventKind.Joined
-          peerId == switch1.peerInfo.peerId
+          peerInfo.peerId == switch1.peerInfo.peerId
       of 1:
         check:
           event.kind == PeerEventKind.Left
-          peerId == switch1.peerInfo.peerId
+          peerInfo.peerId == switch1.peerInfo.peerId
       else:
         check false
 
@@ -474,7 +474,7 @@ suite "Switch":
 
     var step = 0
     var kinds: set[PeerEventKind]
-    proc handler(peerId: PeerID, event: PeerEvent) {.async, gcsafe.} =
+    proc handler(peerInfo: PeerInfo, event: PeerEvent) {.async, gcsafe.} =
       kinds = kinds + {event.kind}
       case step:
       of 0:
@@ -535,7 +535,7 @@ suite "Switch":
     var switches: seq[Switch]
     var done = newFuture[void]()
     var onConnect: Future[void]
-    proc hook(peerId: PeerID, event: ConnEvent) {.async, gcsafe.} =
+    proc hook(peerInfo: PeerInfo, event: ConnEvent) {.async, gcsafe.} =
       case event.kind:
       of ConnEventKind.Connected:
         await onConnect
@@ -577,7 +577,7 @@ suite "Switch":
     var switches: seq[Switch]
     var done = newFuture[void]()
     var onConnect: Future[void]
-    proc hook(peerId: PeerID, event: ConnEvent) {.async, gcsafe.} =
+    proc hook(peerInfo2: PeerInfo, event: ConnEvent) {.async, gcsafe.} =
       case event.kind:
       of ConnEventKind.Connected:
         if conns == 5:


### PR DESCRIPTION
Following #504 
Ref #537

This PR add a `PeerStore` to the `Switch`.
The PeerStore is still user-overridable to wrap it with other fields if needed (as done in Waku)

The connmanager's PeerEvent has a new type of event: `Identify`, which is triggered when the peer identifies (or `pushidentity`, in the future)
On identify, the peer informations are store inside the PeerStore through a `PeerEventHandler`

**Breaking change**
The `ConnEventHandler` & `PeerEventHandler` signatures changed: they now receive a `PeerInfo` instead of a `PeerID`