### PR TITLE
Add PM flow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,10 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug, prio:low
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,10 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: enhancement, prio:low
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,10 @@
+---
+name: Question
+about: Question regarding libp2p
+title: ''
+labels: question
+assignees: ''
+
+---
+
+

--- a/.github/workflows/project_management.yml
+++ b/.github/workflows/project_management.yml
@@ -1,0 +1,27 @@
+name: Assign to Github Project
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  assign_one_project:
+    runs-on: ubuntu-latest
+    name: Assign to One Project
+    steps:
+    - name: Assign NEW issues and NEW pull requests to project 1
+      uses: srggrs/assign-one-project-github-action@1.2.1
+      if: github.event_name == 'issues' && contains(github.event.issue.labels.*.name, 'prio:high')
+      with:
+        project: 'https://github.com/status-im/nim-libp2p/projects/1'
+        column_name: 'Urgent'
+
+    - name: Assign NEW issues and NEW pull requests to project 1
+      uses: srggrs/assign-one-project-github-action@1.2.1
+      if: github.event.action == 'opened'
+      with:
+        project: 'https://github.com/status-im/nim-libp2p/projects/1'


### PR DESCRIPTION
This PR adds two things:

- A CI workflow to add new PRs & Issues to the [PM board](https://github.com/status-im/nim-libp2p/projects/1)
- Super simple templates to new issues to help with organization

This is mostly to avoid PR/issues falling through the cracks, be sure that the PM board is up to date, and help us "triage" issues better.
The templates are mostly empty, because I don't like the forced patterns on some project, be we can change that


You can see an example of how that works on my fork: https://github.com/Menduist/nim-libp2p