### PR TITLE
make it more Nim 1.4+ compatible

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -2,8 +2,6 @@
 if dirExists("nimbledeps/pkgs"):
   switch("NimblePath", "nimbledeps/pkgs")
 
-when (NimMajor, NimMinor) > (1, 2):
-  switch("hint", "XCannotRaiseY:off")
 # begin Nimble config (version 1)
 when fileExists("nimble.paths"):
   include "nimble.paths"

--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -16,7 +16,10 @@ runnableExamples:
    # etc
    .build()
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import
   options, tables, chronos, chronicles, sequtils,

--- a/libp2p/cid.nim
+++ b/libp2p/cid.nim
@@ -9,7 +9,10 @@
 
 ## This module implementes CID (Content IDentifier).
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import tables, hashes
 import multibase, multicodec, multihash, vbuffer, varint

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[options, tables, sequtils, sets]
 import pkg/[chronos, chronicles, metrics]

--- a/libp2p/crypto/chacha20poly1305.nim
+++ b/libp2p/crypto/chacha20poly1305.nim
@@ -15,7 +15,10 @@
 
 # RFC @ https://tools.ietf.org/html/rfc7539
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import bearssl/blockx
 from stew/assign2 import assign

--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -8,7 +8,10 @@
 # those terms.
 
 ## This module implements Public Key and Private Key interface for libp2p.
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 from strutils import split, strip, cmpIgnoreCase
 

--- a/libp2p/crypto/curve25519.nim
+++ b/libp2p/crypto/curve25519.nim
@@ -15,7 +15,10 @@
 
 # RFC @ https://tools.ietf.org/html/rfc7748
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import bearssl/[ec, rand, hash]
 import stew/results

--- a/libp2p/crypto/ecnist.nim
+++ b/libp2p/crypto/ecnist.nim
@@ -14,7 +14,10 @@
 ## BearSSL library <https://bearssl.org/>
 ## Copyright(C) 2018 Thomas Pornin <pornin@bolet.org>.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import bearssl/[ec, rand, hash]
 # We use `ncrutils` for constant-time hexadecimal encoding/decoding procedures.

--- a/libp2p/crypto/ed25519/ed25519.nim
+++ b/libp2p/crypto/ed25519/ed25519.nim
@@ -11,7 +11,10 @@
 ## This code is a port of the public domain, "ref10" implementation of ed25519
 ## from SUPERCOP.
 
-{.push raises: Defect.}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import bearssl/rand
 import constants

--- a/libp2p/crypto/hkdf.nim
+++ b/libp2p/crypto/hkdf.nim
@@ -9,7 +9,10 @@
 
 # https://tools.ietf.org/html/rfc5869
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import nimcrypto
 import bearssl/[kdf, rand, hash]

--- a/libp2p/crypto/minasn1.nim
+++ b/libp2p/crypto/minasn1.nim
@@ -9,7 +9,10 @@
 
 ## This module implements minimal ASN.1 encoding/decoding primitives.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import stew/[endians2, results, ctops]
 export results

--- a/libp2p/crypto/rsa.nim
+++ b/libp2p/crypto/rsa.nim
@@ -13,7 +13,11 @@
 ## BearSSL library <https://bearssl.org/>
 ## Copyright(C) 2018 Thomas Pornin <pornin@bolet.org>.
 
-{.push raises: Defect.}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
 import bearssl/[rsa, rand, hash]
 import minasn1
 import stew/[results, ctops]

--- a/libp2p/crypto/secp.nim
+++ b/libp2p/crypto/secp.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import bearssl/rand
 import

--- a/libp2p/daemon/daemonapi.nim
+++ b/libp2p/daemon/daemonapi.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 ## This module implementes API for `go-libp2p-daemon`.
 import std/[os, osproc, strutils, tables, strtabs, sequtils]

--- a/libp2p/daemon/transpool.nim
+++ b/libp2p/daemon/transpool.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 ## This module implements Pool of StreamTransport.
 import chronos

--- a/libp2p/dial.nim
+++ b/libp2p/dial.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import chronos
 import peerid,

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -9,7 +9,10 @@
 
 ## This module implements MultiAddress.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 {.push public.}
 
 import pkg/chronos

--- a/libp2p/multibase.nim
+++ b/libp2p/multibase.nim
@@ -13,7 +13,10 @@
 ## 1. base32z
 ##
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import tables
 import stew/[base32, base58, base64, results]

