### PR TITLE
Pin go version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.15.5'
+          go-version: '~1.15.5'
 
       - name: Install p2pd
         run: |

--- a/.github/workflows/multi_nim.yml
+++ b/.github/workflows/multi_nim.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.15.5'
+          go-version: '~1.15.5'
 
       - name: Install p2pd
         run: |


### PR DESCRIPTION
The version of the go daemon we use doesn't work with recent go versions

I've disabled the daily job until this hit master