### PR TITLE
Specify EOF error

### DIFF
--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -59,6 +59,7 @@ type
     isOpen*: bool                 # has channel been opened
     closedLocal*: bool            # has channel been closed locally
     remoteReset*: bool            # has channel been remotely reset
+    localReset*: bool             # has channel been reset locally
     msgCode*: MessageType         # cached in/out message code
     closeCode*: MessageType       # cached in/out close code
     resetCode*: MessageType       # cached in/out reset code
@@ -104,6 +105,7 @@ proc reset*(s: LPChannel) {.async, gcsafe.} =
 
   s.isClosed = true
   s.closedLocal = true
+  s.localReset = not s.remoteReset
 
   trace "Resetting channel", s, len = s.len
 
@@ -171,6 +173,8 @@ method readOnce*(s: LPChannel,
   ## or the reads will lock each other.
   if s.remoteReset:
     raise newLPStreamResetError()
+  if s.localReset:
+    raise newLPStreamClosedError()
   if s.atEof():
     raise newLPStreamRemoteClosedError()
   if s.conn.closed:

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -195,7 +195,7 @@ method readOnce*(s: LPChannel,
     # data has been lost in s.readBuf and there's no way to gracefully recover /
     # use the channel any more
     await s.reset()
-    raise exc
+    raise newLPStreamConnDownError(exc)
 
 proc prepareWrite(s: LPChannel, msg: seq[byte]): Future[void] {.async.} =
   # prepareWrite is the slow path of writing a message - see conditions in

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -189,10 +189,6 @@ method handle*(m: Mplex) {.async, gcsafe.} =
     debug "Unexpected cancellation in mplex handler", m
   except LPStreamEOFError as exc:
     trace "Stream EOF", m, msg = exc.msg
-    for channel in m.channels[true].mvalues():
-      channel.connDown = true
-    for channel in m.channels[false].mvalues():
-      channel.connDown = true
   except CatchableError as exc:
     debug "Unexpected exception in mplex read loop", m, msg = exc.msg
   finally:

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -153,10 +153,12 @@ type
     sendQueue: seq[ToSend]
     recvQueue: seq[byte]
     isReset: bool
+    remoteReset: bool
     closedRemotely: Future[void]
     closedLocally: bool
     receivedData: AsyncEvent
     returnedEof: bool
+    connDown: ref LPStreamConnDownError
 
 proc `$`(channel: YamuxChannel): string =
   result = if channel.conn.dir == Out: "=> " else: "<= "
@@ -194,23 +196,25 @@ method closeImpl*(channel: YamuxChannel) {.async, gcsafe.} =
     await channel.actuallyClose()
 
 proc reset(channel: YamuxChannel, isLocal: bool = false) {.async.} =
-  if not channel.isReset:
-    trace "Reset channel"
-    channel.isReset = true
-    for (d, s, fut) in channel.sendQueue:
-      fut.fail(newLPStreamEOFError())
-    channel.sendQueue = @[]
-    channel.recvQueue = @[]
-    channel.sendWindow = 0
-    if not channel.closedLocally:
-      if isLocal:
-        try: await channel.conn.write(YamuxHeader.data(channel.id, 0, {Rst}))
-        except LPStreamEOFError as exc: discard
-        except LPStreamClosedError as exc: discard
-      await channel.close()
-    if not channel.closedRemotely.done():
-      await channel.remoteClosed()
-    channel.receivedData.fire()
+  if channel.isReset:
+    return
+  trace "Reset channel"
+  channel.isReset = true
+  channel.remoteReset = not isLocal
+  for (d, s, fut) in channel.sendQueue:
+    fut.fail(newLPStreamEOFError())
+  channel.sendQueue = @[]
+  channel.recvQueue = @[]
+  channel.sendWindow = 0
+  if not channel.closedLocally:
+    if isLocal:
+      try: await channel.conn.write(YamuxHeader.data(channel.id, 0, {Rst}))
+      except LPStreamEOFError as exc: discard
+      except LPStreamClosedError as exc: discard
+    await channel.close()
+  if not channel.closedRemotely.done():
+    await channel.remoteClosed()
+  channel.receivedData.fire()
   if not isLocal:
     # If we reset locally, we want to flush up to a maximum of recvWindow
     # bytes. We use the recvWindow in the proc cleanupChann.
@@ -235,7 +239,15 @@ method readOnce*(
   nbytes: int):
   Future[int] {.async.} =
 
-  if channel.returnedEof: raise newLPStreamEOFError()
+  if channel.isReset:
+    raise if channel.remoteReset:
+        newLPStreamResetError()
+      elif not isNil(channel.connDown):
+        channel.connDown
+      else:
+        newLPStreamClosedError()
+  if channel.returnedEof:
+    raise newLPStreamRemoteClosedError()
   if channel.recvQueue.len == 0:
     channel.receivedData.clear()
     await channel.closedRemotely or channel.receivedData.wait()
@@ -313,8 +325,9 @@ proc trySend(channel: YamuxChannel) {.async.} =
     channel.sendWindow.dec(toSend)
     try: await channel.conn.write(sendBuffer)
     except CatchableError as exc:
+      channel.connDown = newLPStreamConnDownError(exc)
       for fut in futures.items():
-        fut.fail(exc)
+        fut.fail(channel.connDown)
       await channel.reset()
       break
     for fut in futures.items():
@@ -323,8 +336,11 @@ proc trySend(channel: YamuxChannel) {.async.} =
 
 method write*(channel: YamuxChannel, msg: seq[byte]): Future[void] =
   result = newFuture[void]("Yamux Send")
-  if channel.closedLocally or channel.isReset:
-    result.fail(newLPStreamEOFError())
+  if channel.closedLocally or (channel.isReset and not channel.remoteReset):
+    result.fail(newLPStreamClosedError())
+    return result
+  if channel.isReset:
+    result.fail(newLPStreamResetError())
     return result
   if msg.len == 0:
     result.complete()
@@ -453,8 +469,9 @@ method handle*(m: Yamux) {.async, gcsafe.} =
             m.flushed[header.streamId].dec(int(header.length))
             if m.flushed[header.streamId] < 0:
               raise newException(YamuxError, "Peer exhausted the recvWindow after reset")
-            var buffer = newSeqUninitialized[byte](header.length)
-            await m.connection.readExactly(addr buffer[0], int(header.length))
+            if header.length > 0:
+              var buffer = newSeqUninitialized[byte](header.length)
+              await m.connection.readExactly(addr buffer[0], int(header.length))
           continue
 
         let channel = m.channels[header.streamId]
@@ -481,6 +498,9 @@ method handle*(m: Yamux) {.async, gcsafe.} =
           await channel.reset()
   except LPStreamEOFError as exc:
     trace "Stream EOF", msg = exc.msg
+    let exc = newLPStreamConnDownError(exc)
+    for channel in m.channels.mvalues():
+      channel.connDown = exc
   except YamuxError as exc:
     trace "Closing yamux connection", error=exc.msg
     await m.connection.write(YamuxHeader.goAway(ProtocolError))

--- a/libp2p/stream/bufferstream.nim
+++ b/libp2p/stream/bufferstream.nim
@@ -79,7 +79,7 @@ method pushData*(s: BufferStream, data: seq[byte]) {.base, async.} =
     &"Only one concurrent push allowed for stream {s.shortLog()}")
 
   if s.isClosed or s.pushedEof:
-    raise newLPStreamEOFError()
+    raise newLPStreamClosedError()
 
   if data.len == 0:
     return # Don't push 0-length buffers, these signal EOF

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -60,6 +60,13 @@ type
     par*: ref CatchableError
   LPStreamEOFError* = object of LPStreamError
 
+#        X        |           Read            |         Write
+#   Local close   |           Works           |  LPStreamClosedError
+#   Remote close  | LPStreamRemoteClosedError |         Works
+#   Local reset   |    LPStreamClosedError    |  LPStreamClosedError
+#   Remote reset  |    LPStreamResetError     |  LPStreamResetError
+# Connection down |     LPStreamConnDown      | LPStreamConnDownError
+
   LPStreamResetError* = object of LPStreamEOFError
   LPStreamClosedError* = object of LPStreamEOFError
   LPStreamRemoteClosedError* = object of LPStreamEOFError

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -59,7 +59,11 @@ type
   LPStreamWriteError* = object of LPStreamError
     par*: ref CatchableError
   LPStreamEOFError* = object of LPStreamError
-  LPStreamClosedError* = object of LPStreamError
+
+  LPStreamResetError* = object of LPStreamEOFError
+  LPStreamClosedError* = object of LPStreamEOFError
+  LPStreamRemoteClosedError* = object of LPStreamEOFError
+  LPStreamConnDownError* = object of LPStreamEOFError
 
   InvalidVarintError* = object of LPStreamError
   MaxSizeError* = object of LPStreamError
@@ -119,8 +123,21 @@ proc newLPStreamIncorrectDefect*(m: string): ref LPStreamIncorrectDefect =
 proc newLPStreamEOFError*(): ref LPStreamEOFError =
   result = newException(LPStreamEOFError, "Stream EOF!")
 
+proc newLPStreamResetError*(): ref LPStreamResetError =
+  result = newException(LPStreamResetError, "Stream Reset!")
+
 proc newLPStreamClosedError*(): ref LPStreamClosedError =
   result = newException(LPStreamClosedError, "Stream Closed!")
+
+proc newLPStreamRemoteClosedError*(): ref LPStreamRemoteClosedError =
+  result = newException(LPStreamRemoteClosedError, "Stream Remotely Closed!")
+
+proc newLPStreamConnDownError*(
+    parentException: ref Exception = nil): ref LPStreamConnDownError =
+  result = newException(
+    LPStreamConnDownError,
+    "Stream Underlying Connection Closed!",
+    parentException)
 
 func shortLog*(s: LPStream): auto =
   if s.isNil: "LPStream(nil)"

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -230,12 +230,7 @@ proc readLine*(s: LPStream,
 
   while true:
     var ch: char
-    if (await readOnce(s, addr ch, 1)) == 0:
-      # Re-readOnce to raise a more specific error than EOF
-      # Raise EOF if it doesn't raise anything(shouldn't happen)
-      discard await readOnce(s, addr ch, 1)
-      warn "Read twice while at EOF"
-      raise newLPStreamEOFError()
+    await readExactly(s, addr ch, 1)
 
     if sep[state] == ch:
       inc(state)
@@ -258,12 +253,7 @@ proc readVarint*(conn: LPStream): Future[uint64] {.async, gcsafe, public.} =
     buffer: array[10, byte]
 
   for i in 0..<len(buffer):
-    if (await conn.readOnce(addr buffer[i], 1)) == 0:
-      # Re-readOnce to raise a more specific error than EOF
-      # Raise EOF if it doesn't raise anything(shouldn't happen)
-      discard await conn.readOnce(addr buffer[i], 1)
-      warn "Read twice while at EOF"
-      raise newLPStreamEOFError()
+    await conn.readExactly(addr buffer[i], 1)
 
     var
       varint: uint64

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -225,6 +225,10 @@ proc readLine*(s: LPStream,
   while true:
     var ch: char
     if (await readOnce(s, addr ch, 1)) == 0:
+      # Re-readOnce to raise a more specific error than EOF
+      # Raise EOF if it doesn't raise anything(shouldn't happen)
+      discard await readOnce(s, addr ch, 1)
+      warn "Read twice while at EOF"
       raise newLPStreamEOFError()
 
     if sep[state] == ch:
@@ -249,6 +253,10 @@ proc readVarint*(conn: LPStream): Future[uint64] {.async, gcsafe, public.} =
 
   for i in 0..<len(buffer):
     if (await conn.readOnce(addr buffer[i], 1)) == 0:
+      # Re-readOnce to raise a more specific error than EOF
+      # Raise EOF if it doesn't raise anything(shouldn't happen)
+      discard await conn.readOnce(addr buffer[i], 1)
+      warn "Read twice while at EOF"
       raise newLPStreamEOFError()
 
     var

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -119,7 +119,7 @@ suite "Mplex":
       # should still allow reading until buffer EOF
       await chann.readExactly(addr data[3], 3)
 
-      expect LPStreamEOFError:
+      expect LPStreamRemoteClosedError:
         # this should fail now
         await chann.readExactly(addr data[0], 3)
 
@@ -143,7 +143,7 @@ suite "Mplex":
       let readFut = chann.readExactly(addr data[3], 3)
       await allFutures(closeFut, readFut)
 
-      expect LPStreamEOFError:
+      expect LPStreamRemoteClosedError:
         await chann.readExactly(addr data[0], 6) # this should fail now
 
       await chann.close()
@@ -174,7 +174,7 @@ suite "Mplex":
       var buf: array[1, byte]
       check: (await chann.readOnce(addr buf[0], 1)) == 0 # EOF marker read
 
-      expect LPStreamEOFError:
+      expect LPStreamClosedError:
         await chann.pushData(@[byte(1)])
 
       await chann.close()
@@ -190,7 +190,7 @@ suite "Mplex":
 
       await chann.reset()
       var data = newSeq[byte](1)
-      expect LPStreamEOFError:
+      expect LPStreamClosedError:
         await chann.readExactly(addr data[0], 1)
 
       await conn.close()
@@ -205,7 +205,7 @@ suite "Mplex":
       let fut = chann.readExactly(addr data[0], 1)
 
       await chann.reset()
-      expect LPStreamEOFError:
+      expect LPStreamClosedError:
         await fut
 
       await conn.close()

--- a/tests/testyamux.nim
+++ b/tests/testyamux.nim
@@ -152,3 +152,36 @@ suite "Yamux":
         expect(LPStreamEOFError): await wrFut[i]
       writerBlocker.complete()
       await streamA.close()
+
+  suite "Exception testing":
+    asyncTest "Local & Remote close":
+      mSetup()
+
+      yamuxb.streamHandler = proc(conn: Connection) {.async.} =
+        check (await conn.readLp(100)) == fromHex("1234")
+        await conn.close()
+        expect LPStreamClosedError: await conn.writeLp(fromHex("102030"))
+        check (await conn.readLp(100)) == fromHex("5678")
+
+      let streamA = await yamuxa.newStream()
+      await streamA.writeLp(fromHex("1234"))
+      expect LPStreamRemoteClosedError: discard await streamA.readLp(100)
+      await streamA.writeLp(fromHex("5678"))
+      await streamA.close()
+
+    asyncTest "Local & Remote reset":
+      mSetup()
+      let blocker = newFuture[void]()
+
+      yamuxb.streamHandler = proc(conn: Connection) {.async.} =
+        await blocker
+        expect LPStreamResetError: discard await conn.readLp(100)
+        expect LPStreamResetError: await conn.writeLp(fromHex("1234"))
+        await conn.close()
+
+      let streamA = await yamuxa.newStream()
+      await yamuxA.close()
+      expect LPStreamClosedError: await streamA.writeLp(fromHex("1234"))
+      expect LPStreamClosedError: discard await streamA.readLp(100)
+      blocker.complete()
+      await streamA.close()

--- a/tests/testyamux.nim
+++ b/tests/testyamux.nim
@@ -180,7 +180,7 @@ suite "Yamux":
         await conn.close()
 
       let streamA = await yamuxa.newStream()
-      await yamuxA.close()
+      await yamuxa.close()
       expect LPStreamClosedError: await streamA.writeLp(fromHex("1234"))
       expect LPStreamClosedError: discard await streamA.readLp(100)
       blocker.complete()


### PR DESCRIPTION
Solve #755, it should raise these new errors instead of only LPStreamEOFError

```
X     | Remote reset       | Local reset         | Remote close              | Local close         | Connection down    
Read  | LPStreamResetError | LPStreamClosedError | LPStreamRemoteClosedError | Works               | LPStreamConnDownError
Write | LPStreamResetError | LPStreamClosedError | Works                     | LPStreamClosedError | LPStreamConnDownError
```