--- a/libp2p/multicodec.nim
+++ b/libp2p/multicodec.nim
@@ -9,7 +9,10 @@
 
 ## This module implements MultiCodec.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import tables, hashes
 import varint, vbuffer

--- a/libp2p/multihash.nim
+++ b/libp2p/multihash.nim
@@ -21,7 +21,10 @@
 ## 1. SKEIN
 ## 2. MURMUR
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import tables
 import nimcrypto/[sha, sha2, keccak, blake2, hash, utils]

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[strutils, sequtils]
 import chronos, chronicles, stew/byteutils

--- a/libp2p/muxers/mplex/coder.nim
+++ b/libp2p/muxers/mplex/coder.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import pkg/[chronos, nimcrypto/utils, chronicles, stew/byteutils]
 import ../../stream/connection,

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -87,7 +87,7 @@ proc open*(s: LPChannel) {.async, gcsafe.} =
     await s.conn.close()
     raise exc
 
-method closed*(s: LPChannel): bool {.raises: [Defect].} =
+method closed*(s: LPChannel): bool =
   s.closedLocal
 
 proc closeUnderlying(s: LPChannel): Future[void] {.async.} =

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[oids, strformat]
 import pkg/[chronos, chronicles, metrics, nimcrypto/utils]

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import tables, sequtils, oids
 import chronos, chronicles, stew/byteutils, metrics

--- a/libp2p/muxers/muxer.nim
+++ b/libp2p/muxers/muxer.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import chronos, chronicles
 import ../protocols/protocol,

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import sequtils, std/[tables]
 import chronos, chronicles, metrics, stew/[endians2, byteutils, objects]

--- a/libp2p/nameresolving/dnsresolver.nim
+++ b/libp2p/nameresolving/dnsresolver.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import
   std/[streams, strutils, sets, sequtils],

--- a/libp2p/nameresolving/mockresolver.nim
+++ b/libp2p/nameresolving/mockresolver.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import
   std/[streams, strutils, tables],

--- a/libp2p/nameresolving/nameresolver.nim
+++ b/libp2p/nameresolving/nameresolver.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[sugar, sets, sequtils, strutils]
 import 

--- a/libp2p/peerid.nim
+++ b/libp2p/peerid.nim
@@ -9,7 +9,10 @@
 
 ## This module implementes API for libp2p peer.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 {.push public.}
 
 import

--- a/libp2p/peerinfo.nim
+++ b/libp2p/peerinfo.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 {.push public.}
 
 import std/[options, sequtils]

--- a/libp2p/peerstore.nim
+++ b/libp2p/peerstore.nim
@@ -22,7 +22,10 @@ runnableExamples:
   peerStore[MoodBook][somePeerId] = "Happy"
   doAssert peerStore[MoodBook][somePeerId] == "Happy"
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import
   std/[tables, sets, options, macros],

--- a/libp2p/protobuf/minprotobuf.nim
+++ b/libp2p/protobuf/minprotobuf.nim
@@ -9,7 +9,10 @@
 
 ## This module implements minimal Google's ProtoBuf primitives.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import ../varint, ../utility, stew/[endians2, results]
 export results, utility

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -10,7 +10,10 @@
 ## `Identify <https://docs.libp2p.io/concepts/protocols/#identify>`_ and
 ## `Push Identify <https://docs.libp2p.io/concepts/protocols/#identify-push>`_ implementation
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[sequtils, options, strutils, sugar]
 import chronos, chronicles

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -9,7 +9,10 @@
 
 ## `Ping <https://docs.libp2p.io/concepts/protocols/#ping>`_ protocol implementation
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import chronos, chronicles
 import bearssl/[rand, hash]

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import chronos
 import ../stream/connection

--- a/libp2p/protocols/pubsub/floodsub.nim
+++ b/libp2p/protocols/pubsub/floodsub.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[sequtils, sets, hashes, tables]
 import chronos, chronicles, metrics

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -9,7 +9,10 @@
 
 ## Gossip based publishing
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[tables, sets, options, sequtils]
 import chronos, chronicles, metrics

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[tables, sequtils, sets, algorithm]
 import chronos, chronicles, metrics

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[tables, sets, options]
 import chronos, chronicles, metrics
@@ -101,7 +104,6 @@ proc disconnectPeer(g: GossipSub, peer: PubSubPeer) {.async.} =
   except CatchableError as exc: # Never cancelled
     trace "Failed to close connection", peer, error = exc.name, msg = exc.msg
 
