### PR TITLE
Gossipsub scoring fixes

### DIFF
--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -42,6 +42,9 @@ proc addSeen*(f: FloodSub, msgId: MessageID): bool =
   # Return true if the message has already been seen
   f.seen.put(f.seenSalt & msgId)
 
+proc firstSeen*(f: FloodSub, msgId: MessageID): Moment =
+  f.seen.addedAt(f.seenSalt & msgId)
+
 proc handleSubscribe*(f: FloodSub,
                       peer: PubsubPeer,
                       topic: string,

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -583,6 +583,7 @@ method start*(g: GossipSub) {.async.} =
 
   g.heartbeatRunning = true
   g.heartbeatFut = g.heartbeat()
+  g.scoringHeartbeatFut = g.scoringHeartbeat()
   g.directPeersLoop = g.maintainDirectPeers()
 
 method stop*(g: GossipSub) {.async.} =
@@ -594,6 +595,7 @@ method stop*(g: GossipSub) {.async.} =
   # stop heartbeat interval
   g.heartbeatRunning = false
   g.directPeersLoop.cancel()
+  g.scoringHeartbeatFut.cancel()
   if not g.heartbeatFut.finished:
     trace "awaiting last heartbeat"
     await g.heartbeatFut

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -602,8 +602,6 @@ proc onHeartbeat(g: GossipSub) {.raises: [Defect].} =
         peer.iWantBudget = IWantPeerBudget
         peer.iHaveBudget = IHavePeerBudget
 
-    g.updateScores()
-
     var meshMetrics = MeshMetrics()
 
     for t in toSeq(g.topics.keys):

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -656,6 +656,7 @@ proc onHeartbeat(g: GossipSub) {.raises: [Defect].} =
 
 proc heartbeat*(g: GossipSub) {.async.} =
   while g.heartbeatRunning:
+    let sleepFuture = sleepAsync(g.parameters.heartbeatInterval)
     trace "running heartbeat", instance = cast[int](g)
     g.onHeartbeat()
 
@@ -663,4 +664,4 @@ proc heartbeat*(g: GossipSub) {.async.} =
       trace "firing heartbeat event", instance = cast[int](g)
       trigger.fire()
 
-    await sleepAsync(g.parameters.heartbeatInterval)
+    await sleepFuture

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -14,7 +14,7 @@ import chronos, chronicles, metrics
 import "."/[types, scoring]
 import ".."/[pubsubpeer, peertable, timedcache, mcache, floodsub, pubsub]
 import "../rpc"/[messages]
-import "../../.."/[peerid, multiaddress, utility, switch, routing_record, signed_envelope]
+import "../../.."/[peerid, multiaddress, utility, switch, routing_record, signed_envelope, utils/heartbeat]
 
 declareGauge(libp2p_gossipsub_cache_window_size, "the number of messages in the cache")
 declareGauge(libp2p_gossipsub_peers_per_topic_mesh, "gossipsub peers per topic in mesh", labels = ["topic"])
@@ -659,13 +659,10 @@ proc onHeartbeat(g: GossipSub) {.raises: [Defect].} =
 # {.pop.} # raises [Defect]
 
 proc heartbeat*(g: GossipSub) {.async.} =
-  while g.heartbeatRunning:
-    let sleepFuture = sleepAsync(g.parameters.heartbeatInterval)
+  heartbeat "GossipSub", g.parameters.heartbeatInterval:
     trace "running heartbeat", instance = cast[int](g)
     g.onHeartbeat()
 
     for trigger in g.heartbeatEvents:
       trace "firing heartbeat event", instance = cast[int](g)
       trigger.fire()
-
-    await sleepFuture

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -253,6 +253,12 @@ proc updateScores*(g: GossipSub) = # avoid async
 
   trace "updated scores", peers = g.peers.len
 
+proc scoringHeartbeat*(g: GossipSub) {.async.} =
+  while g.heartbeatRunning:
+    trace "running scoring heartbeat", instance = cast[int](g)
+    g.updateScores()
+    await sleepAsync(g.parameters.decayInterval)
+
 proc punishInvalidMessage*(g: GossipSub, peer: PubSubPeer, topics: seq[string]) =
   for tt in topics:
     let t = tt

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -255,9 +255,10 @@ proc updateScores*(g: GossipSub) = # avoid async
 
 proc scoringHeartbeat*(g: GossipSub) {.async.} =
   while g.heartbeatRunning:
+    let sleepFuture = sleepAsync(g.parameters.decayInterval)
     trace "running scoring heartbeat", instance = cast[int](g)
     g.updateScores()
-    await sleepAsync(g.parameters.decayInterval)
+    await sleepFuture
 
 proc punishInvalidMessage*(g: GossipSub, peer: PubSubPeer, topics: seq[string]) =
   for tt in topics:

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -274,7 +274,7 @@ proc addCapped*[T](stat: var T, diff, cap: T) =
   stat += min(diff, cap - stat)
 
 proc rewardDelivered*(
-    g: GossipSub, peer: PubSubPeer, topics: openArray[string], first: bool) =
+    g: GossipSub, peer: PubSubPeer, topics: openArray[string], first: bool, delay = ZeroDuration) =
   for tt in topics:
     let t = tt
     if t notin g.topics:
@@ -283,6 +283,10 @@ proc rewardDelivered*(
     let tt = t
     let topicParams = g.topicParams.mgetOrPut(t, TopicParams.init())
                                             # if in mesh add more delivery score
+
+    if delay > topicParams.meshMessageDeliveriesWindow:
+      # Too old
+      continue
 
     g.withPeerStats(peer.peerId) do (stats: var PeerStats):
       stats.topicInfos.withValue(tt, tstats):

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -161,6 +161,7 @@ type
     mcache*: MCache                            # messages cache
     validationSeen*: ValidationSeenTable       # peers who sent us message in validation
     heartbeatFut*: Future[void]                # cancellation future for heartbeat interval
+    scoringHeartbeatFut*: Future[void]         # cancellation future for scoring heartbeat interval
     heartbeatRunning*: bool
 
     peerStats*: Table[PeerId, PeerStats]

--- a/libp2p/utils/heartbeat.nim
+++ b/libp2p/utils/heartbeat.nim
@@ -22,6 +22,6 @@ template heartbeat*(name: string, interval: Duration, body: untyped): untyped =
     nextHeartbeat += interval
     let now = Moment.now()
     if nextHeartbeat < now:
-      info "Missed heartbeat", heartbeat = name, delay = nextHeartbeat - now
+      info "Missed heartbeat", heartbeat = name, delay = now - nextHeartbeat
       nextHeartbeat = now + interval
     await sleepAsync(nextHeartbeat - now)

--- a/libp2p/utils/heartbeat.nim
+++ b/libp2p/utils/heartbeat.nim
@@ -1,0 +1,27 @@
+# Nim-Libp2p
+# Copyright (c) 2022 Status Research & Development GmbH
+# Licensed under either of
+#  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
+#  * MIT license ([LICENSE-MIT](LICENSE-MIT))
+# at your option.
+# This file may not be copied, modified, or distributed except according to
+# those terms.
+
+{.push raises: [Defect].}
+
+import sequtils
+import chronos, chronicles
+
+export chronicles
+
+template heartbeat*(name: string, interval: Duration, body: untyped): untyped =
+  var nextHeartbeat = Moment.now()
+  while true:
+    body
+
+    nextHeartbeat += interval
+    let now = Moment.now()
+    if nextHeartbeat < now:
+      info "Missed heartbeat", heartbeat = name, delay = nextHeartbeat - now
+      nextHeartbeat = now + interval
+    await sleepAsync(nextHeartbeat - now)

--- a/tests/pubsub/testgossipsub2.nim
+++ b/tests/pubsub/testgossipsub2.nim
@@ -454,7 +454,7 @@ suite "GossipSub":
     # MacOs has some nasty jitter when sleeping
     # (up to 7 ms), so we need some pretty long
     # sleeps to be safe here
-    gossip.parameters.decayInterval = 30.milliseconds
+    gossip.parameters.decayInterval = 300.milliseconds
 
     # start pubsub
     await allFuturesThrowing(
@@ -478,12 +478,11 @@ suite "GossipSub":
 
     gossip.peerStats[nodes[1].peerInfo.peerId].topicInfos["foobar"].meshMessageDeliveries = 100
     gossip.topicParams["foobar"].meshMessageDeliveriesDecay = 0.9
-    await sleepAsync(150.milliseconds)
+    await sleepAsync(1500.milliseconds)
 
     # We should have decayed 5 times, though allowing 4..6
     check:
-      gossip.peerStats[nodes[1].peerInfo.peerId].topicInfos["foobar"].meshMessageDeliveries < 66
-      gossip.peerStats[nodes[1].peerInfo.peerId].topicInfos["foobar"].meshMessageDeliveries > 50
+      gossip.peerStats[nodes[1].peerInfo.peerId].topicInfos["foobar"].meshMessageDeliveries in 50.0 .. 66.0
 
     await allFuturesThrowing(
       nodes[0].switch.stop(),

--- a/tests/pubsub/testgossipsub2.nim
+++ b/tests/pubsub/testgossipsub2.nim
@@ -452,7 +452,7 @@ suite "GossipSub":
       )
 
     var gossip = GossipSub(nodes[0])
-    gossip.parameters.decayInterval = 1.milliseconds
+    gossip.parameters.decayInterval = 10.milliseconds
 
     # start pubsub
     await allFuturesThrowing(
@@ -476,7 +476,7 @@ suite "GossipSub":
 
     gossip.peerStats[nodes[1].peerInfo.peerId].topicInfos["foobar"].meshMessageDeliveries = 100
     gossip.topicParams["foobar"].meshMessageDeliveriesDecay = 0.9
-    await sleepAsync(5.milliseconds)
+    await sleepAsync(50.milliseconds)
 
     # We should have decayed 5 times, though allowing 4..6
     check:

--- a/tests/pubsub/testgossipsub2.nim
+++ b/tests/pubsub/testgossipsub2.nim
@@ -218,7 +218,6 @@ suite "GossipSub":
     ### await subscribeNodes(nodes)
 
     proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} = discard
-    nodes[0].subscribe("foobar", handler)
     nodes[1].subscribe("foobar", handler)
 
     await invalidDetected.wait(10.seconds)
@@ -452,7 +451,10 @@ suite "GossipSub":
       )
 
     var gossip = GossipSub(nodes[0])
-    gossip.parameters.decayInterval = 10.milliseconds
+    # MacOs has some nasty jitter when sleeping
+    # (up to 7 ms), so we need some pretty long
+    # sleeps to be safe here
+    gossip.parameters.decayInterval = 30.milliseconds
 
     # start pubsub
     await allFuturesThrowing(
@@ -476,7 +478,7 @@ suite "GossipSub":
 
     gossip.peerStats[nodes[1].peerInfo.peerId].topicInfos["foobar"].meshMessageDeliveries = 100
     gossip.topicParams["foobar"].meshMessageDeliveriesDecay = 0.9
-    await sleepAsync(50.milliseconds)
+    await sleepAsync(150.milliseconds)
 
     # We should have decayed 5 times, though allowing 4..6
     check:

--- a/tests/pubsub/testgossipsub2.nim
+++ b/tests/pubsub/testgossipsub2.nim
@@ -335,3 +335,58 @@ suite "GossipSub":
           it.switch.stop())))
 
     await allFuturesThrowing(nodesFut)
