### PR TITLE
New builders PoC

### DIFF
--- a/libp2p/builders2.nim
+++ b/libp2p/builders2.nim
@@ -1,82 +1,85 @@
 {.push raises: [Defect].}
 
 import
-  macros,
-  options, tables, chronos, chronicles, bearssl,
-  switch, peerid, peerinfo, stream/connection, multiaddress,
-  crypto/crypto, transports/[transport, tcptransport],
-  muxers/[muxer, mplex/mplex],
-  protocols/[identify, secure/secure, secure/noise],
-  connmanager, upgrademngrs/muxedupgrade,
-  nameresolving/nameresolver,
-  errors,
+  std/[macros, options, tables],
+  chronos, chronicles, bearssl,
+  switch, peerid, peerinfo,
   sequtils
 
-export
-  switch, peerid, peerinfo, connection, multiaddress, crypto, errors
+export switch, peerid, peerinfo
 
 type
   SwitchBuilder* = ref object
     switch: Switch
     locks: Table[string, string]
+    finishedMounting: seq[proc() {.gcsafe.}]
     mounting: string
 
 proc new*(T: type[SwitchBuilder], switchType: type[Switch] = Switch): T =
   T(
-    switch: switchType.new()
+    switch: switchType(peerStore: PeerStore.new())
   )
-
-#proc new*(T: type[SwitchBuilder],
-#  addrs: seq[MultiAddress],
-#  rng = newRng()): T =
-#
-#  try:
-#    let
-#      secKey = PrivateKey.random(rng[])
-#      peerInfo = PeerInfo.new(secKey.tryGet(), addrs)
-#    result = T.new(peerInfo)
-#  except: discard
 
 template borrowVar(toBorrow: untyped) =
   const field = $typeof(Switch.toBorrow) # Shows "seq[Transport]"
   #const field = astToStr(toBorrow)      # Shows "transports"
 
-  proc toBorrow*(switchBuilder: SwitchBuilder): auto =
-    let isNotSetup =
-      when Switch.toBorrow is ref:
-        isNil switchBuilder.switch.toBorrow
-      elif Switch.toBorrow is seq:
-        switchBuilder.switch.toBorrow.len == 0
-      elif Switch.toBorrow is Table:
-        toSeq(switchBuilder.switch.toBorrow.keys).len == 0
 
-    if isNotSetup:
-      raise newException(Defect,
-        "With(" & switchBuilder.mounting & "): " & field & " should be setup first")
+  # Goal is to avoid 2 things:
+  # - Someone using something which is not initialized
+  # - Someone writing to a variable which has already been used
+  #   by somebody else.
+  #
+  # For refs, it's easy:
+  # When someone access it, we check if it's nil. If it's nil, we raise
+  # If someone access it and it's not nil, we'll store who accessed to it
+  # in the `lock` table. If someone tries to write to it afterward, we'll throw
+  #
+  #
+  # For seq & table it's basically the same, the only issue is
+  # that we don't know when people write to it, because they just do
+  # `sequence.add(value)`, which just calls toBorrow, and not toBorrow=
+  #
+  # Instead, when someone access it, we store the current length
+  # and when he's done mounting it, we have 2 cases:
+  #
+  # oldLen == newLen: user copied it, verify that it was initialised + lock
+  # oldLen < newLen: user added something to it, verify that it isn't locked
+
+  proc toBorrow*(switchBuilder: SwitchBuilder): var typeof(Switch.toBorrow) =
+    when Switch.toBorrow is ref:
+      if isNil switchBuilder.switch.toBorrow:
+        raise newException(Defect,
+          "With(" & switchBuilder.mounting & "): " & field & " should be setup first")
+
+    when Switch.toBorrow is seq or Switch.toBorrow is Table:
+      let currentLen = switchBuilder.switch.toBorrow.len
+
+      switchBuilder.finishedMounting &= proc() =
+        if switchBuilder.switch.toBorrow.len != currentLen: # Wrote to it
+          if field in switchBuilder.locks:
+            raise newException(Defect,
+              "With(" & switchBuilder.mounting & "): can't be done after With(" & switchBuilder.locks.getOrDefault(field) & ")")
+        else: # Read it
+          if switchBuilder.switch.toBorrow.len == 0:
+            raise newException(Defect,
+              "With(" & switchBuilder.mounting & "): " & field & " should be setup first")
+
+          if field notin switchBuilder.locks:
+            switchBuilder.locks[field] = switchBuilder.mounting
+
+      return switchBuilder.switch.toBorrow
 
     if field notin switchBuilder.locks:
       switchBuilder.locks[field] = switchBuilder.mounting
 
     switchBuilder.switch.toBorrow
 
