### PR TITLE
Fix unstable autobump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+      - unstable
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
#603 broke the unstable auto bump, because `ci` was not launched on the unstable branch anymore (we relied on the "unstable merge" PR to run the unstable's CI)

Thus I'm re-enabling the CI on the unstable branch, even though that will duplicate some CI runs on unstable, we merge to unstable sporadically enough that it should not be an issue, hopefully.