### PR TITLE
Start/stop protocols

### DIFF
--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -9,7 +9,7 @@
 
 {.push raises: [Defect].}
 
-import std/[strutils]
+import std/[strutils, sequtils]
 import chronos, chronicles, stew/byteutils
 import stream/connection,
        protocols/protocol
@@ -209,3 +209,9 @@ proc addHandler*(m: MultistreamSelect,
   m.handlers.add(HandlerHolder(protos: @[codec],
                                protocol: protocol,
                                match: matcher))
+
+proc start*(m: MultistreamSelect) {.async.} =
+  await allFutures(m.handlers.mapIt(it.protocol.start()))
+
+proc stop*(m: MultistreamSelect) {.async.} =
+  await allFutures(m.handlers.mapIt(it.protocol.stop()))

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -24,6 +24,8 @@ type
     handler*: LPProtoHandler ## this handler gets invoked by the protocol negotiator
 
 method init*(p: LPProtocol) {.base, gcsafe.} = discard
+method start*(p: LPProtocol) {.async, base.} = discard
+method stop*(p: LPProtocol) {.async, base.} = discard
 
 func codec*(p: LPProtocol): string =
   assert(p.codecs.len > 0, "Codecs sequence was empty!")

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -488,14 +488,6 @@ method initPubSub*(p: PubSub)
   if p.msgIdProvider == nil:
     p.msgIdProvider = defaultMsgIdProvider
 
-method start*(p: PubSub) {.async, base.} =
-  ## start pubsub
-  discard
-
-method stop*(p: PubSub) {.async, base.} =
-  ## stopt pubsub
-  discard
-
 method addValidator*(p: PubSub,
                      topic: varargs[string],
                      hook: ValidatorHandler) {.base.} =

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -239,6 +239,8 @@ proc stop*(s: Switch) {.async.} =
     if not a.finished:
       a.cancel()
 
+  await s.ms.stop()
+
   trace "Switch stopped"
 
 proc start*(s: Switch) {.async, gcsafe.} =
@@ -271,6 +273,8 @@ proc start*(s: Switch) {.async, gcsafe.} =
       s.peerInfo.addrs &= t.addrs
 
   s.peerInfo.update()
+
+  await s.ms.start()
 
   debug "Started libp2p node", peer = s.peerInfo
 

--- a/tests/pubsub/testfloodsub.nim
+++ b/tests/pubsub/testfloodsub.nim
@@ -54,13 +54,6 @@ suite "FloodSub":
         nodes[1].switch.start(),
       )
 
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
-
     await subscribeNodes(nodes)
 
     nodes[1].subscribe("foobar", handler)
@@ -72,11 +65,6 @@ suite "FloodSub":
     await allFuturesThrowing(
       nodes[0].switch.stop(),
       nodes[1].switch.stop()
-    )
-
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
     )
 
     await allFuturesThrowing(nodesFut.concat())
@@ -96,12 +84,6 @@ suite "FloodSub":
         nodes[1].switch.start(),
       )
 
-    # start pubsubcon
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     await subscribeNodes(nodes)
 
@@ -115,11 +97,6 @@ suite "FloodSub":
     await allFuturesThrowing(
       nodes[0].switch.stop(),
       nodes[1].switch.stop()
-    )
-
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
     )
 
     await allFuturesThrowing(nodesFut)
@@ -138,13 +115,6 @@ suite "FloodSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsubcon
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     await subscribeNodes(nodes)
 
@@ -168,11 +138,6 @@ suite "FloodSub":
         nodes[1].switch.stop()
       )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut)
 
   asyncTest "FloodSub validation should fail":
@@ -187,13 +152,6 @@ suite "FloodSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsubcon
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     await subscribeNodes(nodes)
     nodes[1].subscribe("foobar", handler)
@@ -214,11 +172,6 @@ suite "FloodSub":
         nodes[1].switch.stop()
       )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut)
 
   asyncTest "FloodSub validation one fails and one succeeds":
