### PR TITLE
Typo: s/unsubcribeBackoff/unsubscribeBackoff

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -43,7 +43,7 @@ proc init*(_: type[GossipSubParams]): GossipSubParams =
   GossipSubParams(
       explicit: true,
       pruneBackoff: 1.minutes,
-      unsubcribeBackoff: 5.seconds,
+      unsubscribeBackoff: 5.seconds,
       floodPublish: true,
       gossipFactor: 0.25,
       d: GossipSubD,
@@ -78,8 +78,8 @@ proc validateParameters*(parameters: GossipSubParams): Result[void, cstring] =
     err("gossipsub: dOut parameter error, Number of outbound connections to keep in the mesh. Must be less than D_lo and at most D/2")
   elif parameters.gossipThreshold >= 0:
     err("gossipsub: gossipThreshold parameter error, Must be < 0")
-  elif parameters.unsubcribeBackoff.seconds <= 0:
-    err("gossipsub: unsubcribeBackoff parameter error, Must be > 0 seconds")
+  elif parameters.unsubscribeBackoff.seconds <= 0:
+    err("gossipsub: unsubscribeBackoff parameter error, Must be > 0 seconds")
   elif parameters.publishThreshold >= parameters.gossipThreshold:
     err("gossipsub: publishThreshold parameter error, Must be < gossipThreshold")
   elif parameters.graylistThreshold >= parameters.publishThreshold:
@@ -416,11 +416,11 @@ method onTopicSubscription*(g: GossipSub, topic: string, subscribed: bool) =
           prune: @[ControlPrune(
             topicID: topic,
             peers: g.peerExchangeList(topic),
-            backoff: g.parameters.unsubcribeBackoff.seconds.uint64)])))
+            backoff: g.parameters.unsubscribeBackoff.seconds.uint64)])))
     g.broadcast(mpeers, msg)
 
     for peer in mpeers:
-      g.pruned(peer, topic, backoff = some(g.parameters.unsubcribeBackoff))
+      g.pruned(peer, topic, backoff = some(g.parameters.unsubscribeBackoff))
 
     g.mesh.del(topic)
 

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -102,7 +102,7 @@ type
   GossipSubParams* = object
     explicit*: bool
     pruneBackoff*: Duration
-    unsubcribeBackoff*: Duration
+    unsubscribeBackoff*: Duration
     floodPublish*: bool
     gossipFactor*: float64
     d*: int

--- a/tests/pubsub/utils.nim
+++ b/tests/pubsub/utils.nim
@@ -40,7 +40,7 @@ proc generateNodes*(
         msgIdProvider = msgIdProvider,
         anonymize = anonymize,
         maxMessageSize = maxMessageSize,
-        parameters = (var p = GossipSubParams.init(); p.floodPublish = false; p.historyLength = 20; p.historyGossip = 20; p.unsubcribeBackoff = 1.seconds; p))
+        parameters = (var p = GossipSubParams.init(); p.floodPublish = false; p.historyLength = 20; p.historyGossip = 20; p.unsubscribeBackoff = 1.seconds; p))
       # set some testing params, to enable scores
       g.topicParams.mgetOrPut("foobar", TopicParams.init()).topicWeight = 1.0
       g.topicParams.mgetOrPut("foo", TopicParams.init()).topicWeight = 1.0


### PR DESCRIPTION
My number of typo per commit is through the roof