### PR TITLE
Score correctly on mesh peer unsub

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -182,15 +182,15 @@ method unsubscribePeer*(g: GossipSub, peer: PeerID) =
       if s[].len == 0:
         g.peersInIP.del(pubSubPeer.address.get())
 
-  for t in toSeq(g.gossipsub.keys):
-    g.gossipsub.removePeer(t, pubSubPeer)
-    # also try to remove from explicit table here
-    g.explicit.removePeer(t, pubSubPeer)
-
   for t in toSeq(g.mesh.keys):
     trace "pruning unsubscribing peer", pubSubPeer, score = pubSubPeer.score
     g.pruned(pubSubPeer, t)
     g.mesh.removePeer(t, pubSubPeer)
+
+  for t in toSeq(g.gossipsub.keys):
+    g.gossipsub.removePeer(t, pubSubPeer)
+    # also try to remove from explicit table here
+    g.explicit.removePeer(t, pubSubPeer)
 
   for t in toSeq(g.fanout.keys):
     g.fanout.removePeer(t, pubSubPeer)
@@ -233,13 +233,13 @@ proc handleSubscribe*(g: GossipSub,
   else:
     trace "peer unsubscribed from topic"
 
-    # unsubscribe remote peer from the topic
-    g.gossipsub.removePeer(topic, peer)
-
     if g.mesh.hasPeer(topic, peer):
       #against spec
       g.mesh.removePeer(topic, peer)
       g.pruned(peer, topic)
+
+    # unsubscribe remote peer from the topic
+    g.gossipsub.removePeer(topic, peer)
 
     g.fanout.removePeer(topic, peer)
     if peer.peerId in g.parameters.directPeers:

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -235,7 +235,12 @@ proc handleSubscribe*(g: GossipSub,
 
     # unsubscribe remote peer from the topic
     g.gossipsub.removePeer(topic, peer)
-    g.mesh.removePeer(topic, peer)
+
+    if g.mesh.hasPeer(topic, peer):
+      #against spec
+      g.mesh.removePeer(topic, peer)
+      g.pruned(peer, topic)
+
     g.fanout.removePeer(topic, peer)
     if peer.peerId in g.parameters.directPeers:
       g.explicit.removePeer(topic, peer)


### PR DESCRIPTION
Related to #641

When a peer unsub without pruning before, we currently keep it "in mesh" in the scoring mechanism, which create issues