@@ -235,13 +188,6 @@ suite "FloodSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsubcon
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     await subscribeNodes(nodes)
     nodes[1].subscribe("foo", handler)
@@ -264,11 +210,6 @@ suite "FloodSub":
     await allFuturesThrowing(
       nodes[0].switch.stop(),
       nodes[1].switch.stop()
-    )
-
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
     )
 
     await allFuturesThrowing(nodesFut)
@@ -296,7 +237,6 @@ suite "FloodSub":
       nodes = generateNodes(runs, triggerSelf = false)
       nodesFut = nodes.mapIt(it.switch.start())
 
-    await allFuturesThrowing(nodes.mapIt(it.start()))
     await subscribeNodes(nodes)
 
     for i in 0..<runs:
@@ -318,7 +258,6 @@ suite "FloodSub":
     await allFuturesThrowing(
       nodes.mapIt(
         allFutures(
-          it.stop(),
           it.switch.stop())))
 
     await allFuturesThrowing(nodesFut)
@@ -346,7 +285,6 @@ suite "FloodSub":
       nodes = generateNodes(runs, triggerSelf = true)
       nodesFut = nodes.mapIt(it.switch.start())
 
-    await allFuturesThrowing(nodes.mapIt(it.start()))
     await subscribeNodes(nodes)
 
     for i in 0..<runs:
@@ -379,7 +317,6 @@ suite "FloodSub":
     await allFuturesThrowing(
       nodes.mapIt(
         allFutures(
-          it.stop(),
           it.switch.stop())))
 
     await allFuturesThrowing(nodesFut)
@@ -399,13 +336,6 @@ suite "FloodSub":
         bigNode[0].switch.start(),
         smallNode[0].switch.start(),
       )
-
-    # start pubsubcon
-    await allFuturesThrowing(
-      allFinished(
-        bigNode[0].start(),
-        smallNode[0].start(),
-    ))
 
     await subscribeNodes(bigNode & smallNode)
     bigNode[0].subscribe("foo", handler)
@@ -429,11 +359,6 @@ suite "FloodSub":
     await allFuturesThrowing(
       smallNode[0].switch.stop(),
       bigNode[0].switch.stop()
-    )
-
-    await allFuturesThrowing(
-      smallNode[0].stop(),
-      bigNode[0].stop()
     )
 
     await allFuturesThrowing(nodesFut)

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -89,13 +89,6 @@ suite "GossipSub":
         nodes[1].switch.start(),
       )
 
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
-
     await subscribeNodes(nodes)
 
     nodes[0].subscribe("foobar", handler)
@@ -125,11 +118,6 @@ suite "GossipSub":
       nodes[1].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "GossipSub validation should fail (reject)":
@@ -144,13 +132,6 @@ suite "GossipSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     await subscribeNodes(nodes)
 
@@ -187,11 +168,6 @@ suite "GossipSub":
       nodes[1].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "GossipSub validation should fail (ignore)":
@@ -206,13 +182,6 @@ suite "GossipSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     await subscribeNodes(nodes)
 
@@ -249,11 +218,6 @@ suite "GossipSub":
       nodes[1].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "GossipSub validation one fails and one succeeds":
@@ -270,13 +234,6 @@ suite "GossipSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     await subscribeNodes(nodes)
 
@@ -314,11 +271,6 @@ suite "GossipSub":
       nodes[1].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "GossipSub unsub - resub faster than backoff":
@@ -335,13 +287,6 @@ suite "GossipSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     await subscribeNodes(nodes)
 
@@ -378,11 +323,6 @@ suite "GossipSub":
       nodes[1].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "e2e - GossipSub should add remote peer topic subscriptions":
@@ -399,13 +339,6 @@ suite "GossipSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     await subscribeNodes(nodes)
 
@@ -425,11 +358,6 @@ suite "GossipSub":
       nodes[1].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "e2e - GossipSub should add remote peer topic subscriptions if both peers are subscribed":
