### PR TITLE
Fix macos go-daemon CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
 
       - name: Install p2pd
         run: |
-          V=1 bash scripts/build_p2pd.sh p2pdCache v0.3.0
+          V=1 bash scripts/build_p2pd.sh p2pdCache 124530a3
 
       - name: Run nim-libp2p tests
         run: |


### PR DESCRIPTION
bump libp2p-go-daemon to `124530a3` (v0.3.0 is broken on MacOS)