### PR TITLE
Track ChronosStream in test

### DIFF
--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -45,7 +45,7 @@ chronicles.formatIt(ChronosStream): shortLog(it)
 
 method initStream*(s: ChronosStream) =
   if s.objName.len == 0:
-    s.objName = "ChronosStream"
+    s.objName = ChronosStreamTrackerName
 
   s.timeoutHandler = proc() {.async, gcsafe.} =
     trace "Idle timeout expired, closing ChronosStream", s

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -6,6 +6,7 @@ import ../libp2p/transports/tcptransport
 import ../libp2p/stream/bufferstream
 import ../libp2p/crypto/crypto
 import ../libp2p/stream/lpstream
+import ../libp2p/stream/chronosstream
 import ../libp2p/muxers/mplex/lpchannel
 import ../libp2p/protocols/secure/secure
 
@@ -24,6 +25,7 @@ const
     BufferStreamTrackerName,
     TcpTransportTrackerName,
     StreamTransportTrackerName,
+    ChronosStreamTrackerName,
     StreamServerTrackerName
   ]
 


### PR DESCRIPTION
The current failures in macos are triggered by the `ChronosStreamTrackerName`, which is currently not tracked in every test.

Putting it here to see what breaks