-{.push raises: [Defect].}
 
 proc updateScores*(g: GossipSub) = # avoid async
   ## https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#the-score-function

--- a/libp2p/protocols/pubsub/gossipsub/types.nim
+++ b/libp2p/protocols/pubsub/gossipsub/types.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import chronos
 import std/[tables, sets]

--- a/libp2p/protocols/pubsub/mcache.nim
+++ b/libp2p/protocols/pubsub/mcache.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[sets, tables, options]
 import rpc/[messages]

--- a/libp2p/protocols/pubsub/peertable.nim
+++ b/libp2p/protocols/pubsub/peertable.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[tables, sets]
 import ./pubsubpeer, ../../peerid

--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -13,7 +13,10 @@
 ## `publish<#publish.e%2CPubSub%2Cstring%2Cseq%5Bbyte%5D>`_ something on it,
 ## and eventually `unsubscribe<#unsubscribe%2CPubSub%2Cstring%2CTopicHandler>`_ from it.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[tables, sequtils, sets, strutils]
 import chronos, chronicles, metrics

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[sequtils, strutils, tables, hashes]
 import chronos, chronicles, nimcrypto/sha2, metrics

--- a/libp2p/protocols/pubsub/rpc/message.nim
+++ b/libp2p/protocols/pubsub/rpc/message.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import hashes
 import chronicles, metrics, stew/[byteutils, endians2]