-  proc `toBorrow Add`*(switchBuilder: SwitchBuilder, value: auto) =
-    if field in switchBuilder.locks:
-      raise newException(Defect,
-        "With(" & switchBuilder.mounting & "): can't be done after With(" & switchBuilder.locks.getOrDefault(field) & ")")
-    # I don't like this
-    switchBuilder.switch.toBorrow &= value
-
-  proc `toBorrow Add`*(switchBuilder: SwitchBuilder, key, value: auto) =
-    if field in switchBuilder.locks:
-      raise newException(Defect,
-        "With(" & switchBuilder.mounting & "): can't be done after With(" & switchBuilder.locks.getOrDefault(field) & ")")
-    # I don't like this
-    switchBuilder.switch.toBorrow[key] = value
-
   proc `toBorrow=`*(switchBuilder: SwitchBuilder, value: auto): auto =
     if field in switchBuilder.locks:
       raise newException(Defect,
         "With(" & switchBuilder.mounting & "): can't be done after With(" & switchBuilder.locks.getOrDefault(field) & ")")
+
     switchBuilder.switch.toBorrow = value
 
 borrowVar(identify)
@@ -89,6 +92,14 @@ borrowVar(ms)
 borrowVar(dialer)
 borrowVar(transports)
 
+proc build*(switchBuilder: SwitchBuilder): Switch =
+  # to throw if Dialer is not set
+  discard switchBuilder.dialer
+  switchBuilder.switch
+
+{.pop.}
+# mount can raise
+
 # borrow
 proc mount*(s: SwitchBuilder, proto: LPProtocol, matcher: Matcher = nil)
   {.gcsafe, raises: [Defect, LPError].} =
@@ -99,15 +110,13 @@ proc mount*(s: SwitchBuilder, proto: LPProtocol, matcher: Matcher = nil)
 
 proc with*[T](switchBuilder: SwitchBuilder, val: T): T {.discardable.} =
   switchBuilder.mounting = $typeof(val)
-  switchBuilder.switchWith(val)
+  switchBuilder.finishedMounting.setLen(0)
+  switchBuilder.setup(val)
+  for handler in switchBuilder.finishedMounting:
+    handler()
   switchBuilder.mounting = "Unknown"
   val
 
 template with*(switchBuilder: SwitchBuilder, args: varargs[untyped]) =
   #switchBuilder.with(unpackVarargs(new, args))
   switchBuilder.with(new(args))
-
-proc build*(switchBuilder: SwitchBuilder): Switch =
-  # to throw if Dialer is not set
-  discard switchBuilder.dialer
-  switchBuilder.switch

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -103,11 +103,9 @@ proc new*(C: type ConnManager,
     inSema: inSema,
     outSema: outSema)
 
-proc switchWith*[Switch](s: Switch,
-  connManager: ConnManager,
-  ) =
-  s.connManager = connManager
-  connManager.peerStore = s.peerStore
+proc setup*[Ctx](c: Ctx, connManager: ConnManager) =
+  c.connManager = connManager
+  connManager.peerStore = c.peerStore
 
 proc connCount*(c: ConnManager, peerId: PeerID): int =
   c.conns.getOrDefault(peerId).len

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -107,6 +107,7 @@ proc switchWith*[Switch](s: Switch,
   connManager: ConnManager,
   ) =
   s.connManager = connManager
+  connManager.peerStore = s.peerStore
 
 proc connCount*(c: ConnManager, peerId: PeerID): int =
   c.conns.getOrDefault(peerId).len

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -103,6 +103,15 @@ proc new*(C: type ConnManager,
     inSema: inSema,
     outSema: outSema)
 
+proc mount*[Switch](s: Switch,
+  T: typedesc[ConnManager],
+  maxConnsPerPeer = MaxConnectionsPerPeer,
+  maxConnections = MaxConnections,
+  maxIn = -1,
+  maxOut = -1) =
+  let connManager = T.new(maxConnsPerPeer, maxConnections, maxIn, maxOut)
+  s.connManager = connManager
+
 proc connCount*(c: ConnManager, peerId: PeerID): int =
   c.conns.getOrDefault(peerId).len
 

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -250,12 +250,9 @@ proc new*(
     ms: ms,
     nameResolver: nameResolver)
 
