### PR TITLE
Customizable gossipsub backoff on unsubscribe

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -43,7 +43,7 @@ proc init*(_: type[GossipSubParams]): GossipSubParams =
   GossipSubParams(
       explicit: true,
       pruneBackoff: 1.minutes,
-      unsubcribeBackoff: 1.minutes,
+      unsubcribeBackoff: 5.seconds,
       floodPublish: true,
       gossipFactor: 0.25,
       d: GossipSubD,

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -420,7 +420,7 @@ method onTopicSubscription*(g: GossipSub, topic: string, subscribed: bool) =
     g.broadcast(mpeers, msg)
 
     for peer in mpeers:
-      g.pruned(peer, topic, backoff = g.parameters.unsubcribeBackoff)
+      g.pruned(peer, topic, backoff = some(g.parameters.unsubcribeBackoff))
 
     g.mesh.del(topic)
 

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -43,6 +43,7 @@ proc init*(_: type[GossipSubParams]): GossipSubParams =
   GossipSubParams(
       explicit: true,
       pruneBackoff: 1.minutes,
+      unsubcribeBackoff: 1.minutes,
       floodPublish: true,
       gossipFactor: 0.25,
       d: GossipSubD,
@@ -77,6 +78,8 @@ proc validateParameters*(parameters: GossipSubParams): Result[void, cstring] =
     err("gossipsub: dOut parameter error, Number of outbound connections to keep in the mesh. Must be less than D_lo and at most D/2")
   elif parameters.gossipThreshold >= 0:
     err("gossipsub: gossipThreshold parameter error, Must be < 0")
+  elif parameters.unsubcribeBackoff.seconds <= 0:
+    err("gossipsub: unsubcribeBackoff parameter error, Must be > 0 seconds")
   elif parameters.publishThreshold >= parameters.gossipThreshold:
     err("gossipsub: publishThreshold parameter error, Must be < gossipThreshold")
   elif parameters.graylistThreshold >= parameters.publishThreshold:
@@ -413,11 +416,11 @@ method onTopicSubscription*(g: GossipSub, topic: string, subscribed: bool) =
           prune: @[ControlPrune(
             topicID: topic,
             peers: g.peerExchangeList(topic),
-            backoff: g.parameters.pruneBackoff.seconds.uint64)])))
+            backoff: g.parameters.unsubcribeBackoff.seconds.uint64)])))
     g.broadcast(mpeers, msg)
 
     for peer in mpeers:
-      g.pruned(peer, topic)
+      g.pruned(peer, topic, backoff = g.parameters.unsubcribeBackoff)
 
     g.mesh.del(topic)
 

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -42,11 +42,11 @@ proc pruned*(g: GossipSub,
              p: PubSubPeer,
              topic: string,
              setBackoff: bool = true,
-             backoff: Duration = 0.seconds) {.raises: [Defect].} =
+             backoff = none(Duration)) {.raises: [Defect].} =
   if setBackoff:
     let
       backoffDuration =
-        if backoff.seconds > 0: backoff
+        if isSome(backoff): backoff.get()
         else: g.parameters.pruneBackoff
       backoffMoment = Moment.fromNow(backoffDuration)
 

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -102,6 +102,7 @@ type
   GossipSubParams* = object
     explicit*: bool
     pruneBackoff*: Duration
+    unsubcribeBackoff*: Duration
     floodPublish*: bool
     gossipFactor*: float64
     d*: int

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -320,6 +320,70 @@ suite "GossipSub":
 
     await allFuturesThrowing(nodesFut.concat())
 
+  asyncTest "GossipSub unsub - resub faster than backoff":
+    var handlerFut = newFuture[bool]()
+    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+      check topic == "foobar"
+      handlerFut.complete(true)
+
+    let
+      nodes = generateNodes(2, gossip = true)
+
+      # start switches
+      nodesFut = await allFinished(
+        nodes[0].switch.start(),
+        nodes[1].switch.start(),
+      )
+
+    # start pubsub
+    await allFuturesThrowing(
+      allFinished(
+        nodes[0].start(),
+        nodes[1].start(),
+    ))
+
+    await subscribeNodes(nodes)
+
+    nodes[0].subscribe("foobar", handler)
+    nodes[1].subscribe("foobar", handler)
+
+    var subs: seq[Future[void]]
+    subs &= waitSub(nodes[1], nodes[0], "foobar")
+    subs &= waitSub(nodes[0], nodes[1], "foobar")
+
+    await allFuturesThrowing(subs)
+
+    nodes[0].unsubscribe("foobar", handler)
+    nodes[0].subscribe("foobar", handler)
+
+    # regular backoff is 60 seconds, so we must not wait that long
+    await (waitSub(nodes[0], nodes[1], "foobar") and waitSub(nodes[1], nodes[0], "foobar")).wait(30.seconds)
+
+    var validatorFut = newFuture[bool]()
+    proc validator(topic: string,
+                    message: Message):
+                    Future[ValidationResult] {.async.} =
+      check topic == "foobar"
+      validatorFut.complete(true)
+      result = ValidationResult.Accept
+
+    nodes[1].addValidator("foobar", validator)
+    tryPublish await nodes[0].publish("foobar", "Hello!".toBytes()), 1
+
+    check (await validatorFut) and (await handlerFut)
+
+    await allFuturesThrowing(
+      nodes[0].switch.stop(),
+      nodes[1].switch.stop()
+    )
+
+    await allFuturesThrowing(
+      nodes[0].stop(),
+      nodes[1].stop()
+    )
+
+    await allFuturesThrowing(nodesFut.concat())
+
   asyncTest "e2e - GossipSub should add remote peer topic subscriptions":
     proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
       discard

--- a/tests/pubsub/utils.nim
+++ b/tests/pubsub/utils.nim
@@ -40,7 +40,7 @@ proc generateNodes*(
         msgIdProvider = msgIdProvider,
         anonymize = anonymize,
         maxMessageSize = maxMessageSize,
-        parameters = (var p = GossipSubParams.init(); p.floodPublish = false; p.historyLength = 20; p.historyGossip = 20; p))
+        parameters = (var p = GossipSubParams.init(); p.floodPublish = false; p.historyLength = 20; p.historyGossip = 20; p.unsubcribeBackoff = 1.seconds; p))
       # set some testing params, to enable scores
       g.topicParams.mgetOrPut("foobar", TopicParams.init()).topicWeight = 1.0
       g.topicParams.mgetOrPut("foo", TopicParams.init()).topicWeight = 1.0


### PR DESCRIPTION
This is an alternative to https://github.com/status-im/nimbus-eth2/pull/3025

It allows applications to choose a different backoff when we unsubcribe from a gossipsub topic.

Currently, if you unsubscribe - resubscribe from a topic in less than `backoff` seconds, all of your peers that were previously in your mesh are in your backoff, and won't allow you to graft them back. Setting the `unsubcribeBackoff` to a lower value allows you to alleviate this issue.

Note that it should still be >0 seconds, or some implementations (including ours) will ignore it. However, if it's less than `BackoffSlackTime` (2 seconds), it will effectively be a 0 seconds backoff.
It should not be an issue to have a 0 seconds backoff, since you're unsubscribed and peers should not attempt to graft you until you resub anyway. But maybe to avoid "race conditions", it's a good idea to keep a few seconds as backoff, just in case. Worst case scenario, a peer may attempt to graft you before receiving your unsub, and since this is not allowed, we'll prune him again with a bigger backoff.