### PR TITLE
Short agent fix

### DIFF
--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -97,6 +97,8 @@ proc newStreamInternal*(m: Mplex,
   result.peerId = m.connection.peerId
   result.observedAddr = m.connection.observedAddr
   result.transportDir = m.connection.transportDir
+  when defined(libp2p_agents_metrics):
+    result.shortAgent = m.connection.shortAgent
 
   trace "Creating new channel", m, channel = result, id, initiator, name
 

--- a/libp2p/upgrademngrs/muxedupgrade.nim
+++ b/libp2p/upgrademngrs/muxedupgrade.nim
@@ -173,6 +173,11 @@ proc muxerHandler(
 
   try:
     await self.identify(muxer)
+    when defined(libp2p_agents_metrics):
+      #TODO Passing data between layers is a pain
+      if muxer.connection of SecureConn:
+        let secureConn = (SecureConn)muxer.connection
+        secureConn.stream.shortAgent = muxer.connection.shortAgent
   except IdentifyError as exc:
     # Identify is non-essential, though if it fails, it might indicate that
     # the connection was closed already - this will be picked up by the read


### PR DESCRIPTION
closes #635 

The current "connection management" makes this operation a bit painful, because it's hard to pass data around layers (`libp2p_peers_identity` needs the shortAgent on "layer 0" (chronosstream), but the shortAgent is given on identify which is "layer 4" (chronosstream -> secureconn -> muxer -> identify), so we have to copy it around everywhere)

So dirty fix for now, hopefully will improve with better conn management