### PR TITLE
Semaphore rework

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -59,8 +59,8 @@ proc new*(T: type[SwitchBuilder]): T =
     addresses: @[address],
     secureManagers: @[],
     maxConnections: MaxConnections,
-    maxIn: -1,
-    maxOut: -1,
+    maxIn: MaxConnections,
+    maxOut: MaxConnections,
     maxConnsPerPeer: MaxConnectionsPerPeer,
     protoVersion: ProtoVersion,
     agentVersion: AgentVersion)
@@ -206,8 +206,8 @@ proc newStandardSwitch*(
   inTimeout: Duration = 5.minutes,
   outTimeout: Duration = 5.minutes,
   maxConnections = MaxConnections,
-  maxIn = -1,
-  maxOut = -1,
+  maxIn = MaxConnections,
+  maxOut = MaxConnections,
   maxConnsPerPeer = MaxConnectionsPerPeer,
   nameResolver: NameResolver = nil): Switch
   {.raises: [Defect, LPError].} =

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -46,7 +46,6 @@ type
     maxConnsPerPeer: int
     protoVersion: string
     agentVersion: string
-    forceDial: bool
     nameResolver: NameResolver
 
 proc new*(T: type[SwitchBuilder]): T =
@@ -112,10 +111,6 @@ proc withMaxConnections*(b: SwitchBuilder, maxConnections: int): SwitchBuilder =
   b.maxConnections = maxConnections
   b
 
-proc withForceDial*(b: SwitchBuilder, forceDial: bool): SwitchBuilder =
-  b.forceDial = forceDial
-  b
-
 proc withMaxIn*(b: SwitchBuilder, maxIn: int): SwitchBuilder =
   b.maxIn = maxIn
   b
@@ -173,7 +168,7 @@ proc build*(b: SwitchBuilder): Switch
     identify = Identify.new(peerInfo)
     maxIn = if b.maxIn >= 0: b.maxIn else: b.maxConnections
     maxOut = if b.maxOut >= 0: b.maxOut else: b.maxConnections
