### PR TITLE
Change dial return to take into account the protocol

### DIFF
--- a/libp2p/dial.nim
+++ b/libp2p/dial.nim
@@ -17,6 +17,10 @@ import peerid,
 type
   Dial* = ref object of RootObj
 
+  DialRes* = tuple
+    conn: Connection
+    proto: string
+
 method connect*(
   self: Dial,
   peerId: PeerId,
@@ -32,7 +36,7 @@ method dial*(
   self: Dial,
   peerId: PeerId,
   protos: seq[string],
-  ): Future[Connection] {.async, base.} =
+  ): Future[DialRes] {.async, base.} =
   ## create a protocol stream over an
   ## existing connection
   ##
@@ -44,7 +48,7 @@ method dial*(
   peerId: PeerId,
   addrs: seq[MultiAddress],
   protos: seq[string],
-  forceDial = false): Future[Connection] {.async, base.} =
+  forceDial = false): Future[DialRes] {.async, base.} =
   ## create a protocol stream and establish
   ## a connection if one doesn't exist already
   ##

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -176,19 +176,19 @@ method connect*(
 proc negotiateStream(
   self: Dialer,
   conn: Connection,
-  protos: seq[string]): Future[Connection] {.async.} =
+  protos: seq[string]): Future[DialRes] {.async.} =
   trace "Negotiating stream", conn, protos
   let selected = await self.ms.select(conn, protos)
   if not protos.contains(selected):
     await conn.closeWithEOF()
     raise newException(DialFailedError, "Unable to select sub-protocol " & $protos)
 
-  return conn
+  return (conn, selected)
 
 method dial*(
   self: Dialer,
   peerId: PeerId,
-  protos: seq[string]): Future[Connection] {.async.} =
+  protos: seq[string]): Future[DialRes] {.async.} =
   ## create a protocol stream over an
   ## existing connection
   ##
@@ -205,7 +205,7 @@ method dial*(
   peerId: PeerId,
   addrs: seq[MultiAddress],
   protos: seq[string],
-  forceDial = false): Future[Connection] {.async.} =
+  forceDial = false): Future[DialRes] {.async.} =
   ## create a protocol stream and establish
   ## a connection if one doesn't exist already
   ##

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -277,8 +277,9 @@ proc getOrCreatePeer*(
   p.peers.withValue(peerId, peer):
     return peer[]
 
-  proc getConn(): Future[Connection] =
-    p.switch.dial(peerId, protos)
+  proc getConn(): Future[Connection] {.async.} =
+    let (conn, _) = await p.switch.dial(peerId, protos)
+    return conn
 
   proc dropConn(peer: PubSubPeer) =
     proc dropConnAsync(peer: PubsubPeer) {.async.} =

--- a/libp2p/protocols/relay.nim
+++ b/libp2p/protocols/relay.nim
@@ -210,7 +210,7 @@ proc handleHopStream(r: Relay, conn: Connection, msg: RelayMessage) {.async, gcs
     return
 
   let connDst = try:
-    await r.switch.dial(dst.peerId, @[RelayCodec])
+    await r.switch.dial(dst.peerId, RelayCodec)
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -111,28 +111,30 @@ method connect*(
 method dial*(
   s: Switch,
   peerId: PeerId,
-  protos: seq[string]): Future[Connection] =
+  protos: seq[string]): Future[DialRes] =
   s.dialer.dial(peerId, protos)
 
 proc dial*(s: Switch,
            peerId: PeerId,
-           proto: string): Future[Connection] =
-  dial(s, peerId, @[proto])
+           proto: string): Future[Connection] {.async.} =
+  let (conn, _) = await dial(s, peerId, @[proto])
+  return conn
 
 method dial*(
   s: Switch,
   peerId: PeerId,
   addrs: seq[MultiAddress],
   protos: seq[string],
-  forceDial = false): Future[Connection] =
+  forceDial = false): Future[DialRes] =
   s.dialer.dial(peerId, addrs, protos, forceDial)
 
 proc dial*(
   s: Switch,
   peerId: PeerId,
   addrs: seq[MultiAddress],
-  proto: string): Future[Connection] =
-  dial(s, peerId, addrs, @[proto])
+  proto: string): Future[Connection] {.async.} =
+  let (conn, _) = await dial(s, peerId, addrs, @[proto])
+  return conn
 
 proc mount*[T: LPProtocol](s: Switch, proto: T, matcher: Matcher = nil)
   {.gcsafe, raises: [Defect, LPError].} =

--- a/tests/testinterop.nim
+++ b/tests/testinterop.nim
@@ -510,7 +510,7 @@ suite "Interop":
 
     await daemonNode.addHandler(@[ "/testCustom" ], daemonHandler)
 
-    let conn = await src.dial(daemonPeer.peer, @[ maddr ], @[ "/testCustom" ])
+    let conn = await src.dial(daemonPeer.peer, @[ maddr ], "/testCustom")
 
     await conn.writeLp("line1")
     check string.fromBytes(await conn.readLp(1024)) == "line2"


### PR DESCRIPTION
As the title said, currently there's no way to know which protocol is accepted when we dial using multiple protocols.