### PR TITLE
New builders PoC, take 3

### DIFF
--- a/libp2p/builder3.nim
+++ b/libp2p/builder3.nim
@@ -1,0 +1,174 @@
+# Nim-Libp2p
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [Defect].}
+
+import std/[tables, macros, sequtils]
+
+type
+  GenHolder = ref object of RootObj
+
+  Holder[T] = ref object of GenHolder
+    value: T
+
+  TypeTable = object
+    table: Table[string, GenHolder]
+
+proc contains[T](tt: TypeTable, typ: type[T]): bool =
+  tt.table.contains($typ)
+
+proc contains(tt: TypeTable, typ: string): bool =
+  tt.table.contains(typ)
+
+proc `[]`[T](tt: TypeTable, typ: type[T]): T =
+  let holder = Holder[T](tt.table.getOrDefault($typ))
+  if holder.isNil:
+    default(T)
+  else:
+    holder.value
+
+proc `[]=`[T](tt: var TypeTable, typ: type[T], val: T) =
+  let holder = Holder[T](tt.table.getOrDefault($typ))
+  if holder.isNil:
+    tt.table[$typ] = Holder[T](value: val)
+  else:
+    holder.value = val
+
+type
+  BuildDep* = object
+    deps: seq[string]
+    outs: seq[string]
+    run: proc(b: Builder)
+
+  Builder* = ref object
+    context: TypeTable
+    deps: seq[BuildDep]
+
+proc with*[T](builder: Builder, val: T): T {.discardable.} =
+  let buildDep = T.getBuildDeps(val)
+  builder.deps.add(buildDep)
+
+template with*(switchBuilder: Builder, args: varargs[untyped]) =
+  when args is ref:
+    switchBuilder.with(new(args))
+  else:
+    switchBuilder.with(default(args))
+
+proc build*[T](builder: Builder, val: type[T]): T {.discardable.} =
+  builder.with(T)
+  while builder.deps.len > 0:
+    for index, dep in builder.deps:
+      var canBeRun = true
+      for dep in dep.deps:
+        if dep notin builder.context:
+          canBeRun = false
+      if canBeRun == false: continue
+
+      dep.run(builder)
+      builder.deps.delete(index)
+      break
+
+  builder.context[T]
+
+macro setupproc(prc: untyped): untyped =
+  result = nnkStmtList.newTree(prc)
+
+  let
+    buildDepsProc = newProc(ident"getBuildDeps")
+    targetType =
+      if params(prc)[1][1].kind == nnkVarTy: params(prc)[1][1][0]
+      else: params(prc)[1][1]
+    targetTypeParam = nnkIdentDefs.newTree(
+      ident"T",
+      nnkBracketExpr.newTree(ident"type", targetType),
+      newEmptyNode()
+    )
+    targetValParam = nnkIdentDefs.newTree(
+      ident"val",
+      targetType,
+      newEmptyNode()
+    )
+
+    setResult = quote do: result = BuildDep()
+
+  buildDepsProc.params = nnkFormalParams.newTree(
+    ident"BuildDep",
+    targetTypeParam,
+    targetValParam
+  )
+
+  buildDepsProc.body = nnkStmtList.newTree(
+    setResult
+  )
+
+  for setupParam in params(prc)[2..^1]:
+    if setupParam[1].kind == nnkVarTy:
+      let paramType = newStrLitNode($setupParam[1][0])
+      buildDepsProc.body.add(
+        quote do: result.outs.add(`paramType`)
+      )
+    else:
+      let paramType = newStrLitNode($setupParam[1])
+      buildDepsProc.body.add(
+        quote do: result.deps.add(`paramType`)
+      )
+
+  let
+    builderParam = nnkIdentDefs.newTree(ident"b", ident"Builder", newEmptyNode())
+    runnerProc = newProc(params = [newEmptyNode(), builderParam])
+    beforeCall = nnkStmtList.newTree()
+    valCopyIdent = ident"valCopy"
+    caller = newCall("setup", valCopyIdent)
+    afterCall = nnkStmtList.newTree()
+  var paramCount = 0
+  for setupParam in params(prc)[2..^1]:
+    if setupParam[1].kind == nnkVarTy:
+      let
+        paramType = setupParam[1][0]
+        paramTempName = ident("p" & $paramCount)
+      paramCount.inc()
+      beforeCall.add(quote do:
+        var `paramTempName` = b.context[`paramType`]
+      )
+      caller.add(paramTempName)
+      afterCall.add(quote do: b.context[`paramType`] = `paramTempName`)
+    else:
+      let paramType = setupParam[1]
+      caller.add(
+        quote do: b.context[`paramType`]
+      )
+  runnerProc.body = nnkStmtList.newTree(
+    (quote do:
+      var `valCopyIdent` = if val == default(`targetType`): b.context[`targetType`] else: val),
+    beforeCall,
+    caller,
+    afterCall,
+    quote do: b.context[`targetType`] = `valCopyIdent`
+  )
+
+  buildDepsProc.body.add(
+    quote do: result.run = `runnerProc`
+  )
+  result.add(buildDepsProc)
+  echo repr(result)
+
+when isMainModule:
+  proc setup(i: int, x: float, res: var string) {.setupproc.} =
+    res = $(i.float + x)
+
+  proc setup(i: var float) {.setupproc.} =
+    i = 10.12
+
+  proc setup(i: var string) {.setupproc.} =
+    discard
+
+  let builder = Builder()
+  builder.with(5)
+  builder.with(float)
+  echo builder.build(string)