+
+  asyncTest "GossipSub scoring - decayInterval":
+
+    let
+      nodes = generateNodes(2, gossip = true)
+
+      # start switches
+      nodesFut = await allFinished(
+        nodes[0].switch.start(),
+        nodes[1].switch.start(),
+      )
+
+    var gossip = GossipSub(nodes[0])
+    gossip.parameters.decayInterval = 1.milliseconds
+
+    # start pubsub
+    await allFuturesThrowing(
+      allFinished(
+        nodes[0].start(),
+        nodes[1].start(),
+    ))
+
+    var handlerFut = newFuture[void]()
+    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+      handlerFut.complete()
+
+    await subscribeNodes(nodes)
+
+    nodes[0].subscribe("foobar", handler)
+    nodes[1].subscribe("foobar", handler)
+
+    tryPublish await nodes[0].publish("foobar", toBytes("hello")), 1
+
+    await handlerFut
+
+    gossip.peerStats[nodes[1].peerInfo.peerId].topicInfos["foobar"].meshMessageDeliveries = 100
+    gossip.topicParams["foobar"].meshMessageDeliveriesDecay = 0.9
+    await sleepAsync(5.milliseconds)
+
+    # We should have decayed 5 times, though allowing 4..6
+    check:
+      gossip.peerStats[nodes[1].peerInfo.peerId].topicInfos["foobar"].meshMessageDeliveries < 66
+      gossip.peerStats[nodes[1].peerInfo.peerId].topicInfos["foobar"].meshMessageDeliveries > 50
+
+    await allFuturesThrowing(
+      nodes[0].switch.stop(),
+      nodes[1].switch.stop()
+    )
+
+    await allFuturesThrowing(
+      nodes[0].stop(),
+      nodes[1].stop()
+    )
+
+    await allFuturesThrowing(nodesFut.concat())