-proc switchWith*[Switch](
-  s: Switch,
-  dial: Dialer) =
-
-  dial.localPeerId = s.peerInfo.peerId
-  dial.connManager = s.connManager
-  dial.transports = s.transports
-  dial.ms = s.ms
-  s.dialer = dial
+proc setup*[Ctx](c: Ctx, dial: Dialer) =
+  dial.localPeerId = c.peerInfo.peerId
+  dial.connManager = c.connManager
+  dial.transports = c.transports
+  dial.ms = c.ms
+  c.dialer = dial

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -43,8 +43,8 @@ type
 proc new*(T: typedesc[MultistreamSelect]): T =
   T(codec: MSCodec)
 
-proc switchWith*[Switch](s: Switch, ms: MultistreamSelect) =
-  s.ms = ms
+proc setup*[Ctx](c: Ctx, ms: MultistreamSelect) =
+  c.ms = ms
 
 template validateSuffix(str: string): untyped =
     if str.endsWith("\n"):

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -240,10 +240,11 @@ method close*(m: Mplex) {.async, gcsafe.} =
 
   trace "Closed mplex", m
 
-proc switchWith*[Switch](s: Switch, mplex: Mplex) =
+proc setup*[Ctx](c: Ctx, mplex: Mplex) =
   proc newMuxer(conn: Connection): Muxer =
     Mplex.new(
       conn,
       inTimeout = 5.minutes,
       outTimeout = 5.minutes)
-  s.muxersAdd(MplexCodec, MuxerProvider.new(newMuxer, MplexCodec))
+
+  c.muxers[MplexCodec] = MuxerProvider.new(newMuxer, MplexCodec)

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -246,4 +246,4 @@ proc switchWith*[Switch](s: Switch, mplex: Mplex) =
       conn,
       inTimeout = 5.minutes,
       outTimeout = 5.minutes)
-  s.switch.muxers[MplexCodec] = MuxerProvider.new(newMuxer, MplexCodec)
+  s.muxersAdd(MplexCodec, MuxerProvider.new(newMuxer, MplexCodec))

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -239,3 +239,11 @@ method close*(m: Mplex) {.async, gcsafe.} =
   m.channels[true].clear()
 
   trace "Closed mplex", m
+
+proc mount*[Switch](s: Switch, T: typedesc[Mplex], inTimeout = 5.minutes, outTimeout = 5.minutes) =
+  proc newMuxer(conn: Connection): Muxer =
+    Mplex.new(
+      conn,
+      inTimeout = inTimeout,
+      outTimeout = outTimeout)
+  s.muxers[MplexCodec] = MuxerProvider.new(newMuxer, MplexCodec)

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -63,3 +63,22 @@ proc new*(
     protocols: @protocols)
 
   return peerInfo
+
+proc new*(
+  p: typedesc[PeerInfo],
+  rng = newRng(),
+  addrs: openarray[MultiAddress] = [],
+  protocols: openarray[string] = [],
+  protoVersion: string = "",
+  agentVersion: string = ""): PeerInfo
+  {.raises: [Defect, PeerInfoError].} =
+
+  try:
+    PeerInfo.new(PrivateKey.random(rng[]).tryGet(), addrs, protocols, protoVersion, agentVersion)
+  except:
+    raise newException(PeerInfoError, "Can't generate random key")
+
+proc switchWith*[Switch](s: Switch,
+  peerInfo: PeerInfo) =
+
+  s.peerInfo = peerInfo

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -73,12 +73,12 @@ proc new*(
   agentVersion: string = ""): PeerInfo
   {.raises: [Defect, PeerInfoError].} =
 
-  try:
-    PeerInfo.new(PrivateKey.random(rng[]).tryGet(), addrs, protocols, protoVersion, agentVersion)
-  except:
-    raise newException(PeerInfoError, "Can't generate random key")
+  let randomPrivateKey = PrivateKey.random(rng[])
+  if randomPrivateKey.isErr:
+    raise newException(PeerInfoError, "Failed to create a random private key")
 
