### PR TITLE
Keep connection alive when peer doesn't support pubsub

### DIFF
--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -22,10 +22,7 @@ proc getPubSubPeer(p: TestGossipSub, peerId: PeerId): PubSubPeer =
   proc getConn(): Future[Connection] =
     p.switch.dial(peerId, GossipSubCodec)
 
-  proc dropConn(peer: PubSubPeer) =
-    discard # we don't care about it here yet
-
-  let pubSubPeer = PubSubPeer.new(peerId, getConn, dropConn, nil, GossipSubCodec, 1024 * 1024)
+  let pubSubPeer = PubSubPeer.new(peerId, getConn, nil, GossipSubCodec, 1024 * 1024)
   debug "created new pubsub peer", peerId
 
   p.peers[peerId] = pubSubPeer


### PR DESCRIPTION
Since this was introduced, nimbus got better peer management, and will eventually kick a useless peer (ie not supporting GS) if required

The current behavior is obviously wrong, because nimbus & waku won't peer with light clients not supporting GS for instance