--- a/tests/testheartbeat.nim
+++ b/tests/testheartbeat.nim
@@ -1,56 +1,55 @@
-import random
 import chronos
 
 import ../libp2p/utils/heartbeat
 import ./helpers
 
-suite "Heartbeat":
-  # MacOs has some nasty jitter when sleeping
-  # (up to 7 ms), so we need some pretty long
-  # sleeps to be safe here
+# MacOs has some nasty jitter when sleeping
+# (up to 7 ms), so we skip test there
+when not defined(macosx):
+  suite "Heartbeat":
 
-  asyncTest "simple heartbeat":
-    var i = 0
-    proc t() {.async.} =
-      heartbeat "shouldn't see this", 30.milliseconds:
-        i.inc()
-    let hb = t()
-    await sleepAsync(300.milliseconds)
-    await hb.cancelAndWait()
-    check:
-      i in 0..11
+    asyncTest "simple heartbeat":
+      var i = 0
+      proc t() {.async.} =
+        heartbeat "shouldn't see this", 30.milliseconds:
+          i.inc()
+      let hb = t()
+      await sleepAsync(300.milliseconds)
+      await hb.cancelAndWait()
+      check:
+        i in 9..11
 
-  asyncTest "change heartbeat period on the fly":
-    var i = 0
-    proc t() {.async.} =
-      var period = 30.milliseconds
-      heartbeat "shouldn't see this", period:
-        i.inc()
-        if i >= 4:
-          period = 75.milliseconds
-    let hb = t()
-    await sleepAsync(500.milliseconds)
-    await hb.cancelAndWait()
+    asyncTest "change heartbeat period on the fly":
+      var i = 0
+      proc t() {.async.} =
+        var period = 30.milliseconds
+        heartbeat "shouldn't see this", period:
+          i.inc()
+          if i >= 4:
+            period = 75.milliseconds
+      let hb = t()
+      await sleepAsync(500.milliseconds)
+      await hb.cancelAndWait()
 
-    # 4x 30 ms heartbeat = 120ms
-    # (500 ms - 120 ms) / 75ms = 5x 75ms
-    # total 9
-    check:
-      i in 8..10
+      # 4x 30 ms heartbeat = 120ms
+      # (500 ms - 120 ms) / 75ms = 5x 75ms
+      # total 9
+      check:
+        i in 8..10
 
-  asyncTest "catch up on slow heartbeat":
-    var i = 0
-    proc t() {.async.} =
-      heartbeat "this is normal", 30.milliseconds:
-        if i < 3:
-          await sleepAsync(150.milliseconds)
-        i.inc()
+    asyncTest "catch up on slow heartbeat":
+      var i = 0
+      proc t() {.async.} =
+        heartbeat "this is normal", 30.milliseconds:
+          if i < 3:
+            await sleepAsync(150.milliseconds)
+          i.inc()
 
-    let hb = t()
-    await sleepAsync(900.milliseconds)
-    await hb.cancelAndWait()
-    # 3x (150ms heartbeat + 30ms interval) = 540ms
-    # 360ms remaining, / 30ms = 12x
-    # total 15
-    check:
-      i in 14..16
+      let hb = t()
+      await sleepAsync(900.milliseconds)
+      await hb.cancelAndWait()
+      # 3x (150ms heartbeat + 30ms interval) = 540ms
+      # 360ms remaining, / 30ms = 12x
+      # total 15
+      check:
+        i in 14..16

--- a/tests/testheartbeat.nim
+++ b/tests/testheartbeat.nim
@@ -5,13 +5,17 @@ import ../libp2p/utils/heartbeat
 import ./helpers
 
 suite "Heartbeat":
+  # MacOs has some nasty jitter when sleeping
+  # (up to 7 ms), so we need some pretty long
+  # sleeps to be safe here
+
   asyncTest "simple heartbeat":
     var i = 0
     proc t() {.async.} =
