### PR TITLE
Rename getKey -> getPublicKey

### DIFF
--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -303,33 +303,36 @@ proc random*(T: typedesc[KeyPair], rng: var BrHmacDrbgContext,
   else:
     err(SchemeError)
 
-proc getKey*(key: PrivateKey): CryptoResult[PublicKey] =
+proc getPublicKey*(key: PrivateKey): CryptoResult[PublicKey] =
   ## Get public key from corresponding private key ``key``.
   case key.scheme
   of PKScheme.RSA:
     when supported(PKScheme.RSA):
-      let rsakey = key.rsakey.getKey()
+      let rsakey = key.rsakey.getPublicKey()
       ok(PublicKey(scheme: RSA, rsakey: rsakey))
     else:
       err(SchemeError)
   of PKScheme.Ed25519:
     when supported(PKScheme.Ed25519):
-      let edkey = key.edkey.getKey()
+      let edkey = key.edkey.getPublicKey()
       ok(PublicKey(scheme: Ed25519, edkey: edkey))
     else:
       err(SchemeError)
   of PKScheme.ECDSA:
     when supported(PKScheme.ECDSA):
-      let eckey = ? key.eckey.getKey().orError(KeyError)
+      let eckey = ? key.eckey.getPublicKey().orError(KeyError)
       ok(PublicKey(scheme: ECDSA, eckey: eckey))
     else:
       err(SchemeError)
   of PKScheme.Secp256k1:
     when supported(PKScheme.Secp256k1):
-      let skkey = key.skkey.getKey()
+      let skkey = key.skkey.getPublicKey()
       ok(PublicKey(scheme: Secp256k1, skkey: skkey))
     else:
       err(SchemeError)
+
+proc getKey*(key: PrivateKey): CryptoResult[PublicKey] {.deprecated: "use getPublicKey".} =
+  key.getPublicKey()
 
 proc toRawBytes*(key: PrivateKey | PublicKey,
                  data: var openarray[byte]): CryptoResult[int] =

--- a/libp2p/crypto/ecnist.nim
+++ b/libp2p/crypto/ecnist.nim
@@ -245,7 +245,7 @@ proc random*(
   else:
     ok(res)
 
-proc getKey*(seckey: EcPrivateKey): EcResult[EcPublicKey] =
+proc getPublicKey*(seckey: EcPrivateKey): EcResult[EcPublicKey] =
   ## Calculate and return EC public key from private key ``seckey``.
   if isNil(seckey):
     return err(EcKeyIncorrectError)
@@ -272,7 +272,7 @@ proc random*(
   ## secp521r1).
   let
     seckey = ? EcPrivateKey.random(kind, rng)
-    pubkey = ? seckey.getKey()
+    pubkey = ? seckey.getPublicKey()
     key = EcKeyPair(seckey: seckey, pubkey: pubkey)
   ok(key)
 
@@ -368,7 +368,7 @@ proc toBytes*(seckey: EcPrivateKey, data: var openarray[byte]): EcResult[int] =
     return err(EcKeyIncorrectError)
   if seckey.key.curve in EcSupportedCurvesCint:
     var offset, length: int
-    var pubkey = ? seckey.getKey()
+    var pubkey = ? seckey.getPublicKey()
     var b = Asn1Buffer.init()
     var p = Asn1Composite.init(Asn1Tag.Sequence)
     var c0 = Asn1Composite.init(0)

--- a/libp2p/crypto/ed25519/ed25519.nim
+++ b/libp2p/crypto/ed25519/ed25519.nim
@@ -1682,7 +1682,7 @@ proc random*(t: typedesc[EdKeyPair], rng: var BrHmacDrbgContext): EdKeyPair =
 
   res
 
-proc getKey*(key: EdPrivateKey): EdPublicKey =
+proc getPublicKey*(key: EdPrivateKey): EdPublicKey =
   ## Calculate and return ED25519 public key from private key ``key``.
   copyMem(addr result.data[0], unsafeAddr key.data[32], 32)
 

--- a/libp2p/crypto/rsa.nim
+++ b/libp2p/crypto/rsa.nim
@@ -225,7 +225,7 @@ proc copy*[T: RsaPKI](key: T): T =
       result = new RsaSignature
       result.buffer = key.buffer
 
-proc getKey*(key: RsaPrivateKey): RsaPublicKey =
+proc getPublicKey*(key: RsaPrivateKey): RsaPublicKey =
   ## Get RSA public key from RSA private key.
   doAssert(not isNil(key))
   let length = key.pubk.nlen + key.pubk.elen
@@ -245,7 +245,7 @@ proc seckey*(pair: RsaKeyPair): RsaPrivateKey {.inline.} =
 
 proc pubkey*(pair: RsaKeyPair): RsaPublicKey {.inline.} =
   ## Get RSA public key from pair ``pair``.
-  result = cast[RsaPrivateKey](pair).getKey()
+  result = cast[RsaPrivateKey](pair).getPublicKey()
 
 proc clear*[T: RsaPKI|RsaKeyPair](pki: var T) =
   ## Wipe and clear EC private key, public key or scalar object.

--- a/libp2p/crypto/secp.nim
+++ b/libp2p/crypto/secp.nim
@@ -141,7 +141,7 @@ proc init*(t: typedesc[SkSignature], data: string): SkResult[SkSignature] =
   var sig: SkSignature
   sig.init(data) and ok(sig)
 
-proc getKey*(key: SkPrivateKey): SkPublicKey =
+proc getPublicKey*(key: SkPrivateKey): SkPublicKey =
   ## Calculate and return Secp256k1 `public key` from `private key` ``key``.
   SkPublicKey(SkSecretKey(key).toPublicKey())
 

--- a/libp2p/peerid.nim
+++ b/libp2p/peerid.nim
@@ -172,7 +172,7 @@ func init*(t: typedesc[PeerID], pubkey: PublicKey): Result[PeerID, cstring] =
 
 func init*(t: typedesc[PeerID], seckey: PrivateKey): Result[PeerID, cstring] =
   ## Create new peer id from private key ``seckey``.
-  PeerID.init(? seckey.getKey().orError(cstring("invalid private key")))
+  PeerID.init(? seckey.getPublicKey().orError(cstring("invalid private key")))
 
 func match*(pid: PeerID, pubkey: PublicKey): bool =
   ## Returns ``true`` if ``pid`` matches public key ``pubkey``.

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -143,7 +143,7 @@ proc publicKey*(p: PeerInfo): Option[PublicKey] =
     elif p.key.isSome:
       res = p.key
   else:
-    let pkeyRes = p.privateKey.getKey()
+    let pkeyRes = p.privateKey.getPublicKey()
     if pkeyRes.isOk:
       res = some(pkeyRes.get())
 

--- a/libp2p/protocols/pubsub/rpc/message.nim
+++ b/libp2p/protocols/pubsub/rpc/message.nim
@@ -82,7 +82,7 @@ proc init*(
 
       msg.signature = sign(msg, peer.privateKey).expect("Couldn't sign message!")
       msg.key = peer.privateKey
-        .getKey()
+        .getPublicKey()
         .expect("Expected a Private Key!")
         .getBytes()
         .expect("Couldn't get Private Key bytes!")

--- a/libp2p/protocols/pubsub/rpc/message.nim
+++ b/libp2p/protocols/pubsub/rpc/message.nim
@@ -81,8 +81,8 @@ proc init*(
         raise (ref LPError)(msg: "Cannot sign message without private key")
 
       msg.signature = sign(msg, peer.privateKey).expect("Couldn't sign message!")
-      msg.key = peer.privateKey.getPublicKey().expect("Expected a Private Key!")
-        .getBytes().expect("Couldn't get Private Key bytes!")
+      msg.key = peer.privateKey.getPublicKey().expect("Invalid private key!")
+        .getBytes().expect("Couldn't get public key bytes!")
   elif sign:
     raise (ref LPError)(msg: "Cannot sign message without peer info")
 

--- a/libp2p/protocols/pubsub/rpc/message.nim
+++ b/libp2p/protocols/pubsub/rpc/message.nim
@@ -81,11 +81,8 @@ proc init*(
         raise (ref LPError)(msg: "Cannot sign message without private key")
 
       msg.signature = sign(msg, peer.privateKey).expect("Couldn't sign message!")
-      msg.key = peer.privateKey
-        .getPublicKey()
-        .expect("Expected a Private Key!")
-        .getBytes()
-        .expect("Couldn't get Private Key bytes!")
+      msg.key = peer.privateKey.getPublicKey().expect("Expected a Private Key!")
+        .getBytes().expect("Couldn't get Private Key bytes!")
   elif sign:
     raise (ref LPError)(msg: "Cannot sign message without peer info")
 

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -604,7 +604,7 @@ proc new*(
 
   let pkBytes = privateKey.getPublicKey()
   .expect("Expected valid Private Key")
-  .getBytes().expect("Couldn't get Private Key bytes")
+  .getBytes().expect("Couldn't get public Key bytes")
 
   var noise = Noise(
     rng: rng,

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -602,11 +602,9 @@ proc new*(
   outgoing: bool = true,
   commonPrologue: seq[byte] = @[]): T =
 
-  let pkBytes = privateKey
-  .getPublicKey()
+  let pkBytes = privateKey.getPublicKey()
   .expect("Expected valid Private Key")
-  .getBytes()
-  .expect("Couldn't get Private Key bytes")
+  .getBytes().expect("Couldn't get Private Key bytes")
 
   var noise = Noise(
     rng: rng,

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -603,7 +603,7 @@ proc new*(
   commonPrologue: seq[byte] = @[]): T =
 
   let pkBytes = privateKey
-  .getKey()
+  .getPublicKey()
   .expect("Expected valid Private Key")
   .getBytes()
   .expect("Couldn't get Private Key bytes")

--- a/libp2p/protocols/secure/secio.nim
+++ b/libp2p/protocols/secure/secio.nim
@@ -435,16 +435,14 @@ proc new*(
   T: typedesc[Secio],
   rng: ref BrHmacDrbgContext,
   localPrivateKey: PrivateKey): T =
-  let pkRes = localPrivateKey.getKey()
+  let pkRes = localPrivateKey.getPublicKey()
   if pkRes.isErr:
     raise newException(Defect, "Can't fetch local private key")
 
   let secio = Secio(
     rng: rng,
     localPrivateKey: localPrivateKey,
-    localPublicKey: localPrivateKey
-      .getKey()
-      .expect("Can't fetch local private key"),
+    localPublicKey: localPrivateKey.getPublicKey().expect("Can't fetch local private key"),
   )
   secio.init()
   secio

--- a/libp2p/protocols/secure/secio.nim
+++ b/libp2p/protocols/secure/secio.nim
@@ -437,12 +437,12 @@ proc new*(
   localPrivateKey: PrivateKey): T =
   let pkRes = localPrivateKey.getPublicKey()
   if pkRes.isErr:
-    raise newException(Defect, "Can't fetch local private key")
+    raise newException(Defect, "Invalid private key")
 
   let secio = Secio(
     rng: rng,
     localPrivateKey: localPrivateKey,
-    localPublicKey: localPrivateKey.getPublicKey().expect("Can't fetch local private key"),
+    localPublicKey: pkRes.get(),
   )
   secio.init()
   secio

--- a/tests/testcrypto.nim
+++ b/tests/testcrypto.nim
@@ -372,7 +372,7 @@ suite "Key interface test suite":
     for i in 0..<len(PrivateKeys):
       var seckey = PrivateKey.init(fromHex(stripSpaces(PrivateKeys[i]))).expect("private key")
       var pubkey = PublicKey.init(fromHex(stripSpaces(PublicKeys[i]))).expect("public key")
-      var calckey = seckey.getKey().expect("public key")
+      var calckey = seckey.getPublicKey().expect("public key")
       check:
         pubkey == calckey
       var checkseckey = seckey.getBytes().expect("private key")
@@ -387,7 +387,7 @@ suite "Key interface test suite":
 
     for i in 0..<5:
       var seckey = PrivateKey.random(ECDSA, rng[]).get()
-      var pubkey = seckey.getKey().get()
+      var pubkey = seckey.getPublicKey().get()
       var pair = KeyPair.random(ECDSA, rng[]).get()
       var sig1 = pair.seckey.sign(bmsg).get()
       var sig2 = seckey.sign(bmsg).get()
@@ -407,7 +407,7 @@ suite "Key interface test suite":
 
     for i in 0..<5:
       var seckey = PrivateKey.random(Ed25519, rng[]).get()
-      var pubkey = seckey.getKey().get()
+      var pubkey = seckey.getPublicKey().get()
       var pair = KeyPair.random(Ed25519, rng[]).get()
       var sig1 = pair.seckey.sign(bmsg).get()
       var sig2 = seckey.sign(bmsg).get()
@@ -427,7 +427,7 @@ suite "Key interface test suite":
 
     for i in 0 ..< 2:
       var seckey = PrivateKey.random(RSA, rng[], 2048).get()
-      var pubkey = seckey.getKey().get()
+      var pubkey = seckey.getPublicKey().get()
       var pair = KeyPair.random(RSA, rng[], 2048).get()
       var sig1 = pair.seckey.sign(bmsg).get()
       var sig2 = seckey.sign(bmsg).get()

--- a/tests/testecnist.nim
+++ b/tests/testecnist.nim
@@ -351,8 +351,8 @@ suite "EC NIST-P256/384/521 test suite":
       var key2 = fromHex(stripSpaces(ECDHEPrivateKeys[i * 2 + 1]))
       var seckey1 = EcPrivateKey.initRaw(key1).expect("initRaw key")
       var seckey2 = EcPrivateKey.initRaw(key2).expect("initRaw key")
-      var pubkey1 = seckey1.getKey().expect("public key")
-      var pubkey2 = seckey2.getKey().expect("public key")
+      var pubkey1 = seckey1.getPublicKey().expect("public key")
+      var pubkey2 = seckey2.getPublicKey().expect("public key")
       var secret1 = getSecret(pubkey2, seckey1)
       var secret2 = getSecret(pubkey1, seckey2)
       var expsecret = fromHex(stripSpaces(ECDHESecrets[i]))
@@ -364,7 +364,7 @@ suite "EC NIST-P256/384/521 test suite":
     for i in 0..<2:
       var sk = EcPrivateKey.init(stripSpaces(SignatureSecKeys[i])).expect("private key")
       var expectpk = EcPublicKey.init(stripSpaces(SignaturePubKeys[i])).expect("private key")
-      var checkpk = sk.getKey().expect("public key")
+      var checkpk = sk.getPublicKey().expect("public key")
       check expectpk == checkpk
       var checksig = sk.sign(SignatureMessages[i]).expect("signature")
       var expectsig = EcSignature.init(stripSpaces(SignatureVectors[i])).expect("signature")
@@ -378,7 +378,7 @@ suite "EC NIST-P256/384/521 test suite":
   test "[secp256r1] ECDSA non-deterministic test vectors":
     var sk = EcPrivateKey.init(stripSpaces(NDPrivateKeys[0])).expect("private key")
     var pk = EcPublicKey.init(stripSpaces(NDPublicKeys[0])).expect("public key")
-    var checkpk = sk.getKey().expect("public key")
+    var checkpk = sk.getPublicKey().expect("public key")
     check pk == checkpk
     for i in 0..<6:
       var message = NDMessages[i]
@@ -458,8 +458,8 @@ suite "EC NIST-P256/384/521 test suite":
       var key2 = fromHex(stripSpaces(ECDHEPrivateKeys[i * 2 + 1]))
       var seckey1 = EcPrivateKey.initRaw(key1).expect("private key")
       var seckey2 = EcPrivateKey.initRaw(key2).expect("private key")
-      var pubkey1 = seckey1.getKey().expect("public key")
-      var pubkey2 = seckey2.getKey().expect("public key")
+      var pubkey1 = seckey1.getPublicKey().expect("public key")
+      var pubkey2 = seckey2.getPublicKey().expect("public key")
       var secret1 = getSecret(pubkey2, seckey1)
       var secret2 = getSecret(pubkey1, seckey2)
       var expsecret = fromHex(stripSpaces(ECDHESecrets[i]))
@@ -471,7 +471,7 @@ suite "EC NIST-P256/384/521 test suite":
     for i in 2..<4:
       var sk = EcPrivateKey.init(stripSpaces(SignatureSecKeys[i])).expect("private key")
       var expectpk = EcPublicKey.init(stripSpaces(SignaturePubKeys[i])).expect("public key")
-      var checkpk = sk.getKey().expect("public key")
+      var checkpk = sk.getPublicKey().expect("public key")
       check expectpk == checkpk
       var checksig = sk.sign(SignatureMessages[i]).expect("signature")
       var expectsig = EcSignature.init(stripSpaces(SignatureVectors[i])).expect("signature")
@@ -485,7 +485,7 @@ suite "EC NIST-P256/384/521 test suite":
   test "[secp384r1] ECDSA non-deterministic test vectors":
     var sk = EcPrivateKey.init(stripSpaces(NDPrivateKeys[1])).expect("private key")
     var pk = EcPublicKey.init(stripSpaces(NDPublicKeys[1])).expect("public key")
-    var checkpk = sk.getKey().expect("public key")
+    var checkpk = sk.getPublicKey().expect("public key")
     check pk == checkpk
     for i in 6..<12:
       var message = NDMessages[i]
@@ -565,8 +565,8 @@ suite "EC NIST-P256/384/521 test suite":
       var key2 = fromHex(stripSpaces(ECDHEPrivateKeys[i * 2 + 1]))
       var seckey1 = EcPrivateKey.initRaw(key1).expect("private key")
       var seckey2 = EcPrivateKey.initRaw(key2).expect("private key")
-      var pubkey1 = seckey1.getKey().expect("public key")
-      var pubkey2 = seckey2.getKey().expect("public key")
+      var pubkey1 = seckey1.getPublicKey().expect("public key")
+      var pubkey2 = seckey2.getPublicKey().expect("public key")
       var secret1 = getSecret(pubkey2, seckey1)
       var secret2 = getSecret(pubkey1, seckey2)
       var expsecret = fromHex(stripSpaces(ECDHESecrets[i]))
@@ -578,7 +578,7 @@ suite "EC NIST-P256/384/521 test suite":
     for i in 4..<6:
       var sk = EcPrivateKey.init(stripSpaces(SignatureSecKeys[i])).expect("private key")
       var expectpk = EcPublicKey.init(stripSpaces(SignaturePubKeys[i])).expect("public key")
-      var checkpk = sk.getKey().expect("public key")
+      var checkpk = sk.getPublicKey().expect("public key")
       check expectpk == checkpk
       var checksig = sk.sign(SignatureMessages[i]).expect("signature")
       var expectsig = EcSignature.init(stripSpaces(SignatureVectors[i])).expect("signature")
@@ -592,7 +592,7 @@ suite "EC NIST-P256/384/521 test suite":
   test "[secp521r1] ECDSA non-deterministic test vectors":
     var sk = EcPrivateKey.init(stripSpaces(NDPrivateKeys[2])).expect("private key")
     var pk = EcPublicKey.init(stripSpaces(NDPublicKeys[2])).expect("public key")
-    var checkpk = sk.getKey().expect("public key")
+    var checkpk = sk.getPublicKey().expect("public key")
     check pk == checkpk
     for i in 12..<18:
       var message = NDMessages[i]

--- a/tests/tested25519.nim
+++ b/tests/tested25519.nim
@@ -161,7 +161,7 @@ suite "Ed25519 test suite":
     for i in 0..<5:
       var key = EdPrivateKey.init(stripSpaces(SecretKeys[i])).expect("key/sig")
       var exppub = EdPublicKey.init(stripSpaces(PublicKeys[i])).expect("key/sig")
-      var pubkey = key.getKey()
+      var pubkey = key.getPublicKey()
       check pubkey == exppub
       var msg = fromHex(stripSpaces(Messages[i]))
       var sig = key.sign(msg)

--- a/tests/testidentify.nim
+++ b/tests/testidentify.nim
@@ -70,7 +70,7 @@ suite "Identify":
       discard await msDial.select(conn, IdentifyCodec)
       let id = await identifyProto2.identify(conn, remotePeerInfo)
 
-      check id.pubKey.get() == remoteSecKey.getKey().get()
+      check id.pubKey.get() == remoteSecKey.getPublicKey().get()
       check id.addrs[0] == ma
       check id.protoVersion.get() == ProtoVersion
       check id.agentVersion.get() == AgentVersion
@@ -93,7 +93,7 @@ suite "Identify":
       discard await msDial.select(conn, IdentifyCodec)
       let id = await identifyProto2.identify(conn, remotePeerInfo)
 
-      check id.pubKey.get() == remoteSecKey.getKey().get()
+      check id.pubKey.get() == remoteSecKey.getPublicKey().get()
       check id.addrs[0] == ma
       check id.protoVersion.get() == ProtoVersion
       check id.agentVersion.get() == customAgentVersion

--- a/tests/testpeerid.nim
+++ b/tests/testpeerid.nim
@@ -183,7 +183,7 @@ suite "Peer testing suite":
   test "Go PeerID test vectors":
     for i in 0..<len(PrivateKeys):
       var seckey = PrivateKey.init(stripSpaces(PrivateKeys[i])).get()
-      var pubkey = seckey.getKey().get()
+      var pubkey = seckey.getPublicKey().get()
       var p1 = PeerID.init(seckey).get()
       var p2 = PeerID.init(pubkey).get()
       var p3 = PeerID.init(PeerIDs[i]).get()

--- a/tests/testpeerinfo.nim
+++ b/tests/testpeerinfo.nim
@@ -16,23 +16,23 @@ suite "PeerInfo":
 
     check peerId == peerInfo.peerId
     check seckey == peerInfo.privateKey
-    check seckey.getKey().get() == peerInfo.publicKey.get()
+    check seckey.getPublicKey().get() == peerInfo.publicKey.get()
 
   test "Should init with public key":
     let seckey = PrivateKey.random(ECDSA, rng[]).get()
-    var peerInfo = PeerInfo.init(seckey.getKey().get())
-    var peerId = PeerID.init(seckey.getKey().get()).get()
+    var peerInfo = PeerInfo.init(seckey.getPublicKey().get())
+    var peerId = PeerID.init(seckey.getPublicKey().get()).get()
 
     check peerId == peerInfo.peerId
-    check seckey.getKey.get() == peerInfo.publicKey.get()
+    check seckey.getPublicKey.get() == peerInfo.publicKey.get()
 
   test "Should init from PeerId with public key":
     let seckey = PrivateKey.random(Ed25519, rng[]).get()
-    var peerInfo = PeerInfo.init(PeerID.init(seckey.getKey.get()).get())
-    var peerId = PeerID.init(seckey.getKey.get()).get()
+    var peerInfo = PeerInfo.init(PeerID.init(seckey.getPublicKey.get()).get())
+    var peerId = PeerID.init(seckey.getPublicKey.get()).get()
 
     check peerId == peerInfo.peerId
-    check seckey.getKey.get() == peerInfo.publicKey.get()
+    check seckey.getPublicKey.get() == peerInfo.publicKey.get()
 
   test "Should init from CIDv0 string":
     var peerInfo: PeerInfo

--- a/tests/testrsa.nim
+++ b/tests/testrsa.nim
@@ -524,7 +524,7 @@ suite "RSA 2048/3072/4096 test suite":
     var pubkey = RsaPublicKey.init(pubser).expect("key initialization")
     check:
       seckey.getBytes().expect("bytes") == prvser
-    var cpubkey = seckey.getKey()
+    var cpubkey = seckey.getPublicKey()
     check:
       pubkey == cpubkey
       pubkey.getBytes().expect("bytes") == cpubkey.getBytes().expect("bytes")
@@ -547,7 +547,7 @@ suite "RSA 2048/3072/4096 test suite":
     var pubkey = RsaPublicKey.init(pubser).expect("key initialization")
     check:
       seckey.getBytes().expect("bytes") == prvser
-    var cpubkey = seckey.getKey()
+    var cpubkey = seckey.getPublicKey()
     check:
       pubkey == cpubkey
       pubkey.getBytes().expect("bytes") == cpubkey.getBytes().expect("bytes")
@@ -570,7 +570,7 @@ suite "RSA 2048/3072/4096 test suite":
     var pubkey = RsaPublicKey.init(pubser).expect("key initialization")
     check:
       seckey.getBytes().expect("bytes") == prvser
-    var cpubkey = seckey.getKey()
+    var cpubkey = seckey.getPublicKey()
     check:
       pubkey == cpubkey
       pubkey.getBytes().expect("bytes") == cpubkey.getBytes().expect("bytes")


### PR DESCRIPTION
Last name was confusing, eg: https://github.com/status-im/nim-libp2p/pull/610#discussion_r699668952
Also avoided to do
```nim
privateKey
.getPublicKey()
```
Which can be confusing