### PR TITLE
Add SPR from identify to new peer book

### DIFF
--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -14,6 +14,7 @@ import
   ./crypto/crypto,
   ./protocols/identify,
   ./peerid, ./peerinfo,
+  ./routing_record,
   ./multiaddress
 
 type
@@ -53,6 +54,8 @@ type
 
     agentBook*: PeerBook[string]
     protoVersionBook*: PeerBook[string]
+
+    signedPeerRecordBook*: PeerBook[Envelope]
   
 ## Constructs a new PeerStore with metadata of type M
 proc new*(T: type PeerStore): PeerStore =
@@ -160,3 +163,6 @@ proc updatePeerInfo*(
 
   if info.protos.len > 0:
     peerStore.protoBook.set(info.peerId, info.protos)
+  
+  if info.signedPeerRecord.isSome:
+    peerStore.signedPeerRecordBook.set(info.peerId, info.signedPeerRecord.get())

--- a/tests/testidentify.nim
+++ b/tests/testidentify.nim
@@ -158,6 +158,9 @@ suite "Identify":
         switch1.peerStore.addressBook.get(switch2.peerInfo.peerId) == switch2.peerInfo.addrs.toHashSet()
         switch2.peerStore.addressBook.get(switch1.peerInfo.peerId) == switch1.peerInfo.addrs.toHashSet()
 
+        switch1.peerStore.signedPeerRecordBook.get(switch2.peerInfo.peerId) == switch2.peerInfo.signedPeerRecord.get()
+        switch2.peerStore.signedPeerRecordBook.get(switch1.peerInfo.peerId) == switch1.peerInfo.signedPeerRecord.get()
+
     proc closeAll() {.async.} =
       await conn.close()
 


### PR DESCRIPTION
Adding received signed peer record from `identify` to new peer book according to #647 and as an increment towards GossipSub Peer Exchange.

(Note: I notice [the go implementation](https://github.com/libp2p/go-libp2p-peerstore/blob/master/pstoreds/addr_book.go#L316) stores the marshalled SPR. Perhaps we should consider doing the same, if it's significantly easier to forward as such on PRUNE? I prefer the current way (with `Envelope` object) though.)