@@ -446,13 +374,6 @@ suite "GossipSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     await subscribeNodes(nodes)
 
@@ -487,11 +408,6 @@ suite "GossipSub":
       nodes[1].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "e2e - GossipSub send over fanout A -> B":
@@ -510,13 +426,6 @@ suite "GossipSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     await subscribeNodes(nodes)
 
@@ -549,17 +458,9 @@ suite "GossipSub":
 
     trace "test done, stopping..."
 
-    await nodes[0].stop()
-    await nodes[1].stop()
-
     await allFuturesThrowing(
       nodes[0].switch.stop(),
       nodes[1].switch.stop()
-    )
-
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
     )
 
     await allFuturesThrowing(nodesFut.concat())
@@ -582,13 +483,6 @@ suite "GossipSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     await subscribeNodes(nodes)
 
@@ -616,17 +510,9 @@ suite "GossipSub":
 
     trace "test done, stopping..."
 
-    await nodes[0].stop()
-    await nodes[1].stop()
-
     await allFuturesThrowing(
       nodes[0].switch.stop(),
       nodes[1].switch.stop()
-    )
-
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
     )
 
     await allFuturesThrowing(nodesFut.concat())
@@ -647,13 +533,6 @@ suite "GossipSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     await subscribeNodes(nodes)
 
@@ -681,11 +560,6 @@ suite "GossipSub":
       nodes[1].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "e2e - GossipSub should not send to source & peers who already seen":
@@ -704,14 +578,6 @@ suite "GossipSub":
         nodes[1].switch.start(),
         nodes[2].switch.start(),
       )
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-        nodes[2].start(),
-    ))
 
     await subscribeNodes(nodes)
 
@@ -763,12 +629,6 @@ suite "GossipSub":
       nodes[2].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop(),
-      nodes[2].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "e2e - GossipSub send over floodPublish A -> B":
@@ -787,13 +647,6 @@ suite "GossipSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     var gossip1: GossipSub = GossipSub(nodes[0])
     gossip1.parameters.floodPublish = true
@@ -821,11 +674,6 @@ suite "GossipSub":
       nodes[1].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "e2e - GossipSub with multiple peers":
@@ -835,7 +683,6 @@ suite "GossipSub":
       nodes = generateNodes(runs, gossip = true, triggerSelf = true)
       nodesFut = nodes.mapIt(it.switch.start())
 
-    await allFuturesThrowing(nodes.mapIt(it.start()))
     await subscribeNodes(nodes)
 
     var seen: Table[string, int]
@@ -875,7 +722,6 @@ suite "GossipSub":
     await allFuturesThrowing(
       nodes.mapIt(
         allFutures(
-          it.stop(),
           it.switch.stop())))
 
     await allFuturesThrowing(nodesFut)
@@ -887,7 +733,6 @@ suite "GossipSub":
       nodes = generateNodes(runs, gossip = true, triggerSelf = true)
       nodesFut = nodes.mapIt(it.switch.start())
 
-    await allFuturesThrowing(nodes.mapIt(it.start()))
     await subscribeSparseNodes(nodes)
 
     var seen: Table[string, int]
@@ -928,7 +773,6 @@ suite "GossipSub":
     await allFuturesThrowing(
       nodes.mapIt(
         allFutures(
-          it.stop(),
           it.switch.stop())))
 
     await allFuturesThrowing(nodesFut)
@@ -955,14 +799,6 @@ suite "GossipSub":
         nodes[1].switch.start(),
         nodes[2].switch.start(),
       )
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-        nodes[2].start(),
-    ))
 
     var
       gossip0 = GossipSub(nodes[0])
@@ -997,11 +833,4 @@ suite "GossipSub":
       nodes[2].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop(),
-      nodes[2].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
-