-      heartbeat "shouldn't see this", 10.milliseconds:
+      heartbeat "shouldn't see this", 30.milliseconds:
         i.inc()
     let hb = t()
-    await sleepAsync(100.milliseconds)
+    await sleepAsync(300.milliseconds)
     await hb.cancelAndWait()
     check:
       i in 0..11
@@ -19,34 +23,34 @@ suite "Heartbeat":
   asyncTest "change heartbeat period on the fly":
     var i = 0
     proc t() {.async.} =
-      var period = 10.milliseconds
+      var period = 30.milliseconds
       heartbeat "shouldn't see this", period:
         i.inc()
-        if i >= 5:
-          period = 50.milliseconds
+        if i >= 4:
+          period = 75.milliseconds
     let hb = t()
     await sleepAsync(500.milliseconds)
     await hb.cancelAndWait()
 
-    # 5x 10 ms heartbeat = 50ms
-    # then 10x 50 ms heartbeat = 500ms
-    # total 15
+    # 4x 30 ms heartbeat = 120ms
+    # (500 ms - 120 ms) / 75ms = 5x 75ms
+    # total 9
     check:
-      i in 14..16
+      i in 8..10
 
   asyncTest "catch up on slow heartbeat":
     var i = 0
     proc t() {.async.} =
-      heartbeat "this is normal", 10.milliseconds:
+      heartbeat "this is normal", 30.milliseconds:
         if i < 3:
-          await sleepAsync(50.milliseconds)
+          await sleepAsync(150.milliseconds)
         i.inc()
 
     let hb = t()
-    await sleepAsync(300.milliseconds)
+    await sleepAsync(900.milliseconds)
     await hb.cancelAndWait()
-    # 3x 50ms heartbeat + 10ms interval = 180ms
-    # 120ms remaining, / 10ms = 12x
+    # 3x (150ms heartbeat + 30ms interval) = 540ms
+    # 360ms remaining, / 30ms = 12x
     # total 15
     check:
       i in 14..16

--- a/tests/testheartbeat.nim
+++ b/tests/testheartbeat.nim
@@ -1,0 +1,52 @@
+import random
+import chronos
+
+import ../libp2p/utils/heartbeat
+import ./helpers
+
+suite "Heartbeat":
+  asyncTest "simple heartbeat":
+    var i = 0
+    proc t() {.async.} =
+      heartbeat "shouldn't see this", 10.milliseconds:
+        i.inc()
+    let hb = t()
+    await sleepAsync(100.milliseconds)
+    await hb.cancelAndWait()
+    check:
+      i in 0..11
+
+  asyncTest "change heartbeat period on the fly":
+    var i = 0
+    proc t() {.async.} =
+      var period = 10.milliseconds
+      heartbeat "shouldn't see this", period:
+        i.inc()
+        if i >= 5:
+          period = 50.milliseconds
+    let hb = t()
+    await sleepAsync(500.milliseconds)
+    await hb.cancelAndWait()
+
+    # 5x 10 ms heartbeat = 50ms
+    # then 10x 50 ms heartbeat = 500ms
+    # total 15
+    check:
+      i in 14..16
+
+  asyncTest "catch up on slow heartbeat":
+    var i = 0
+    proc t() {.async.} =
+      heartbeat "this is normal", 10.milliseconds:
+        if i < 3:
+          await sleepAsync(50.milliseconds)
+        i.inc()
+
+    let hb = t()
+    await sleepAsync(300.milliseconds)
+    await hb.cancelAndWait()
+    # 3x 50ms heartbeat + 10ms interval = 180ms
+    # 120ms remaining, / 10ms = 12x
+    # total 15
+    check:
+      i in 14..16

--- a/tests/testnative.nim
+++ b/tests/testnative.nim
@@ -2,7 +2,8 @@ import testvarint,
        testconnection,
        testminprotobuf,
        teststreamseq,
-       testsemaphore
+       testsemaphore,
+       testheartbeat
 
 import testminasn1,
        testrsa,


### PR DESCRIPTION
We were lacking implementation for two parameters that changed the scoring completely:
decayInterval: was pegged to the heartbeat, so the decay speed was wrong
meshMessageDeliveriesWindow: every peer was gaining score for delivering, even if it was 5 minutes late

Also added a little check, to avoid peers sending us duplicate, hoping to get more points