-proc switchWith*[Switch](s: Switch,
+  PeerInfo.new(randomPrivateKey.get(), addrs, protocols, protoVersion, agentVersion)
+
+proc setup*[Ctx](c: Ctx,
   peerInfo: PeerInfo) =
-
-  s.peerInfo = peerInfo
+  c.peerInfo = peerInfo

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -122,6 +122,16 @@ proc new*(T: typedesc[Identify], peerInfo: PeerInfo): T =
   identify.init()
   identify
 
+proc new*(T: typedesc[Identify]): T =
+  let identify = T()
+  identify.init()
+  identify
+
+proc setup*[Ctx](c: Ctx, i: Identify) {.raises: [Defect, LPError].} =
+  i.peerInfo = c.peerInfo
+  c.identify = i
+  c.mount(i)
+
 method init*(p: Identify) =
   proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
     try:
@@ -209,12 +219,3 @@ proc push*(p: IdentifyPush, peerInfo: PeerInfo, conn: Connection) {.async.} =
   var pb = encodeMsg(peerInfo, conn.observedAddr)
   await conn.writeLp(pb.buffer)
 
-proc switchWith*[Switch](s: Switch, i: Identify)
-  {.gcsafe, raises: [Defect].} =
-
-  i.init()
-  i.peerInfo = s.peerInfo
-  s.identify = i
-  try:
-    s.mount(i)
-  except: discard

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -208,3 +208,10 @@ proc init*(p: IdentifyPush) =
 proc push*(p: IdentifyPush, peerInfo: PeerInfo, conn: Connection) {.async.} =
   var pb = encodeMsg(peerInfo, conn.observedAddr)
   await conn.writeLp(pb.buffer)
+
+proc mount*[Switch](i: Identify, s: Switch)
+  {.gcsafe, raises: [Defect, LPError].} =
+
+  i.init()
+  i.peerInfo = s.peerInfo
+  s.identify = i

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -215,3 +215,12 @@ proc mount*[Switch](i: Identify, s: Switch)
   i.init()
   i.peerInfo = s.peerInfo
   s.identify = i
+
+proc mount*[Switch](i: IdentifyPush, s: Switch)
+  {.gcsafe, raises: [Defect, LPError].} =
+
+  proc updateStore(peerId: PeerId, info: IdentifyInfo) {.async.} =
+    s.peerStore.updatePeerInfo(info)
+
+  i.identifyHandler = updateStore
+  i.init()

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -216,5 +216,5 @@ proc switchWith*[Switch](s: Switch, i: Identify)
   i.peerInfo = s.peerInfo
   s.identify = i
   try:
-    s.switch.mount(i)
+    s.mount(i)
   except: discard

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -629,14 +629,11 @@ proc new*(
     commonPrologue: commonPrologue,
   )
 
+  noise.init()
   noise
 
-proc switchWith*[Switch](
-  s: Switch,
-  noise: Noise) =
-
-  noise.init()
-  noise.localPrivateKey = s.peerInfo.privateKey
+proc setup*[Ctx](c: Ctx, noise: Noise) =
+  noise.localPrivateKey = c.peerInfo.privateKey
 
   let pkBytes = noise.localPrivateKey.getPublicKey()
   .expect("Expected valid Private Key")
@@ -644,4 +641,4 @@ proc switchWith*[Switch](
 
   noise.localPublicKey = pkBytes
 
-  s.secureManagersAdd(noise)
+  c.secureManagers &= noise

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -615,3 +615,13 @@ proc new*(
 
   noise.init()
   noise
+
+proc mount*[Switch](
+  s: Switch,
+  T: typedesc[Noise],
+  rng: ref BrHmacDrbgContext,
+  outgoing: bool = true,
+  commonPrologue: seq[byte] = @[]) =
+
+  let noise = T.new(rng, s.peerInfo.privateKey, outgoing, commonPrologue)
+  s.secureManagers &= noise

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -143,12 +143,6 @@ proc mount*(s: Switch, proto: LPProtocol, matcher: Matcher = nil)
   s.ms.addHandler(proto.codecs, proto, matcher)
   s.peerInfo.protocols.add(proto.codec)
 
-proc mount*(s: Switch, T: typedesc[LPProtocol])
-  {.gcsafe, raises: [Defect, LPError].} =
-  let t = T.new()
-  t.mount(s)
-  s.mount(t)
-
 proc upgradeMonitor(conn: Connection, upgrades: AsyncSemaphore) {.async.} =
   ## monitor connection for upgrades
   ##
@@ -275,12 +269,12 @@ proc start*(s: Switch) {.async, gcsafe.} =
   debug "Started libp2p node", peer = s.peerInfo
 
 proc new*(
-  T: typedesc[Switch],
-  peerInfo: PeerInfo,
-  ms = MultistreamSelect.new()): T =
+  T: typedesc[Switch]
+  ): T =
+
   T(
-    peerInfo: peerInfo,
-    ms: ms)
+    peerStore: PeerStore.new()
+  )
 
 proc new*(T: typedesc[Switch],
   addrs: seq[MultiAddress],

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -268,23 +268,6 @@ proc start*(s: Switch) {.async, gcsafe.} =
 
   debug "Started libp2p node", peer = s.peerInfo
 
-proc new*(
-  T: typedesc[Switch]
-  ): T =
-
-  T(
-    peerStore: PeerStore.new()
-  )
-
-proc new*(T: typedesc[Switch],
-  addrs: seq[MultiAddress],
-  rng = newRng()): T =
-
-  let
-    secKey = PrivateKey.random(rng[])
-    peerInfo = PeerInfo.new(secKey.tryGet(), addrs)
-  T.new(peerInfo)
-
 proc newSwitch*(peerInfo: PeerInfo,
                 transports: seq[Transport],
                 identity: Identify,

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -127,6 +127,14 @@ proc new*(
   inc getTcpTransportTracker().opened
   return transport
 
+proc mount*[Switch](s: Switch,
+  T: typedesc[TcpTransport],
+  flags: set[ServerFlags] = {}) =
+
+  let transp = T.new(flags, s.getUpgrade())
+  s.transports &= transp
+
+
 method start*(
   self: TcpTransport,
   ma: MultiAddress) {.async.} =

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -128,12 +128,10 @@ proc new*(
   inc getTcpTransportTracker().opened
   return transport
 
-proc switchWith*[Switch](s: Switch,
-  tcpTransport: TcpTransport) =
-
-  let upgrade = MuxedUpgrade.new(s.identify, s.muxers, s.secureManagers, s.connManager, s.ms)
+proc setup*[Ctx](c: Ctx, tcpTransport: TcpTransport) =
+  let upgrade = MuxedUpgrade.new(c.identify, c.muxers, c.secureManagers, c.connManager, c.ms)
   tcpTransport.upgrader = upgrade
-  s.transportsAdd(tcpTransport)
+  c.transports = c.transports & tcpTransport
 
 method start*(
   self: TcpTransport,

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -133,7 +133,7 @@ proc switchWith*[Switch](s: Switch,
 
   let upgrade = MuxedUpgrade.new(s.identify, s.muxers, s.secureManagers, s.connManager, s.ms)
   tcpTransport.upgrader = upgrade
-  s.switch.transports &= tcpTransport
+  s.transportsAdd(tcpTransport)
 
 method start*(
   self: TcpTransport,


### PR DESCRIPTION
#551 introduced Builders, which allows to build the switch like this:
```nim
  var switch = SwitchBuilder
    .new()
    .withRng(rng)       # Give the application RNG
    .withAddress(ma)    # Our local address(es)
    .withTcpTransport() # Use TCP as transport
    .withMplex()        # Use Mplex as muxer
    .withNoise()        # Use Noise as secure manager
    .build()
```

My main gripe with it is that the `builders.nim` file must import & handle the setup logic of every module of libp2p. Beside being fairly centralized, this also forces everyone to compile every module, even if they don't use them.

To avoid this issue with WS, I had to create a generic builder:
```nim
.withTransport(proc (upgr: Upgrade): Transport = WsTransport.new(upgr))
```
But now, websocket is a second class citizen, because it's harder to create than Tcp.

Other example, to implement PushIdentify, which requires some wiring up in the switch, I need to add it again in the `builders.nim`

This PR is an attempt to create a new builder system which alleviates some of the issues. Example build with it:
```nim
  var switch = Switch.new(peerInfo)
  switch.mount(Identify)
  switch.mount(Mplex)
  switch.mount(ConnManager)
  switch.mount(Noise, rng)
  switch.mount(TcpTransport)
```

Each `mount` is now handled in each module directly, ex in `tcptransport.nim`:
```nim
proc mount*[Switch](s: Switch,
  T: typedesc[TcpTransport],
  flags: set[ServerFlags] = {}) =
  
  let transp = T.new(flags, s.getUpgrade())
  s.transports &= transp
```
(The generic is a ugly hack to avoid circular imports in some cases)


The biggest downside of this technique is that you must mount everything manually, and in the right order (eg, mount transports last because they need the upgrade). But imo, it's easy & clear enough to add errors when you miss some mandatory protocols

Creating this PR to get some opinions. There is a lot of cleanup potential, this `mount` (which we can rename) could replace most constructors, the `LPProtocol` `init` method, etc

Obviously, big breaking change, which is why I would like to squeeze it before V1 if you like it