### PR TITLE
[WIP] Cancellation test

### DIFF
--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -35,7 +35,8 @@ import stream/connection,
        peerid,
        peerstore,
        errors,
-       dialer
+       dialer,
+       utility
 
 export connmanager, upgrade, dialer, peerstore
 
@@ -226,18 +227,18 @@ proc stop*(s: Switch) {.async.} =
   trace "Stopping switch"
 
   # close and cleanup all connections
-  await s.connManager.close()
+  awaitrc s.connManager.close()
 
   for t in s.transports:
     try:
-      await t.stop()
+      awaitrc t.stop()
     except CancelledError as exc:
       raise exc
     except CatchableError as exc:
       warn "error cleaning up transports", msg = exc.msg
 
   try:
-    await allFutures(s.acceptFuts)
+    awaitrc allFutures(s.acceptFuts)
       .wait(1.seconds)
   except CatchableError as exc:
     trace "Exception while stopping accept loops", exc = exc.msg

--- a/tests/asyncunit.nim
+++ b/tests/asyncunit.nim
@@ -34,7 +34,7 @@ template cancelTest*(name: string, body: untyped): untyped =
         if testFuture.finished: break
         poll()
       if testFuture.finished: break #We actually finished the sequence
+      echo "cancelling"
       waitFor(testFuture.cancelAndWait())
-      waitFor(sleepAsync(1.seconds))
-      #check testFuture.cancelled
+      #waitFor(sleepAsync(100.milliseconds))
       checkTrackers()

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -903,3 +903,9 @@ suite "Switch":
 
       storedInfo1.protos.toSeq() == switch2.peerInfo.protocols
       storedInfo2.protos.toSeq() == switch1.peerInfo.protocols
+  cancelTest "e2e start top":
+
+    let switch1 = newStandardSwitch()
+    let toWait = await switch1.start()
+    await allFuturesThrowing(toWait)
+    await switch1.stop()


### PR DESCRIPTION
Start of the cancellation test:

- Adding `awaitrc` on cleanup to avoid cleanup being cancelled (and thus, leaks)
- Adding a `cancelTest` which is cancelling every step of the way
- Adding a simple connect test for now

Few notes:
The cancel test works like that:
```nim
    for i in 0..1000:
      echo "polling ", i ," times"
      let testFuture = cancelledTest()
      for _ in 0..<i:
        if testFuture.finished: break
        poll()
      if testFuture.finished: break
```

Poll is emptying the callback list, so a "computation only" future will only poll once.
For poll to return, there needs to be a IO wait or something like that.

So this is only testing cancellation a "IO operations"!

This is already good enough to leak on a simple connect, but not perfect yet.
(The simple connect test has 143 poll, but a simple switch start/stop has 1 poll)

`awaitrc` or equivalent should move to chronos