### PR TITLE
add `lodestar` to known lib p2p agents documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ nim c -d:libp2p_expensive_metrics some_file.nim
 **use identify metrics**
 
 ```bash
-nim c -d:libp2p_agents_metrics -d:KnownLibP2PAgents=nimbus,lighthouse,prysm,teku some_file.nim
+nim c -d:libp2p_agents_metrics -d:KnownLibP2PAgents=nimbus,lighthouse,lodestar,prysm,teku some_file.nim
 ```
 
 **specify gossipsub specific topics to measure**


### PR DESCRIPTION
Lodestar is switching from `js-libp2p/0.36.2` to `lodestar/version`. Document how to collect metrics on Lodestar peers following that scheme. https://github.com/status-im/nimbus-eth2/issues/4106