-    connManager = ConnManager.new(b.maxConnsPerPeer, b.maxConnections, maxIn, maxOut, b.forceDial)
+    connManager = ConnManager.new(b.maxConnsPerPeer, b.maxConnections, maxIn, maxOut)
     ms = MultistreamSelect.new()
     muxedUpgrade = MuxedUpgrade.new(identify, muxers, secureManagerInstances, connManager, ms)
 

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -472,8 +472,8 @@ proc trackOutgoingConn*(c: ConnManager,
     if not c.connSema.tryAcquire():
       trace "Too many connections!", count = c.connSema.count,
                                      max = c.connSema.size
-      raise newTooManyConnectionsError()
       c.outSema.release()
+      raise newTooManyConnectionsError()
 
   var conn: Connection
   try:

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -463,11 +463,7 @@ proc trackOutgoingConn*(c: ConnManager,
                                             max = c.outSema.size
     raise newTooManyConnectionsError()
 
-  if not c.connSema.tryAcquire():
-    trace "Too many connections!", count = c.connSema.count,
-                                            max = c.connSema.size
-    c.outSema.release()
-    raise newTooManyConnectionsError()
+  c.connSema.forceAcquire()
 
   var conn: Connection
   try:

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -410,8 +410,8 @@ proc trackConn(c: ConnManager,
       except CatchableError as exc:
         trace "Exception in semaphore monitor, ignoring", exc = exc.msg
 
-      sema.release()
       c.connSema.release()
+      sema.release()
 
     asyncSpawn semaphoreMonitor()
   except CatchableError as exc:
@@ -438,14 +438,14 @@ proc trackIncomingConn*(c: ConnManager,
     conn = await c.trackConn(provider, c.inSema)
     if isNil(conn):
       trace "Couldn't acquire connection, releasing semaphore slot", dir = $Direction.In
-      c.inSema.release()
       c.connSema.release()
+      c.inSema.release()
 
     return conn
   except CatchableError as exc:
     trace "Exception tracking connection", exc = exc.msg
-    c.inSema.release()
     c.connSema.release()
+    c.inSema.release()
     raise exc
 
 proc trackOutgoingConn*(c: ConnManager,
@@ -479,14 +479,14 @@ proc trackOutgoingConn*(c: ConnManager,
     conn = await c.trackConn(provider, c.outSema)
     if isNil(conn):
       trace "Couldn't acquire connection, releasing semaphore slot", dir = $Direction.Out
-      c.outSema.release()
       c.connSema.release()
+      c.outSema.release()
 
     return conn
   except CatchableError as exc:
     trace "Exception tracking connection", exc = exc.msg
-    c.outSema.release()
     c.connSema.release()
+    c.outSema.release()
     raise exc
 
 proc storeMuxer*(c: ConnManager,

--- a/libp2p/dial.nim
+++ b/libp2p/dial.nim
@@ -19,7 +19,8 @@ type
 method connect*(
   self: Dial,
   peerId: PeerId,
-  addrs: seq[MultiAddress]) {.async, base.} =
+  addrs: seq[MultiAddress],
+  forceDial = false) {.async, base.} =
   ## connect remote peer without negotiating
   ## a protocol
   ##
@@ -40,7 +41,8 @@ method dial*(
   self: Dial,
   peerId: PeerId,
   addrs: seq[MultiAddress],
-  protos: seq[string]): Future[Connection] {.async, base.} =
+  protos: seq[string],
+  forceDial = false): Future[Connection] {.async, base.} =
   ## create a protocol stream and establish
   ## a connection if one doesn't exist already
   ##

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -48,7 +48,7 @@ proc dialAndUpgrade(
   self: Dialer,
   peerId: PeerId,
   addrs: seq[MultiAddress],
-  forceDial = false):
+  forceDial: bool):
   Future[Connection] {.async.} =
   debug "Dialing peer", peerId
 
@@ -114,7 +114,7 @@ proc internalConnect(
   self: Dialer,
   peerId: PeerId,
   addrs: seq[MultiAddress],
-  forceDial = false):
+  forceDial: bool):
   Future[Connection] {.async.} =
   if self.localPeerId == peerId:
     raise newException(CatchableError, "can't dial self!")
@@ -170,7 +170,7 @@ method connect*(
   if self.connManager.connCount(peerId) > 0:
     return
 
-  discard await self.internalConnect(peerId, addrs)
+  discard await self.internalConnect(peerId, addrs, forceDial)
 
 proc negotiateStream(
   self: Dialer,
@@ -222,7 +222,7 @@ method dial*(
 
   try:
     trace "Dialing (new)", peerId, protos
-    conn = await self.internalConnect(peerId, addrs)
+    conn = await self.internalConnect(peerId, addrs, forceDial)
     trace "Opening stream", conn
     stream = await self.connManager.getStream(conn)
 

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -99,8 +99,9 @@ proc disconnect*(s: Switch, peerId: PeerId): Future[void] {.gcsafe.} =
 method connect*(
   s: Switch,
   peerId: PeerId,
-  addrs: seq[MultiAddress]): Future[void] =
-  s.dialer.connect(peerId, addrs)
+  addrs: seq[MultiAddress],
+  forceDial = false): Future[void] =
+  s.dialer.connect(peerId, addrs, forceDial)
 
 method dial*(
   s: Switch,
@@ -117,15 +118,17 @@ method dial*(
   s: Switch,
   peerId: PeerId,
   addrs: seq[MultiAddress],
-  protos: seq[string]): Future[Connection] =
-  s.dialer.dial(peerId, addrs, protos)
+  protos: seq[string],
+  forceDial = false): Future[Connection] =
+  s.dialer.dial(peerId, addrs, protos, forceDial)
 
 proc dial*(
   s: Switch,
   peerId: PeerId,
   addrs: seq[MultiAddress],
-  proto: string): Future[Connection] =
-  dial(s, peerId, addrs, @[proto])
+  proto: string,
+  forceDial = false): Future[Connection] =
+  dial(s, peerId, addrs, @[proto], forceDial)
 
 proc mount*[T: LPProtocol](s: Switch, proto: T, matcher: Matcher = nil)
   {.gcsafe, raises: [Defect, LPError].} =

--- a/libp2p/utils/semaphore.nim
+++ b/libp2p/utils/semaphore.nim
@@ -7,7 +7,7 @@
 ## This file may not be copied, modified, or distributed except according to
 ## those terms.
 
-{.push raises: [].}
+{.push raises: [Defect].}
 
 import sequtils
 import chronos, chronicles

--- a/libp2p/utils/semaphore.nim
+++ b/libp2p/utils/semaphore.nim
@@ -38,14 +38,6 @@ proc tryAcquire*(s: AsyncSemaphore): bool =
     trace "Acquired slot", available = s.count, queue = s.queue.len
     return true
 
-proc forceAcquire*(s: AsyncSemaphore) =
-  ## Always acquire a semaphore, even
-  ## if it is currently empty
-  ##
-
-  s.count.dec
-  trace "Acquired slot", available = s.count, queue = s.queue.len
-
 proc acquire*(s: AsyncSemaphore): Future[void] =
   ## Acquire a resource and decrement the resource
   ## counter. If no more resources are available,
@@ -68,6 +60,13 @@ proc acquire*(s: AsyncSemaphore): Future[void] =
   s.queue.add(fut)
   trace "Queued slot", available = s.count, queue = s.queue.len
   return fut
+
+proc forceAcquire*(s: AsyncSemaphore) =
+  ## Always acquire a semaphore, even
+  ## if it is currently empty
+  ##
+
+  asyncSpawn s.acquire()
 
 proc release*(s: AsyncSemaphore) =
   ## Release a resource from the semaphore,

--- a/tests/testconnmngr.nim
+++ b/tests/testconnmngr.nim
@@ -465,15 +465,16 @@ suite "Connection Manager":
       allFutures(conns.mapIt( it.close() )))
 
   asyncTest "allow force dial":
-    let connMngr = ConnManager.new(maxOut = 3, maxConnections = 2, forceDial = true)
+    let connMngr = ConnManager.new(maxOut = 3, maxConnections = 2)
 
     var conns: seq[Connection]
     for i in 0..<3:
       let conn = connMngr.trackOutgoingConn(
-        proc(): Future[Connection] {.async.} =
+        (proc(): Future[Connection] {.async.} =
           return Connection.new(
             PeerId.init(PrivateKey.random(ECDSA, (newRng())[]).tryGet()).tryGet(),
             Direction.In)
+        ), true
       )
 
       check await conn.withTimeout(10.millis)
@@ -482,10 +483,11 @@ suite "Connection Manager":
     # should throw adding a connection over the limit
     expect TooManyConnectionsError:
       discard await connMngr.trackOutgoingConn(
-          proc(): Future[Connection] {.async.} =
+          (proc(): Future[Connection] {.async.} =
             return Connection.new(
               PeerId.init(PrivateKey.random(ECDSA, (newRng())[]).tryGet()).tryGet(),
               Direction.In)
+          ), true
         )
 
     await connMngr.close()

--- a/tests/testsemaphore.nim
+++ b/tests/testsemaphore.nim
@@ -161,11 +161,11 @@ suite "AsyncSemaphore":
 
     await fut1 or fut2 or sleepAsync(1.millis)
     check:
-      not fut1.finished()
+      fut1.finished()
       not fut2.finished()
 
     sema.release()
     await fut1 or sleepAsync(1.millis)
     check:
       fut1.finished()
-      not fut2.finished()
+      fut2.finished()

--- a/tests/testsemaphore.nim
+++ b/tests/testsemaphore.nim
@@ -36,7 +36,7 @@ suite "AsyncSemaphore":
     await sema.acquire()
     let fut = sema.acquire()
 
-    check sema.count == -1
+    check sema.count == 0
     sema.release()
     sema.release()
     check sema.count == 1
@@ -66,7 +66,7 @@ suite "AsyncSemaphore":
 
     let fut = sema.acquire()
     check fut.finished == false
-    check sema.count == -1
+    check sema.count == 0
 
     sema.release()
     sema.release()
@@ -145,3 +145,27 @@ suite "AsyncSemaphore":
     sema.release()
 
     check await sema.acquire().withTimeout(10.millis)
+
+  asyncTest "should handle tryAcquire properly":
+    let sema = newAsyncSemaphore(1)
+
+    await sema.acquire()
+    check not(await sema.acquire().withTimeout(1.millis)) # should not acquire but cancel
+
+    let
+      fut1 = sema.acquire()
+      fut2 = sema.acquire()
+
+    sema.forceAcquire()
+    sema.release()
+
+    await fut1 or fut2 or sleepAsync(1.millis)
+    check:
+      not fut1.finished()
+      not fut2.finished()
+
+    sema.release()
+    await fut1 or sleepAsync(1.millis)
+    check:
+      fut1.finished()
+      not fut2.finished()

--- a/tests/testsemaphore.nim
+++ b/tests/testsemaphore.nim
@@ -146,7 +146,7 @@ suite "AsyncSemaphore":
 
     check await sema.acquire().withTimeout(10.millis)
 
-  asyncTest "should handle tryAcquire properly":
+  asyncTest "should handle forceAcquire properly":
     let sema = newAsyncSemaphore(1)
 
     await sema.acquire()


### PR DESCRIPTION
This is an alternative to https://github.com/status-im/nim-libp2p/pull/629

This PR modifies the way the maxIn, maxOut & maxConnections are handled.

Previously, this was the logic:
```nim
  if maxIn > 0 or maxOut > 0:
    inSema = newAsyncSemaphore(maxIn)
    outSema = newAsyncSemaphore(maxOut)
  elif maxConnections > 0:
    inSema = newAsyncSemaphore(maxConnections)
    outSema = inSema
```

Now:
```nim
    inSema: newAsyncSemaphore(maxIn),
    outSema: newAsyncSemaphore(maxOut),
    connSema: newAsyncSemaphore(maxConnections)
```

In practice, this means that there is always a global & per direction limit.
We now have to acquire two semaphore, but I don't think it can create liveness issues.

This new method seems more elegant (& flexible) than the current system, and than 629, imo

Second feature of this PR: you can now enable forceDial on the connManager.
This means that outgoing connections will only fail if the outSema is full, the connSema will be forceAcquired.