### PR TITLE
Fixes failing peer store test in Nim 1.4.8

### DIFF
--- a/tests/testidentify.nim
+++ b/tests/testidentify.nim
@@ -151,11 +151,11 @@ suite "Identify":
         storedInfo1.peerId == switch2.peerInfo.peerId
         storedInfo2.peerId == switch1.peerInfo.peerId
 
-        storedInfo1.addrs.toSeq() == switch2.peerInfo.addrs
-        storedInfo2.addrs.toSeq() == switch1.peerInfo.addrs
+        storedInfo1.addrs == switch2.peerInfo.addrs.toSet()
+        storedInfo2.addrs == switch1.peerInfo.addrs.toSet()
 
-        storedInfo1.protos.toSeq() == switch2.peerInfo.protocols
-        storedInfo2.protos.toSeq() == switch1.peerInfo.protocols
+        storedInfo1.protos == switch2.peerInfo.protocols.toSet()
+        storedInfo2.protos == switch1.peerInfo.protocols.toSet()
 
     proc closeAll() {.async.} =
       await conn.close()
@@ -171,7 +171,7 @@ suite "Identify":
       switch2.peerInfo.addrs.add(MultiAddress.init("/ip4/127.0.0.1/tcp/5555").tryGet())
 
       check:
-        switch1.peerStore.get(switch2.peerInfo.peerId).addrs.toSeq() != switch2.peerInfo.addrs
+        switch1.peerStore.get(switch2.peerInfo.peerId).addrs != switch2.peerInfo.addrs.toSet()
         switch1.peerStore.get(switch2.peerInfo.peerId).protos != switch2.peerInfo.protocols.toSet()
 
       await identifyPush2.push(switch2.peerInfo, conn)
@@ -179,12 +179,8 @@ suite "Identify":
       await closeAll()
 
       # Wait the very end to be sure that the push has been processed
-      var aprotos = switch1.peerStore.get(switch2.peerInfo.peerId).protos.toSeq()
-      var bprotos = switch2.peerInfo.protocols
-      aprotos.sort()
-      bprotos.sort()
       check:
-        aprotos == bprotos
+        switch1.peerStore.get(switch2.peerInfo.peerId).protos == switch2.peerInfo.protocols.toSet()
         switch1.peerStore.get(switch2.peerInfo.peerId).addrs == switch2.peerInfo.addrs.toSet()
 
 
@@ -194,7 +190,7 @@ suite "Identify":
 
       check:
         switch1.peerStore.get(switch2.peerInfo.peerId).addrs != switch2.peerInfo.addrs.toSet()
-        switch1.peerStore.get(switch2.peerInfo.peerId).protos.toSeq() != switch2.peerInfo.protocols
+        switch1.peerStore.get(switch2.peerInfo.peerId).protos != switch2.peerInfo.protocols.toSet()
 
       let oldPeerId = switch2.peerInfo.peerId
       switch2.peerInfo = PeerInfo.init(PrivateKey.random(newRng()[]).get())
@@ -204,10 +200,6 @@ suite "Identify":
       await closeAll()
 
       # Wait the very end to be sure that the push has been processed
-      var aprotos = switch1.peerStore.get(oldPeerId).protos.toSeq()
-      var bprotos = switch2.peerInfo.protocols
-      aprotos.sort()
-      bprotos.sort()
       check:
-        aprotos != bprotos
-        switch1.peerStore.get(oldPeerId).addrs.toSeq() != switch2.peerInfo.addrs
+        switch1.peerStore.get(oldPeerId).protos != switch2.peerInfo.protocols.toSet()
+        switch1.peerStore.get(oldPeerId).addrs != switch2.peerInfo.addrs.toSet()

--- a/tests/testidentify.nim
+++ b/tests/testidentify.nim
@@ -151,11 +151,11 @@ suite "Identify":
         storedInfo1.peerId == switch2.peerInfo.peerId
         storedInfo2.peerId == switch1.peerInfo.peerId
 
-        storedInfo1.addrs == switch2.peerInfo.addrs.toSet()
-        storedInfo2.addrs == switch1.peerInfo.addrs.toSet()
+        storedInfo1.addrs == switch2.peerInfo.addrs.toHashSet()
+        storedInfo2.addrs == switch1.peerInfo.addrs.toHashSet()
 