--- a/tests/pubsub/testgossipsub2.nim
+++ b/tests/pubsub/testgossipsub2.nim
@@ -77,7 +77,6 @@ suite "GossipSub":
       nodes = generateNodes(runs, gossip = true, triggerSelf = true)
       nodesFut = nodes.mapIt(it.switch.start())
 
-    await allFuturesThrowing(nodes.mapIt(it.start()))
     await subscribeSparseNodes(nodes)
 
     var seen: Table[string, int]
@@ -120,7 +119,6 @@ suite "GossipSub":
     await allFuturesThrowing(
       nodes.mapIt(
         allFutures(
-          it.stop(),
           it.switch.stop())))
 
     await allFuturesThrowing(nodesFut)
@@ -139,13 +137,6 @@ suite "GossipSub":
         nodes[0].switch.start(),
         nodes[1].switch.start(),
       )
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     # We must subscribe before setting the validator
     nodes[0].subscribe("foobar", handler)
@@ -174,36 +165,15 @@ suite "GossipSub":
       nodes[1].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "GossipSub test directPeers":
-
-    let
-      nodes = generateNodes(2, gossip = true)
-
-      # start switches
-      nodesFut = await allFinished(
-        nodes[0].switch.start(),
-        nodes[1].switch.start(),
-      )
-
-    var gossip = GossipSub(nodes[0])
-    gossip.parameters.directPeers[nodes[1].switch.peerInfo.peerId] = nodes[1].switch.peerInfo.addrs
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
+    let nodes = generateNodes(2, gossip = true)
+    await allFutures(nodes[0].switch.start(), nodes[1].switch.start())
+    await GossipSub(nodes[0]).addDirectPeer(nodes[1].switch.peerInfo.peerId, nodes[1].switch.peerInfo.addrs)
 
     let invalidDetected = newFuture[void]()
-    gossip.subscriptionValidator =
+    GossipSub(nodes[0]).subscriptionValidator =
       proc(topic: string): bool =
         if topic == "foobar":
           try:
@@ -227,13 +197,6 @@ suite "GossipSub":
       nodes[1].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
-    await allFuturesThrowing(nodesFut.concat())
-
   asyncTest "GossipSub directPeers: always forward messages":
     let
       nodes = generateNodes(2, gossip = true)
@@ -244,15 +207,8 @@ suite "GossipSub":
         nodes[1].switch.start(),
       )
 
-    GossipSub(nodes[0]).parameters.directPeers[nodes[1].switch.peerInfo.peerId] = nodes[1].switch.peerInfo.addrs
-    GossipSub(nodes[1]).parameters.directPeers[nodes[0].switch.peerInfo.peerId] = nodes[0].switch.peerInfo.addrs
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
+    await GossipSub(nodes[0]).addDirectPeer(nodes[1].switch.peerInfo.peerId, nodes[1].switch.peerInfo.addrs)
+    await GossipSub(nodes[1]).addDirectPeer(nodes[0].switch.peerInfo.peerId, nodes[0].switch.peerInfo.addrs)
 
     var handlerFut = newFuture[void]()
     proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
@@ -275,11 +231,6 @@ suite "GossipSub":
       nodes[1].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "GossipSub directPeers: don't kick direct peer with low score":
@@ -292,18 +243,11 @@ suite "GossipSub":
         nodes[1].switch.start(),
       )
 
-    GossipSub(nodes[0]).parameters.directPeers[nodes[1].switch.peerInfo.peerId] = nodes[1].switch.peerInfo.addrs
-    GossipSub(nodes[1]).parameters.directPeers[nodes[0].switch.peerInfo.peerId] = nodes[0].switch.peerInfo.addrs
+    await GossipSub(nodes[0]).addDirectPeer(nodes[1].switch.peerInfo.peerId, nodes[1].switch.peerInfo.addrs)
+    await GossipSub(nodes[1]).addDirectPeer(nodes[0].switch.peerInfo.peerId, nodes[0].switch.peerInfo.addrs)
 
     GossipSub(nodes[1]).parameters.disconnectBadPeers = true
     GossipSub(nodes[1]).parameters.graylistThreshold = 100000
