### PR TITLE
Fix trackers tests

### DIFF
--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -139,7 +139,7 @@ method close*(s: LPChannel) {.async, gcsafe.} =
 
 method initStream*(s: LPChannel) =
   if s.objName.len == 0:
-    s.objName = "LPChannel"
+    s.objName = LPChannelTrackerName
 
   s.timeoutHandler = proc(): Future[void] {.gcsafe.} =
     trace "Idle timeout expired, resetting LPChannel", s

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -59,7 +59,7 @@ proc init*(T: type SecureConn,
 
 method initStream*(s: SecureConn) =
   if s.objName.len == 0:
-    s.objName = "SecureConn"
+    s.objName = SecureConnTrackerName
 
   procCall Connection(s).initStream()
 

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -50,7 +50,7 @@ proc len*(s: BufferStream): int =
 
 method initStream*(s: BufferStream) =
   if s.objName.len == 0:
-    s.objName = "BufferStream"
+    s.objName = BufferStreamTrackerName
 
   procCall Connection(s).initStream()
 

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -68,7 +68,7 @@ chronicles.formatIt(Connection): shortLog(it)
 
 method initStream*(s: Connection) =
   if s.objName.len == 0:
-    s.objName = "Connection"
+    s.objName = ConnectionTrackerName
 
   procCall LPStream(s).initStream()
 

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -264,9 +264,9 @@ proc write*(s: LPStream, msg: string): Future[void] =
 method closeImpl*(s: LPStream): Future[void] {.async, base.} =
   ## Implementation of close - called only once
   trace "Closing stream", s, objName = s.objName, dir = $s.dir
-  s.closeEvent.fire()
   libp2p_open_streams.dec(labelValues = [s.objName, $s.dir])
   inc getStreamTracker(s.objName).closed
+  s.closeEvent.fire()
   trace "Closed stream", s, objName = s.objName, dir = $s.dir
 
 method close*(s: LPStream): Future[void] {.base, async.} = # {.raises [Defect].}

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -123,7 +123,7 @@ chronicles.formatIt(LPStream): shortLog(it)
 
 method initStream*(s: LPStream) {.base.} =
   if s.objName.len == 0:
-    s.objName = "LPStream"
+    s.objName = LPStreamTrackerName
 
   s.closeEvent = newAsyncEvent()
   s.oid = genOid()

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -36,7 +36,7 @@ iterator testTrackers*(extras: openArray[string] = []): TrackerBase =
     if not isNil(t): yield t
 
 template checkTracker*(name: string) =
-  var tracker = getTracker(LPChannelTrackerName)
+  var tracker = getTracker(name)
   if tracker.isLeaked():
     checkpoint tracker.dump()
     fail()

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -718,8 +718,7 @@ suite "Switch":
     checkTracker(SecureConnTrackerName)
     checkTracker(ChronosStreamTrackerName)
 
-    await allFuturesThrowing(
-      switch1.stop())
+    await switch1.stop()
 
     # this needs to go at end
     await allFuturesThrowing(awaiters)

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -596,13 +596,13 @@ suite "Switch":
         rng = rng))
 
     switches[0].addConnEventHandler(hook, ConnEventKind.Connected)
-    switches[0].addConnEventHandler(hook, ConnEventKind.Disconnected)
     awaiters.add(await switches[0].start())
 
     for i in 1..5:
       switches.add(newStandardSwitch(
         privKey = some(peerInfo.privateKey),
         rng = rng))
+      switches[i].addConnEventHandler(hook, ConnEventKind.Disconnected)
       onConnect = switches[i].connect(switches[0].peerInfo.peerId, switches[0].peerInfo.addrs)
       await onConnect
 
@@ -627,6 +627,7 @@ suite "Switch":
       try:
         let conn = await transport.accept()
         discard await conn.readLp(100)
+        await conn.close()
       except CatchableError:
         discard
 
@@ -712,13 +713,13 @@ suite "Switch":
       readers.add(closeReader())
 
     await allFuturesThrowing(readers)
+    await switch2.stop() #Otherwise this leeks
     checkTracker(LPChannelTrackerName)
     checkTracker(SecureConnTrackerName)
     checkTracker(ChronosStreamTrackerName)
 
     await allFuturesThrowing(
-      switch1.stop(),
-      switch2.stop())
+      switch1.stop())
 
     # this needs to go at end
     await allFuturesThrowing(awaiters)


### PR DESCRIPTION
There is a typo in `test/helpers.nim` which made `checkTracker` useless. Fixing it broke a few tests

(nim doesn't have a "unused parameter" warning? seems like a super important warning)