### PR TITLE
Send signed peer record as part of identify

### DIFF
--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -9,13 +9,18 @@
 
 {.push raises: [Defect].}
 
-import std/[options, sequtils, hashes]
-import pkg/[chronos, chronicles, stew/results]
-import peerid, multiaddress, crypto/crypto, errors
+import std/[options, sequtils, hashes, times]
+import pkg/[chronos, chronicles, stew/byteutils, stew/results]
+import peerid, multiaddress, crypto/crypto, signed_envelope, routing_record, errors
 
-export peerid, multiaddress, crypto, errors, results
+export peerid, multiaddress, crypto, signed_envelope, errors, results
 
 ## Our local peer info
+
+## Constants relating to signed peer records
+const
+  EnvelopePayloadType* = "/libp2p/routing-state-record".toBytes() # payload_type for routing records as spec'ed in RFC0003
+  EnvelopeDomain* = "libp2p-routing-record" # envelope domain as per RFC0002
 
 type
   PeerInfoError* = LPError
@@ -28,6 +33,25 @@ type
     agentVersion*: string
     privateKey*: PrivateKey
     publicKey*: PublicKey
+    signedPeerRecord*: Option[Envelope]
+
+proc createSignedPeerRecord(peerId: PeerID, addrs: seq[MultiAddress], key: PrivateKey): Result[Envelope, CryptoError] =
+  ## Creates a signed peer record for this peer:
+  ## a peer routing record according to https://github.com/libp2p/specs/blob/master/RFC/0003-routing-records.md
+  ## in a signed envelope according to https://github.com/libp2p/specs/blob/master/RFC/0002-signed-envelopes.md
+
+  # First create a peer record from the peer info
+  let peerRecord = PeerRecord.init(peerId,
+                                   getTime().toUnix().uint64, # This currently follows the recommended implementation, using unix epoch as seq no.
+                                   addrs)
+
+  # Wrap peer record in envelope and sign
+  let envelope = ? Envelope.init(key,
+                                 EnvelopePayloadType,
+                                 peerRecord.encode(),
+                                 EnvelopeDomain)
+  
+  ok(envelope)
 
 func shortLog*(p: PeerInfo): auto =
   (
@@ -52,14 +76,24 @@ proc new*(
       key.getPublicKey().tryGet()
     except CatchableError:
       raise newException(PeerInfoError, "invalid private key")
+  
+  let peerId = PeerID.init(key).tryGet()
+
+  # TODO: should using signed peer records be configurable?
+  let sprRes = createSignedPeerRecord(peerId, @addrs, key)
+  let spr = if sprRes.isOk:
+              some(sprRes.get())
+            else:
+              none(Envelope)
 
   let peerInfo = PeerInfo(
-    peerId: PeerID.init(key).tryGet(),
+    peerId: peerId,
     publicKey: pubkey,
     privateKey: key,
     protoVersion: protoVersion,
     agentVersion: agentVersion,
     addrs: @addrs,
-    protocols: @protocols)
+    protocols: @protocols,
+    signedPeerRecord: spr)
 
   return peerInfo

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -44,6 +44,7 @@ type
     protoVersion*: Option[string]
     agentVersion*: Option[string]
     protos*: seq[string]
+    signedPeerRecord*: Option[Envelope]
 
   Identify* = ref object of LPProtocol
     peerInfo*: PeerInfo
@@ -76,6 +77,14 @@ proc encodeMsg*(peerInfo: PeerInfo, observedAddr: Multiaddress): ProtoBuffer
   else:
     peerInfo.agentVersion
   result.write(6, agentVersion)
+
+  ## Optionally populate signedPeerRecord field.
+  ## See https://github.com/libp2p/go-libp2p/blob/master/p2p/protocol/identify/pb/identify.proto for reference.
+  if peerInfo.signedPeerRecord.isSome():
+    let sprBuff = peerInfo.signedPeerRecord.get().encode()
+    if sprBuff.isOk():
+      result.write(8, sprBuff.get())
+
   result.finish()
 
 proc decodeMsg*(buf: seq[byte]): Option[IdentifyInfo] =
@@ -85,6 +94,7 @@ proc decodeMsg*(buf: seq[byte]): Option[IdentifyInfo] =
     oaddr: MultiAddress
     protoVersion: string
     agentVersion: string
+    signedPeerRecord: Envelope
 
   var pb = initProtoBuffer(buf)
 
@@ -95,8 +105,11 @@ proc decodeMsg*(buf: seq[byte]): Option[IdentifyInfo] =
   let r5 = pb.getField(5, protoVersion)
   let r6 = pb.getField(6, agentVersion)
 
+  let r8 = pb.getField(8, signedPeerRecord, EnvelopeDomain)
+
   let res = r1.isOk() and r2.isOk() and r3.isOk() and
-            r4.isOk() and r5.isOk() and r6.isOk()
+            r4.isOk() and r5.isOk() and r6.isOk() and
+            r8.isOk()
 
   if res:
     if r1.get():
@@ -107,11 +120,14 @@ proc decodeMsg*(buf: seq[byte]): Option[IdentifyInfo] =
       iinfo.protoVersion = some(protoVersion)
     if r6.get():
       iinfo.agentVersion = some(agentVersion)
+    if r8.get():
+      iinfo.signedPeerRecord = some(signedPeerRecord)
     debug "decodeMsg: decoded message", pubkey = ($pubKey).shortLog,
           addresses = $iinfo.addrs, protocols = $iinfo.protos,
           observable_address = $iinfo.observedAddr,
           proto_version = $iinfo.protoVersion,
-          agent_version = $iinfo.agentVersion
+          agent_version = $iinfo.agentVersion,
+          signedPeerRecord = $iinfo.signedPeerRecord
     some(iinfo)
   else:
     trace "decodeMsg: failed to decode received message"

--- a/libp2p/signed_envelope.nim
+++ b/libp2p/signed_envelope.nim
@@ -100,3 +100,19 @@ proc encode*(env: Envelope): Result[seq[byte], CryptoError] =
 proc payload*(env: Envelope): seq[byte] =
   # Payload is readonly
   env.payload
+
+proc getField*(pb: ProtoBuffer, field: int,
+               value: var Envelope,
+               domain: string): ProtoResult[bool] {.
+     inline.} =
+  var buffer: seq[byte]
+  let res = ? pb.getField(field, buffer)
+  if not(res):
+    ok(false)
+  else:
+    let env = Envelope.decode(buffer, domain)
+    if env.isOk():
+      value = env.get()
+      ok(true)
+    else:
+      err(ProtoError.IncorrectBlob)

--- a/tests/testidentify.nim
+++ b/tests/testidentify.nim
@@ -75,6 +75,7 @@ suite "Identify":
       check id.protoVersion.get() == ProtoVersion
       check id.agentVersion.get() == AgentVersion
       check id.protos == @["/test/proto1/1.0.0", "/test/proto2/1.0.0"]
+      check id.signedPeerRecord.get() == remotePeerInfo.signedPeerRecord.get()
 
     asyncTest "custom agent version":
       const customAgentVersion = "MY CUSTOM AGENT STRING"
@@ -98,6 +99,7 @@ suite "Identify":
       check id.protoVersion.get() == ProtoVersion
       check id.agentVersion.get() == customAgentVersion
       check id.protos == @["/test/proto1/1.0.0", "/test/proto2/1.0.0"]
+      check id.signedPeerRecord.get() == remotePeerInfo.signedPeerRecord.get()
 
     asyncTest "handle failed identify":
       msListen.addHandler(IdentifyCodec, identifyProto1)

--- a/tests/testpeerinfo.nim
+++ b/tests/testpeerinfo.nim
@@ -4,7 +4,8 @@ import options, bearssl
 import chronos
 import ../libp2p/crypto/crypto,
        ../libp2p/peerinfo,
-       ../libp2p/peerid
+       ../libp2p/peerid,
+       ../libp2p/routing_record
 
 import ./helpers
 
@@ -16,3 +17,28 @@ suite "PeerInfo":
 
     check peerId == peerInfo.peerId
     check seckey.getPublicKey().get() == peerInfo.publicKey
+  
+  test "Signed peer record":
+    let
+      seckey = PrivateKey.random(rng[]).tryGet()
+      peerId = PeerID.init(seckey).get()
+      multiAddresses = @[MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet(), MultiAddress.init("/ip4/0.0.0.0/tcp/25").tryGet()]
+      peerInfo = PeerInfo.new(seckey, multiAddresses)
+    
+    let
+      env = peerInfo.signedPeerRecord.get()
+      rec = PeerRecord.decode(env.payload()).tryGet()
+    
+    # Check envelope fields
+    check:
+      env.publicKey == peerInfo.publicKey
+      env.domain == EnvelopeDomain
+      env.payloadType == EnvelopePayloadType
+
+    # Check payload (routing record)
+    check:
+      rec.peerId == peerId
+      rec.seqNo > 0
+      rec.addresses.len == 2
+      rec.addresses[0].address == multiAddresses[0]
+      rec.addresses[1].address == multiAddresses[1]


### PR DESCRIPTION
Adding signed peer record as part of identify according to #647 and as an increment towards GossipSub Peer Exchange.

I have a couple of questions, though, mostly related to idiomatic use of `nim-libp2p`: 😃

1. Do we want to make the exchange of signed peer records configurable at all? Currently it will be populated if available on the peer info and it will always be available on the peer info, unless we encountered an error during creation.
2. It makes sense to me to cache the `signedPeerRecord` in the `PeerInfo` object, where we keep other local peer information. I'm unsure, however, where best to declare related `const`s such as the envelope `Domain` and `PayloadType`. For now they also exist in `peerinfo`. LMK if you think we should split these into a separate module.
3. I'm not too happy introducing the first use of `std/times` in `nim-libp2p` (`getTime()` for seq number), but `Moment.now()` only has meaning relative to another moment. Any other ideas?  