### PR TITLE
fix: [testswitch e2e peer store] relies on hashset order

### DIFF
--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -901,5 +901,6 @@ suite "Switch":
       storedInfo1.addrs.toSeq() == switch2.peerInfo.addrs
       storedInfo2.addrs.toSeq() == switch1.peerInfo.addrs
 
-      storedInfo1.protos.toSeq() == switch2.peerInfo.protocols
-      storedInfo2.protos.toSeq() == switch1.peerInfo.protocols
+      storedInfo1.protos == switch2.peerInfo.protocols.toHashset()
+      storedInfo2.protos == switch1.peerInfo.protocols.toHashset()
+


### PR DESCRIPTION
testswitch can fail with the following message:

```
Check failed: storedInfo2.protos.toSeq() == switch1.peerInfo.protocols
    storedInfo2.protos.toSeq() was @["/test/proto/1.0.0", "/ipfs/id/1.0.0"]
    switch1.peerInfo.protocols was @["/ipfs/id/1.0.0", "/test/proto/1.0.0"]
```

The test assumes a specific order of items in a hashset.
This PR converts the sequence into a hashset fixing this issue locally; this makes the test complete successfully on my machine.

Is there a reason for PeerInfo managing supported protocols in a seq, while PeerStore manages it in a HashSet?