-        storedInfo1.protos == switch2.peerInfo.protocols.toSet()
-        storedInfo2.protos == switch1.peerInfo.protocols.toSet()
+        storedInfo1.protos == switch2.peerInfo.protocols.toHashSet()
+        storedInfo2.protos == switch1.peerInfo.protocols.toHashSet()
 
     proc closeAll() {.async.} =
       await conn.close()
@@ -171,8 +171,8 @@ suite "Identify":
       switch2.peerInfo.addrs.add(MultiAddress.init("/ip4/127.0.0.1/tcp/5555").tryGet())
 
       check:
-        switch1.peerStore.get(switch2.peerInfo.peerId).addrs != switch2.peerInfo.addrs.toSet()
-        switch1.peerStore.get(switch2.peerInfo.peerId).protos != switch2.peerInfo.protocols.toSet()
+        switch1.peerStore.get(switch2.peerInfo.peerId).addrs != switch2.peerInfo.addrs.toHashSet()
+        switch1.peerStore.get(switch2.peerInfo.peerId).protos != switch2.peerInfo.protocols.toHashSet()
 
       await identifyPush2.push(switch2.peerInfo, conn)
 
@@ -180,8 +180,8 @@ suite "Identify":
 
       # Wait the very end to be sure that the push has been processed
       check:
-        switch1.peerStore.get(switch2.peerInfo.peerId).protos == switch2.peerInfo.protocols.toSet()
-        switch1.peerStore.get(switch2.peerInfo.peerId).addrs == switch2.peerInfo.addrs.toSet()
+        switch1.peerStore.get(switch2.peerInfo.peerId).protos == switch2.peerInfo.protocols.toHashSet()
+        switch1.peerStore.get(switch2.peerInfo.peerId).addrs == switch2.peerInfo.addrs.toHashSet()
 
 
     asyncTest "wrong peer id push identify":
@@ -189,8 +189,8 @@ suite "Identify":
       switch2.peerInfo.addrs.add(MultiAddress.init("/ip4/127.0.0.1/tcp/5555").tryGet())
 
       check:
-        switch1.peerStore.get(switch2.peerInfo.peerId).addrs != switch2.peerInfo.addrs.toSet()
-        switch1.peerStore.get(switch2.peerInfo.peerId).protos != switch2.peerInfo.protocols.toSet()
+        switch1.peerStore.get(switch2.peerInfo.peerId).addrs != switch2.peerInfo.addrs.toHashSet()
+        switch1.peerStore.get(switch2.peerInfo.peerId).protos != switch2.peerInfo.protocols.toHashSet()
 
       let oldPeerId = switch2.peerInfo.peerId
       switch2.peerInfo = PeerInfo.init(PrivateKey.random(newRng()[]).get())
@@ -201,5 +201,5 @@ suite "Identify":
 
       # Wait the very end to be sure that the push has been processed
       check:
-        switch1.peerStore.get(oldPeerId).protos != switch2.peerInfo.protocols.toSet()
-        switch1.peerStore.get(oldPeerId).addrs != switch2.peerInfo.addrs.toSet()
+        switch1.peerStore.get(oldPeerId).protos != switch2.peerInfo.protocols.toHashSet()
+        switch1.peerStore.get(oldPeerId).addrs != switch2.peerInfo.addrs.toHashSet()

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -898,8 +898,8 @@ suite "Switch":
       storedInfo1.peerId == switch2.peerInfo.peerId
       storedInfo2.peerId == switch1.peerInfo.peerId
 
-      storedInfo1.addrs.toSeq() == switch2.peerInfo.addrs
-      storedInfo2.addrs.toSeq() == switch1.peerInfo.addrs
+      storedInfo1.addrs == switch2.peerInfo.addrs.toHashSet()
+      storedInfo2.addrs == switch1.peerInfo.addrs.toHashSet()
 
-      storedInfo1.protos.toSeq() == switch2.peerInfo.protocols
-      storedInfo2.protos.toSeq() == switch1.peerInfo.protocols
+      storedInfo1.protos == switch2.peerInfo.protocols.toHashSet()
+      storedInfo2.protos == switch1.peerInfo.protocols.toHashSet()


### PR DESCRIPTION
This test failed because the order in which the elements of a hashset are added to a seq is non-deterministic. It accidentally worked in Nim 1.2.6, but not in 1.4.8.