--- a/libp2p/protocols/pubsub/rpc/messages.nim
+++ b/libp2p/protocols/pubsub/rpc/messages.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import options, sequtils
 import "../../.."/[

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import options
 import stew/assign2
@@ -17,7 +20,6 @@ import messages,
        ../../../utility,
        ../../../protobuf/minprotobuf
 
-{.push raises: [Defect].}
 
 logScope:
   topics = "pubsubprotobuf"

--- a/libp2p/protocols/pubsub/timedcache.nim
+++ b/libp2p/protocols/pubsub/timedcache.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[tables]
 

--- a/libp2p/protocols/relay/client.nim
+++ b/libp2p/protocols/relay/client.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import times, options
 

--- a/libp2p/protocols/relay/messages.nim
+++ b/libp2p/protocols/relay/messages.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import options, macros, sequtils
 import stew/objects

--- a/libp2p/protocols/relay/rconn.nim
+++ b/libp2p/protocols/relay/rconn.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import chronos
 

--- a/libp2p/protocols/relay/relay.nim
+++ b/libp2p/protocols/relay/relay.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import options, sequtils, tables, sugar
 

--- a/libp2p/protocols/relay/rtransport.nim
+++ b/libp2p/protocols/relay/rtransport.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import sequtils, strutils
 

--- a/libp2p/protocols/relay/utils.nim
+++ b/libp2p/protocols/relay/utils.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import options
 

--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[oids, strformat]
 import chronos

--- a/libp2p/protocols/secure/plaintext.nim
+++ b/libp2p/protocols/secure/plaintext.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import chronos
 import secure, ../../stream/connection

--- a/libp2p/protocols/secure/secio.nim
+++ b/libp2p/protocols/secure/secio.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[oids, strformat]
 import bearssl/rand

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[strformat]
 import chronos, chronicles

--- a/libp2p/routing_record.nim
+++ b/libp2p/routing_record.nim
@@ -9,7 +9,10 @@
 
 ## This module implements Routing Records.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[sequtils, times]
 import pkg/stew/results

--- a/libp2p/signed_envelope.nim
+++ b/libp2p/signed_envelope.nim
@@ -9,7 +9,10 @@
 
 ## This module implements Signed Envelope.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/sugar
 import pkg/stew/[results, byteutils]

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/strformat
 import stew/byteutils

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -111,7 +111,7 @@ method pushEof*(s: BufferStream) {.base, async.} =
   finally:
     s.pushing = false
 
-method atEof*(s: BufferStream): bool {.raises: [Defect].} =
+method atEof*(s: BufferStream): bool =
   s.isEof and s.readBuf.len == 0
 
 method readOnce*(s: BufferStream,

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[oids, strformat]
 import chronos, chronicles, metrics

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[hashes, oids, strformat]
 import chronicles, chronos, metrics

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -9,7 +9,10 @@
 
 ## Length Prefixed stream implementation
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/oids
 import stew/byteutils

--- a/libp2p/stream/streamseq.nim
+++ b/libp2p/stream/streamseq.nim
@@ -1,4 +1,7 @@
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import stew/bitops2
 

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -11,7 +11,10 @@
 ## transports, the connection manager, the upgrader and other
 ## parts to allow programs to use libp2p
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[tables,
             options,

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -9,7 +9,10 @@
 
 ## TCP transport implementation
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[oids, sequtils]
 import chronos, chronicles

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -8,7 +8,10 @@
 # those terms.
 ##
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import sequtils
 import chronos, chronicles

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -9,7 +9,10 @@
 
 ## WebSocket & WebSocket Secure transport implementation
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[sequtils]
 import chronos, chronicles

--- a/libp2p/upgrademngrs/muxedupgrade.nim
+++ b/libp2p/upgrademngrs/muxedupgrade.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[tables, sequtils]
 import pkg/[chronos, chronicles, metrics]

--- a/libp2p/upgrademngrs/upgrade.nim
+++ b/libp2p/upgrademngrs/upgrade.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import std/[options, sequtils, strutils]
 import pkg/[chronos, chronicles, metrics]

--- a/libp2p/utility.nim
+++ b/libp2p/utility.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import stew/byteutils
 

--- a/libp2p/utils/heartbeat.nim
+++ b/libp2p/utils/heartbeat.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import sequtils
 import chronos, chronicles

--- a/libp2p/utils/semaphore.nim
+++ b/libp2p/utils/semaphore.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import sequtils
 import chronos, chronicles

--- a/libp2p/varint.nim
+++ b/libp2p/varint.nim
@@ -16,7 +16,10 @@
 ##   maximum size of encoded value is 9 octets (bytes).
 ##   https://github.com/multiformats/unsigned-varint
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import stew/[byteutils, leb128, results]
 export leb128, results

--- a/libp2p/vbuffer.nim
+++ b/libp2p/vbuffer.nim
@@ -9,7 +9,10 @@
 
 ## This module implements variable buffer.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import varint, strutils
 

--- a/libp2p/wire.nim
+++ b/libp2p/wire.nim
@@ -7,7 +7,10 @@
 # This file may not be copied, modified, or distributed except according to
 # those terms.
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 ## This module implements wire network connection procedures.
 import chronos, stew/endians2

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -1,4 +1,7 @@
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import chronos
 
@@ -13,7 +16,6 @@ import ../libp2p/protocols/secure/secure
 import ./asyncunit
 export asyncunit
 
-{.push raises: [Defect].}
 
 const
   StreamTransportTrackerName = "stream.transport"

--- a/tests/testmultistream.nim
+++ b/tests/testmultistream.nim
@@ -11,7 +11,10 @@ import ../libp2p/errors,
        ../libp2p/upgrademngrs/upgrade
 
 
-{.push raises: [Defect].}
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
 
 import ./helpers
 

--- a/tests/testmultistream.nim
+++ b/tests/testmultistream.nim
@@ -59,7 +59,7 @@ method readOnce*(s: TestSelectStream,
 
 method write*(s: TestSelectStream, msg: seq[byte]) {.async, gcsafe.} = discard
 
-method close(s: TestSelectStream) {.async, gcsafe, raises: [Defect].} =
+method close(s: TestSelectStream) {.async, gcsafe.} =
   s.isClosed = true
   s.isEof = true
 

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -39,7 +39,12 @@ const
 type
   TestProto = ref object of LPProtocol
 
-method init(p: TestProto) {.gcsafe, raises: [Defect].} =
+when (NimMajor, NimMinor) < (1, 4):
+  {.push raises: [Defect].}
+else:
+  {.push raises: [].}
+
+method init(p: TestProto) {.gcsafe.} =
   proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
     let msg = string.fromBytes(await conn.readLp(1024))
     check "Hello!" == msg
@@ -48,6 +53,9 @@ method init(p: TestProto) {.gcsafe, raises: [Defect].} =
 
   p.codec = TestCodec
   p.handler = handle
+
+{.pop.}
+
 
 proc createSwitch(ma: MultiAddress; outgoing: bool, secio: bool = false): (Switch, PeerInfo) =
   var


### PR DESCRIPTION
A continuation of https://github.com/status-im/nimbus-eth2/pull/3888

Rationale (from that link):

> Currently (the latest commit in unstable branch), the CI log for the 1.6 branch has **107.000 lines**.
Removing every hint about cannot raise 'Defect' (including the ones in the vendor directory) leaves **16.000 lines**. 85% off.