### PR TITLE
Fix flaky macos switch test

### DIFF
--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -713,7 +713,9 @@ suite "Switch":
       readers.add(closeReader())
 
     await allFuturesThrowing(readers)
-    await switch2.stop() #Otherwise this leeks
+    await switch2.stop() #Otherwise this leaks
+    await sleepAsync(500.millis)
+
     checkTracker(LPChannelTrackerName)
     checkTracker(SecureConnTrackerName)
     checkTracker(ChronosStreamTrackerName)

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -714,7 +714,7 @@ suite "Switch":
 
     await allFuturesThrowing(readers)
     await switch2.stop() #Otherwise this leaks
-    await sleepAsync(500.millis)
+    check await checkExpiring(not switch1.isConnected(switch2.peerInfo.peerID))
 
     checkTracker(LPChannelTrackerName)
     checkTracker(SecureConnTrackerName)


### PR DESCRIPTION
Seen on #565 

Probably not the best way to solve it, but MacOS seem takes some time to close the stream on the receiving end, and thus the stream isn't closed quickly enough.

This PR solves it, as demonstrated here: https://github.com/status-im/nim-libp2p/runs/2887560022