### PR TITLE
Faster CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,10 @@
 name: CI
-on: [pull_request, workflow_dispatch]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,6 +1,12 @@
 name: nim-libp2p codecov builds
 
-on: [pull_request]
+on:
+  #On push to common branches, this computes the "bases stats" for PRs
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   GossipSub:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,6 +1,6 @@
 name: nim-libp2p codecov builds
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   GossipSub:


### PR DESCRIPTION
This PR disable CI on push. The goal is stop running the CI twice as it currently does, since it's not necessary and the CI runs end up piling in the actions queue for hours.

To explain `pull_request` vs `push` quickly:
`push` will simply test every time you push to any branch
`pull_request` will test every time you push to a PR __as if the pull request was merged__. You can see it a "merge temporarily, run the CI, and unmerge"

For codecov, it doesn't make much sense to CI on the commit itself, so only doing it on `pull_request` seems legit

For the actual testing, it's not as simple. Only running on `pull_request` means that branches which are not PRed will not be tested. But if you actually want to test a thing without a PR, it's easy to add `push` back to the file, or run the workflow manually inside the github UI (note: to run manually, this PR (as in #603) [will have to be merged into master](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)).

Why not run on `push` only? Because it's more interesting to test the PR as if they were merged.

I propose to set both to `pull_request` only, and if this annoys us, switch `ci` back to `push, pull_request`. But I don't think we'll even notice it.