### PR TITLE
Replace table by seq for storing muxers

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -116,7 +116,7 @@ proc withMplex*(
       maxChannCount)
 
   for m in b.muxers:
-    if MplexCodec == m.codecs:
+    if MplexCodec in m.codecs:
       m.newMuxer = newMuxer
       return b
   b.muxers.add(MuxerProvider.new(newMuxer, MplexCodec))

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -19,7 +19,7 @@ runnableExamples:
 {.push raises: [Defect].}
 
 import
-  options, tables, chronos, chronicles,
+  options, tables, chronos, chronicles, sequtils,
   switch, peerid, peerinfo, stream/connection, multiaddress,
   crypto/crypto, transports/[transport, tcptransport],
   muxers/[muxer, mplex/mplex, yamux/yamux],

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -116,7 +116,7 @@ proc withMplex*(
       maxChannCount)
 
   for m in b.muxers:
-    if m.codecs[0] == MplexCodec:
+    if MplexCodec == m.codecs:
       m.newMuxer = newMuxer
       return b
   b.muxers.add(MuxerProvider.new(newMuxer, MplexCodec))
@@ -126,7 +126,7 @@ proc withYamux*(b: SwitchBuilder): SwitchBuilder =
   proc newMuxer(conn: Connection): Muxer = Yamux.new(conn)
 
   for m in b.muxers:
-    if m.codecs[0] == YamuxCodec:
+    if YamuxCodec in m.codecs:
       m.newMuxer = newMuxer
       return b
   b.muxers.add(MuxerProvider.new(newMuxer, YamuxCodec))

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -115,20 +115,14 @@ proc withMplex*(
       outTimeout,
       maxChannCount)
 
-  for m in b.muxers:
-    if MplexCodec in m.codecs:
-      m.newMuxer = newMuxer
-      return b
+  assert b.muxers.countIt(it.codec == MplexCodec) == 0, "Mplex build multiple times"
   b.muxers.add(MuxerProvider.new(newMuxer, MplexCodec))
   b
 
 proc withYamux*(b: SwitchBuilder): SwitchBuilder =
   proc newMuxer(conn: Connection): Muxer = Yamux.new(conn)
 
-  for m in b.muxers:
-    if YamuxCodec in m.codecs:
-      m.newMuxer = newMuxer
-      return b
+  assert b.muxers.countIt(it.codec == YamuxCodec) == 0, "Yamux build multiple times"
   b.muxers.add(MuxerProvider.new(newMuxer, YamuxCodec))
   b
 

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -322,7 +322,6 @@ proc start*(s: Switch) {.async, gcsafe, public.} =
 proc newSwitch*(peerInfo: PeerInfo,
                 transports: seq[Transport],
                 identity: Identify,
-                muxers: Table[string, MuxerProvider],
                 secureManagers: openArray[Secure] = [],
                 connManager: ConnManager,
                 ms: MultistreamSelect,

--- a/libp2p/upgrademngrs/muxedupgrade.nim
+++ b/libp2p/upgrademngrs/muxedupgrade.nim
@@ -27,7 +27,7 @@ type
 
 proc getMuxerByCodec(self: MuxedUpgrade, muxerName: string): MuxerProvider =
   for m in self.muxers:
-    if m.codecs[0] == muxerName:
+    if muxerName in m.codecs:
       return m
 
 proc identify*(

--- a/libp2p/upgrademngrs/muxedupgrade.nim
+++ b/libp2p/upgrademngrs/muxedupgrade.nim
@@ -22,8 +22,13 @@ logScope:
 
 type
   MuxedUpgrade* = ref object of Upgrade
-    muxers*: Table[string, MuxerProvider]
+    muxers*: seq[MuxerProvider]
     streamHandler*: StreamHandler
+
+proc getMuxerByCodec(self: MuxedUpgrade, muxerName: string): MuxerProvider =
+  for m in self.muxers:
+    if m.codecs[0] == muxerName:
+      return m
 
 proc identify*(
   self: MuxedUpgrade,
@@ -50,7 +55,7 @@ proc mux*(
     warn "no muxers registered, skipping upgrade flow", conn
     return
 
-  let muxerName = await self.ms.select(conn, toSeq(self.muxers.keys()))
+  let muxerName = await self.ms.select(conn, self.muxers.mapIt(it.codec))
   if muxerName.len == 0 or muxerName == "na":
     debug "no muxer available, early exit", conn
     return
@@ -58,7 +63,7 @@ proc mux*(
   trace "Found a muxer", conn, muxerName
 
   # create new muxer for connection
-  let muxer = self.muxers[muxerName].newMuxer(conn)
+  let muxer = self.getMuxerByCodec(muxerName).newMuxer(conn)
 
   # install stream handler
   muxer.streamHandler = self.streamHandler
@@ -127,7 +132,7 @@ method upgradeIncoming*(
 
       cconn = sconn
       # add the muxer
-      for muxer in self.muxers.values:
+      for muxer in self.muxers:
         ms.addHandler(muxer.codecs, muxer)
 
       # handle subsequent secure requests
@@ -197,7 +202,7 @@ proc muxerHandler(
 proc new*(
   T: type MuxedUpgrade,
   identity: Identify,
-  muxers: Table[string, MuxerProvider],
+  muxers: seq[MuxerProvider],
   secureManagers: openArray[Secure] = [],
   connManager: ConnManager,
   ms: MultistreamSelect): T =

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -61,7 +61,7 @@ proc createSwitch(ma: MultiAddress; outgoing: bool, secio: bool = false): (Switc
   let
     identify = Identify.new(peerInfo)
     mplexProvider = MuxerProvider.new(createMplex, MplexCodec)
-    muxers = [(MplexCodec, mplexProvider)].toTable()
+    muxers = @[mplexProvider]
     secureManagers = if secio:
       [Secure(Secio.new(rng, privateKey))]
     else:
@@ -75,7 +75,6 @@ proc createSwitch(ma: MultiAddress; outgoing: bool, secio: bool = false): (Switc
       peerInfo,
       transports,
       identify,
-      muxers,
       secureManagers,
       connManager,
       ms)


### PR DESCRIPTION
A simple change in the way to store `MuxerProvider` to remove the randomness of the Table (it could have been an OrderedTable, but I think it's a bit silly to use that for a maximum of two elements).
Now the first muxer added in the switch builder is always the one used/tried first.