### PR TITLE
Fix transport's switch start

### DIFF
--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -203,32 +203,6 @@ proc accept(s: Switch, transport: Transport) {.async.} = # noraises
         await conn.close()
       return
 
-proc start*(s: Switch): Future[seq[Future[void]]] {.async, gcsafe.} =
-  trace "starting switch for peer", peerInfo = s.peerInfo
-  var startFuts: seq[Future[void]]
-  for t in s.transports: # for each transport
-    for i, a in s.peerInfo.addrs:
-      if t.handles(a): # check if it handles the multiaddr
-        let transpStart = t.start(a)
-        startFuts.add(transpStart)
-        try:
-          await transpStart
-          s.peerInfo.addrs[i] = t.ma # update peer's address
-          s.acceptFuts.add(s.accept(t))
-        except CancelledError:
-          raise
-        except CatchableError as exc:
-          debug "Failed to start one transport", address = $a, err = exc.msg
-          continue
-
-  proc peerIdentifiedHandler(peerInfo: PeerInfo, event: PeerEvent) {.async.} =
-    s.peerStore.replace(peerInfo)
-
-  s.connManager.addPeerEventHandler(peerIdentifiedHandler, PeerEventKind.Identified)
-
-  debug "Started libp2p node", peer = s.peerInfo
-  return startFuts # listen for incoming connections
-
 proc stop*(s: Switch) {.async.} =
   trace "Stopping switch"
 
@@ -256,6 +230,33 @@ proc stop*(s: Switch) {.async.} =
       a.cancel()
 
   trace "Switch stopped"
+
+proc start*(s: Switch): Future[seq[Future[void]]] {.async, gcsafe.} =
+  trace "starting switch for peer", peerInfo = s.peerInfo
+  var startFuts: seq[Future[void]]
+  for t in s.transports: # for each transport
+    for i, a in s.peerInfo.addrs:
+      if t.handles(a): # check if it handles the multiaddr
+        let transpStart = t.start(a)
+        startFuts.add(transpStart)
+        try:
+          await transpStart
+          s.peerInfo.addrs[i] = t.ma # update peer's address
+          s.acceptFuts.add(s.accept(t))
+        except CancelledError:
+          await s.stop()
+          raise
+        except CatchableError as exc:
+          debug "Failed to start one transport", address = $a, err = exc.msg
+          continue
+
+  proc peerIdentifiedHandler(peerInfo: PeerInfo, event: PeerEvent) {.async.} =
+    s.peerStore.replace(peerInfo)
+
+  s.connManager.addPeerEventHandler(peerIdentifiedHandler, PeerEventKind.Identified)
+
+  debug "Started libp2p node", peer = s.peerInfo
+  return startFuts # listen for incoming connections
 
 proc newSwitch*(peerInfo: PeerInfo,
                 transports: seq[Transport],

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -209,10 +209,9 @@ proc start*(s: Switch): Future[seq[Future[void]]] {.async, gcsafe.} =
   for t in s.transports: # for each transport
     for i, a in s.peerInfo.addrs:
       if t.handles(a): # check if it handles the multiaddr
-        var server = t.start(a)
+        await t.start(a)
         s.peerInfo.addrs[i] = t.ma # update peer's address
         s.acceptFuts.add(s.accept(t))
-        startFuts.add(server)
 
   proc peerIdentifiedHandler(peerInfo: PeerInfo, event: PeerEvent) {.async.} =
     s.peerStore.replace(peerInfo)

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -243,9 +243,9 @@ proc start*(s: Switch): Future[seq[Future[void]]] {.async, gcsafe.} =
           await transpStart
           s.peerInfo.addrs[i] = t.ma # update peer's address
           s.acceptFuts.add(s.accept(t))
-        except CancelledError:
+        except CancelledError as exc:
           await s.stop()
-          raise
+          raise exc
         except CatchableError as exc:
           debug "Failed to start one transport", address = $a, err = exc.msg
           continue


### PR DESCRIPTION
The current way the switch is started is wrong, because the transport may take some time to `start` (it's async), but the switch assumes that the `t.ma` is valid and that the `t.running` is true without waiting for `start` to finish.

This can have some pretty bad consequence (for instance not starting the accept loop, as happens here https://ci.status.im/blue/organizations/jenkins/nimbus%2Fnimbus-eth2%2Fmultibranch/detail/PR-2724/1/pipeline/), so merging against master.

By the way, I never understood why we returned the futures of the transport starting? I would remove it, but it would break API. So returning an empty seq

EDIT: not returning and empty seq anymore to allow caller to check how many transports start to fail. But we could find a better way I'm sure (eg returning the number of transports which started successfully, allowing the caller to do `assert await node.start() > 0` or something like that)