### PR TITLE
Fix muxer bandwidth typo

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -20,7 +20,7 @@ requires "nim >= 1.2.0",
 
 proc runTest(filename: string, verify: bool = true, sign: bool = true,
              moreoptions: string = "") =
-  var excstr = "nim c --opt:speed -d:debug -d:libp2p_agents_metrics -d:libp2p_protobuf_metrics -d:lipp2p_network_protocols_metrics --verbosity:0 --hints:off"
+  var excstr = "nim c --opt:speed -d:debug -d:libp2p_agents_metrics -d:libp2p_protobuf_metrics -d:libp2p_network_protocols_metrics --verbosity:0 --hints:off"
   excstr.add(" --warning[CaseTransition]:off --warning[ObservableStores]:off --warning[LockLevel]:off")
   excstr.add(" -d:libp2p_pubsub_sign=" & $sign)
   excstr.add(" -d:libp2p_pubsub_verify=" & $verify)

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -21,7 +21,7 @@ export connection
 logScope:
   topics = "libp2p mplexchannel"
 
-when defined(lipp2p_network_protocols_metrics):
+when defined(libp2p_network_protocols_metrics):
   declareCounter libp2p_protocols_bytes, "total sent or received bytes", ["protocol", "direction"]
 
 ## Channel half-closed states
@@ -159,7 +159,7 @@ method readOnce*(s: LPChannel,
   ## or the reads will lock each other.
   try:
     let bytes = await procCall BufferStream(s).readOnce(pbytes, nbytes)
-    when defined(lipp2p_network_protocols_metrics):
+    when defined(libp2p_network_protocols_metrics):
       if s.tag.len > 0:
         libp2p_protocols_bytes.inc(bytes.int64, labelValues=[s.tag, "in"])
 
@@ -201,7 +201,7 @@ method write*(s: LPChannel, msg: seq[byte]): Future[void] {.async.} =
 
     await s.conn.writeMsg(s.id, s.msgCode, msg)
 
-    when defined(lipp2p_network_protocols_metrics):
+    when defined(libp2p_network_protocols_metrics):
       if s.tag.len > 0:
         libp2p_protocols_bytes.inc(msg.len.int64, labelValues=[s.tag, "out"])
 


### PR DESCRIPTION
Follow up #607 

Fix typo in CT flag: -d:li**p**p2p_network_protocols_metrics