-
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
 
     var handlerFut = newFuture[void]()
     proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
@@ -334,11 +278,6 @@ suite "GossipSub":
       nodes[1].switch.stop()
     )
 
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
-    )
-
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "GossipsSub peers disconnections mechanics":
@@ -348,7 +287,6 @@ suite "GossipSub":
       nodes = generateNodes(runs, gossip = true, triggerSelf = true)
       nodesFut = nodes.mapIt(it.switch.start())
 
-    await allFuturesThrowing(nodes.mapIt(it.start()))
     await subscribeNodes(nodes)
 
     var seen: Table[string, int]
@@ -434,7 +372,6 @@ suite "GossipSub":
     await allFuturesThrowing(
       nodes.mapIt(
         allFutures(
-          it.stop(),
           it.switch.stop())))
 
     await allFuturesThrowing(nodesFut)
@@ -444,24 +381,18 @@ suite "GossipSub":
     let
       nodes = generateNodes(2, gossip = true)
 
-      # start switches
-      nodesFut = await allFinished(
-        nodes[0].switch.start(),
-        nodes[1].switch.start(),
-      )
-
     var gossip = GossipSub(nodes[0])
     # MacOs has some nasty jitter when sleeping
     # (up to 7 ms), so we need some pretty long
     # sleeps to be safe here
     gossip.parameters.decayInterval = 300.milliseconds
 
-    # start pubsub
-    await allFuturesThrowing(
-      allFinished(
-        nodes[0].start(),
-        nodes[1].start(),
-    ))
+    let
+      # start switches
+      nodesFut = await allFinished(
+        nodes[0].switch.start(),
+        nodes[1].switch.start(),
+      )
 
     var handlerFut = newFuture[void]()
     proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
@@ -487,11 +418,6 @@ suite "GossipSub":
     await allFuturesThrowing(
       nodes[0].switch.stop(),
       nodes[1].switch.stop()
-    )
-
-    await allFuturesThrowing(
-      nodes[0].stop(),
-      nodes[1].stop()
     )
 
     await allFuturesThrowing(nodesFut.concat())

--- a/tests/testinterop.nim
+++ b/tests/testinterop.nim
@@ -55,7 +55,6 @@ proc testPubSubDaemonPublish(gossip: bool = false, count: int = 1) {.async.} =
   nativeNode.mount(pubsub)
 
   await nativeNode.start()
-  await pubsub.start()
   let nativePeer = nativeNode.peerInfo
 
   var finished = false
@@ -89,7 +88,6 @@ proc testPubSubDaemonPublish(gossip: bool = false, count: int = 1) {.async.} =
   await wait(publisher(), 5.minutes) # should be plenty of time
 
   await nativeNode.stop()
-  await pubsub.stop()
   await daemonNode.close()
 
 proc testPubSubNodePublish(gossip: bool = false, count: int = 1) {.async.} =
@@ -115,7 +113,6 @@ proc testPubSubNodePublish(gossip: bool = false, count: int = 1) {.async.} =
   nativeNode.mount(pubsub)
 
   await nativeNode.start()
-  await pubsub.start()
   let nativePeer = nativeNode.peerInfo
 
   await nativeNode.connect(daemonPeer.peer, daemonPeer.addresses)
@@ -149,7 +146,6 @@ proc testPubSubNodePublish(gossip: bool = false, count: int = 1) {.async.} =
 
   check finished
   await nativeNode.stop()
-  await pubsub.stop()
   await daemonNode.close()
 
 suite "Interop":


### PR DESCRIPTION
Starting/stopping a switch now starts/stops all protocols mounted on that switch.
Currently, there's only gossipsub that effectively starts something but there's might be others (looking at you circuit relayv2) in a near future.

In addition to this change, I added a proc addDirectPeers to make all the gossipsub tests worked.