--- a/libp2p/builder3.nim
+++ b/libp2p/builder3.nim
@@ -67,10 +67,10 @@ proc with*[T](builder: Builder, val: T): T {.discardable.} =
   builder.deps.add(buildDep)
 
 template with*(switchBuilder: Builder, args: varargs[untyped]) =
-  #TODO find a better test, obviously
-  when not compiles((args) isnot string):
+  #TODO find a better test
+  when not compiles(args isnot string):
     switchBuilder.with(new(args))
-  elif (args) isnot string and (args) isnot float:
+  elif args is ref:
     switchBuilder.with(new(args))
   else:
     switchBuilder.with(default(args))

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -16,6 +16,7 @@ import peerinfo,
        stream/connection,
        muxers/muxer,
        utils/semaphore,
+       builder3,
        errors
 
 logScope:
@@ -581,3 +582,6 @@ proc close*(c: ConnManager) {.async.} =
       await conn.close()
 
   trace "Closed ConnManager"
+
+proc setup*(p: ConnManager, peerStore: PeerStore) {.setupproc.} =
+  p.peerStore = peerStore

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -21,7 +21,8 @@ import dial,
        stream/connection,
        transports/transport,
        nameresolving/nameresolver,
-       errors
+       errors,
+       builder3
 
 export dial, errors
 
@@ -254,3 +255,15 @@ proc new*(
     transports: transports,
     ms: ms,
     nameResolver: nameResolver)
+
+proc setup*(
+  p: Dialer,
+  peerInfo: PeerInfo,
+  connManager: ConnManager,
+  transports: seq[Transport],
+  multistreamSelect: MultistreamSelect) {.setupproc.} =
+
+  p.localPeerId = peerInfo.peerId
+  p.connManager = connManager
+  p.transports = transports
+  p.ms = multistreamSelect

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -13,7 +13,8 @@ import std/[strutils]
 import chronos, chronicles, stew/byteutils
 import stream/connection,
        vbuffer,
-       protocols/protocol
+       protocols/protocol,
+       builder3
 
 logScope:
   topics = "libp2p multistream"
@@ -210,3 +211,5 @@ proc addHandler*(m: MultistreamSelect,
   m.handlers.add(HandlerHolder(protos: @[codec],
                                protocol: protocol,
                                match: matcher))
+
+proc setup*(p: MultistreamSelect) {.setupproc.} = discard

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -17,7 +17,8 @@ import ../muxer,
        ../../utility,
        ../../peerinfo,
        ./coder,
-       ./lpchannel
+       ./lpchannel,
+       ../../builder3
 
 export muxer
 
@@ -239,3 +240,11 @@ method close*(m: Mplex) {.async, gcsafe.} =
   m.channels[true].clear()
 
   trace "Closed mplex", m
+
+proc setup*(n: Mplex, muxers: var Table[string, MuxerProvider]) {.setupproc.} =
+  proc newMuxer(conn: Connection): Muxer =
+    Mplex.new(
+      conn,
+      inTimeout = 5.minutes,
+      outTimeout = 5.minutes)
+  muxers[MplexCodec] = MuxerProvider.new(newMuxer, MplexCodec)

--- a/libp2p/muxers/muxer.nim
+++ b/libp2p/muxers/muxer.nim
@@ -54,7 +54,7 @@ proc new*(
   codec: string): T {.gcsafe.} =
 
   let muxerProvider = T(newMuxer: creator)
-  muxerProvider.codec = codec
+  #muxerProvider.codec = codec wtf?
   muxerProvider.init()
   muxerProvider
 

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -11,7 +11,7 @@
 
 import std/[options, sequtils, hashes]
 import pkg/[chronos, chronicles, stew/results]
-import peerid, multiaddress, crypto/crypto, errors
+import peerid, multiaddress, crypto/crypto, errors, builder3
 
 export peerid, multiaddress, crypto, errors, results
 
@@ -63,3 +63,5 @@ proc new*(
     protocols: @protocols)
 
   return peerInfo
+
+proc setup*(p: PeerInfo) {.setupproc.} = discard

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -13,7 +13,7 @@ import
   std/[tables, sets, sequtils, options],
   ./crypto/crypto,
   ./protocols/identify,
-  ./peerid, ./peerinfo,
+  ./peerid, ./peerinfo, builder3,
   ./multiaddress
 
 type
@@ -160,3 +160,5 @@ proc updatePeerInfo*(
 
   if info.protos.len > 0:
     peerStore.protoBook.set(info.peerId, info.protos)
+
+proc setup*(p: PeerStore) {.setupproc.} = discard

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -19,6 +19,7 @@ import ../protobuf/minprotobuf,
        ../multiaddress,
        ../protocols/protocol,
        ../utility,
+       ../builder3,
        ../errors
 
 logScope:
@@ -124,6 +125,10 @@ proc new*(T: typedesc[Identify], peerInfo: PeerInfo): T =
   let identify = T(peerInfo: peerInfo)
   identify.init()
   identify
+
+proc setup*(p: Identify, peerInfo: PeerInfo) {.setupproc.} =
+  p.peerInfo = peerInfo
+  p.init()
 
 method init*(p: Identify) =
   proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -21,6 +21,7 @@ import ../../peerinfo
 import ../../protobuf/minprotobuf
 import ../../utility
 import ../../errors
+import ../../builder3
 
 import secure,
       ../../crypto/[crypto, chacha20poly1305, curve25519, hkdf]
@@ -622,3 +623,13 @@ proc new*(
 
   noise.init()
   noise
+
+proc setup*(n: Noise, peerInfo: PeerInfo, rng: ref HmacDrbgContext, secureManagers: var seq[Secure]) {.setupproc.} =
+  n.localPrivateKey = peerInfo.privateKey
+  n.noiseKeys = genKeyPair(rng[])
+  let pkBytes = n.localPrivateKey.getPublicKey()
+  .expect("Expected valid Private Key")
+  .getBytes().expect("Couldn't get public Key bytes")
+
+  n.localPublicKey = pkBytes
+  secureManagers &= n

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -37,6 +37,7 @@ import stream/connection,
        peerid,
        peerstore,
        errors,
+       builder3,
        dialer
 
 export connmanager, upgrade, dialer, peerstore
@@ -291,3 +292,22 @@ proc newSwitch*(peerInfo: PeerInfo,
   switch.connManager.peerStore = switch.peerStore
   switch.mount(identity)
   return switch
+
+proc setup*(
+  p: Switch,
+  peerInfo: PeerInfo,
+  ms: MultistreamSelect,
+  transports: seq[Transport],
+  connManager: ConnManager,
+  peerStore: PeerStore,
+  dialer: Dialer,
+  identify: Identify
+  ) {.setupproc, raises: [Defect, LPError].} =
+  
+  p.peerInfo = peerInfo
+  p.ms = ms
+  p.transports = transports
+  p.connManager = connManager
+  p.peerStore = peerStore
+  p.dialer = dialer
+  p.mount(identify)


### PR DESCRIPTION
Alternative to #646

This PR adds a generic builder system:
```nim
import builder3
proc setup(i: int, x: float, res: var string) {.setupproc.} =
  res = $(i.float + x)

proc setup(i: var float) {.setupproc.} =
  i = 10.12

proc setup(i: string) {.setupproc.} = discard

let builder = Builder()
builder.with(5.int)
builder.with(float)
echo builder.build(string) # outputs '15.12'
```
The builder will read the setupprocs of the various input type, and try to create the string from it. In this case:
- `float` is required to create `int`, and `int` will output a `string`
- `float` & `string` doesn't require anything
- So, the float will be created, and his setup procedure (which sets it to 10.12) will be called
- Now that we have the float, the int can be created from it, and will add itself (which in this case is 5, as given to `with`). And finally, output the string
- The string setup will be called, and is a noop

I really like this system, because the ordering is done automatically depending on the arguments of `setup`, and it's fully generic.
Applied to the switch:
```nim
  let rng = newRng()
  var switchBuilder = Builder.new()
  switchBuilder.with(PeerInfo, key=PrivateKey.random(rng[]).tryGet(), addrs=[ma])
  switchBuilder.with(PeerStore)
  switchBuilder.with(MultistreamSelect)
  switchBuilder.with(Identify) 
  switchBuilder.with(rng)
  switchBuilder.with(Noise)
  switchBuilder.with(Mplex)
  switchBuilder.with(ConnManager)
  switchBuilder.with(TcpTransport)
  switchBuilder.with(Dialer)
  switchBuilder.with(TcpTransport)
  
  return switchBuilder.build(Switch)
```
This is very similar to #646, except that we don't have to order the `with`s. Also, it can be used on any type (rng for instance)

The setup is however quite different:
```nim
proc setup*(p: ConnManager, peerStore: PeerStore) {.setupproc.} =
  p.peerStore = peerStore
```
The most basic kind of setup (beside no-ops), we have a dependency on `PeerStore`, so we'll be setup once PeerStore is available. And we can then do whatever we want with it

```nim
proc setup*(n: Mplex, muxers: var Table[string, MuxerProvider]) {.setupproc.} =
  proc newMuxer(conn: Connection): Muxer =
    Mplex.new(conn)
  muxers[MplexCodec] = MuxerProvider.new(newMuxer, MplexCodec)
```
Here, `var` is used to signal that we will modify `muxers`, so any `setup` dependent on `muxers` shouldn't be called before us.

```nim
proc setup*(
  p: Switch,
  peerInfo: PeerInfo,
  ms: MultistreamSelect,
  transports: seq[Transport],
  connManager: ConnManager,
  peerStore: PeerStore,
  dialer: Dialer,
  identify: Identify
  ) {.setupproc, raises: [Defect, LPError].} =

  p.peerInfo = peerInfo
  p.ms = ms
  p.transports = transports
  p.connManager = connManager
  p.peerStore = peerStore
  p.dialer = dialer
  p.mount(identify)
```
Lot of dependencies for the switch, but this should be straightforward to understand.


The builder system itself could be moved to another package, since it's completely standalone.
More details on how it works:
- At the core of it, we have a `context`, which is a type -> value table, similar to how #700 works. For instance, `context[Switch] = Switch.new()`
- Then, the `setupproc` will read the parameters, and build a structure from the parameters, example:
```nim
proc setup(i: int, x: float, res: var string) {.setupproc.} =
  res = $(i.float + x)
```
will become
```nim
proc setup(i: int; x: float; res: var string) =
  res = $(i.float + x)

proc getBuildDeps*(T: type[int]; val: int): BuildDep =
  result = BuildDep()
  result.outs.add("int")
  result.deps.add("float")
  result.outs.add("string")
  result.run = proc (b: Builder) =
    var valCopy = val
    var p0 = b.context[string]
    setup(valCopy, b.context[float], p0)
    b.context[string] = p0
    b.context[int] = valCopy
```
- Finally, `with` will collect every `BuildDep`. When `build` is called, we try to build everything if the dependency graph is not cyclic.


This is a rough PoC, please don't look too much at builder3.nim or your retina may burn

However, I find the API quite nice: if you have a dep, just take it as a parameter, and everything work automagically. This system can be improved upon in a few powerful way, for instance default values:
```nim
# if the user didn't setup the PeerStore manually with `with`, create the default one
proc setup*(p: ConnManager, peerStore: PeerStore = PeerStore.new()) {.setupproc.} =
  p.peerStore = peerStore
```

Multiple parameters to build:
```nim
  let (switch, discoveryInterface) = builder.build(Switch, DiscoveryInterface)
```

And probably other fun stuff.

Also note that the `setup` procedure is usable without the entire system:
```nim
let connManager = ConnManager.new()
connManager.setup(PeerStore.new())
```
And that you can build anything with the system, for instance in tests:
```nim
let builder = Builder.new()
builder.with(PeerStore, maxSize=100)
let conmanager = builder.build(ConnManager)
```
which will become even more powerful with default values (you could build anything without worrying about it's deps)