### PR TITLE
Allow public address mapping

### DIFF
--- a/examples/circuitrelay.nim
+++ b/examples/circuitrelay.nim
@@ -40,19 +40,19 @@ proc main() {.async.} =
     swSrc = createCircuitRelaySwitch(clSrc)
     swDst = createCircuitRelaySwitch(clDst)
 
-    # Create a relay address to swDst using swRel as the relay
-    addrs = MultiAddress.init($swRel.peerInfo.addrs[0] & "/p2p/" &
-                              $swRel.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                              $swDst.peerInfo.peerId).get()
-
   swDst.mount(proto)
 
   await swRel.start()
   await swSrc.start()
   await swDst.start()
 
-  # Connect both Src and Dst to the relay, but not to each other.
-  await swSrc.connect(swRel.peerInfo.peerId, swRel.peerInfo.addrs)
+  let
+    # Create a relay address to swDst using swRel as the relay
+    addrs = MultiAddress.init($swRel.peerInfo.addrs[0] & "/p2p/" &
+                              $swRel.peerInfo.peerId & "/p2p-circuit/p2p/" &
+                              $swDst.peerInfo.peerId).get()
+
+  # Connect Dst to the relay
   await swDst.connect(swRel.peerInfo.peerId, swRel.peerInfo.addrs)
 
   # Dst reserve a slot on the relay.

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -530,7 +530,7 @@ proc protoArgument*(ma: MultiAddress,
           err("multiaddress: Decoding protocol error")
         else:
           ok(res)
-      elif proto.kind in {Length, Path}:
+      elif proto.kind in {MAKind.Length, Path}:
         if vb.data.readSeq(buffer) == -1:
           err("multiaddress: Decoding protocol error")
         else:
@@ -575,7 +575,7 @@ proc getPart(ma: MultiAddress, index: int): MaResult[MultiAddress] =
         res.data.writeVarint(header)
         res.data.writeArray(data)
         res.data.finish()
-    elif proto.kind in {Length, Path}:
+    elif proto.kind in {MAKind.Length, Path}:
       if vb.data.readSeq(data) == -1:
         return err("multiaddress: Decoding protocol error")
 
@@ -637,7 +637,7 @@ iterator items*(ma: MultiAddress): MaResult[MultiAddress] =
 
       res.data.writeVarint(header)
       res.data.writeArray(data)
-    elif proto.kind in {Length, Path}:
+    elif proto.kind in {MAKind.Length, Path}:
       if vb.data.readSeq(data) == -1:
         yield err(MaResult[MultiAddress], "Decoding protocol error")
 

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -299,11 +299,11 @@ proc start*(s: Switch) {.async, gcsafe, public.} =
   trace "starting switch for peer", peerInfo = s.peerInfo
   var startFuts: seq[Future[void]]
   for t in s.transports:
-    let addrs = s.peerInfo.addrs.filterIt(
+    let addrs = s.peerInfo.listenAddrs.filterIt(
       t.handles(it)
     )
 
-    s.peerInfo.addrs.keepItIf(
+    s.peerInfo.listenAddrs.keepItIf(
       it notin addrs
     )
 
@@ -322,9 +322,9 @@ proc start*(s: Switch) {.async, gcsafe, public.} =
   for t in s.transports: # for each transport
     if t.addrs.len > 0 or t.running:
       s.acceptFuts.add(s.accept(t))
-      s.peerInfo.addrs &= t.addrs
+      s.peerInfo.listenAddrs &= t.addrs
 
-  s.peerInfo.update()
+  await s.peerInfo.update()
 
   await s.ms.start()
 

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -60,8 +60,7 @@ method init(p: TestProto) {.gcsafe.} =
 proc createSwitch(ma: MultiAddress; outgoing: bool, secio: bool = false): (Switch, PeerInfo) =
   var
     privateKey = PrivateKey.random(ECDSA, rng[]).get()
-    peerInfo = PeerInfo.new(privateKey)
-  peerInfo.addrs.add(ma)
+    peerInfo = PeerInfo.new(privateKey, @[ma])
 
   proc createMplex(conn: Connection): Muxer =
     result = Mplex.new(conn)

--- a/tests/testpeerinfo.nim
+++ b/tests/testpeerinfo.nim
@@ -18,22 +18,24 @@ suite "PeerInfo":
 
     check peerId == peerInfo.peerId
     check seckey.getPublicKey().get() == peerInfo.publicKey
-  
+
   test "Signed peer record":
     const
       ExpectedDomain = $multiCodec("libp2p-peer-record")
       ExpectedPayloadType = @[(byte) 0x03, (byte) 0x01]
-    
+
     let
       seckey = PrivateKey.random(rng[]).tryGet()
       peerId = PeerId.init(seckey).get()
       multiAddresses = @[MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet(), MultiAddress.init("/ip4/0.0.0.0/tcp/25").tryGet()]
       peerInfo = PeerInfo.new(seckey, multiAddresses)
-    
+
+    waitFor(peerInfo.update())
+
     let
       env = peerInfo.signedPeerRecord.envelope
       rec = PeerRecord.decode(env.payload()).tryGet()
-    
+
     # Check envelope fields
     check:
       env.publicKey == peerInfo.publicKey
@@ -47,3 +49,17 @@ suite "PeerInfo":
       rec.addresses.len == 2
       rec.addresses[0].address == multiAddresses[0]
       rec.addresses[1].address == multiAddresses[1]
+
+  test "Public address mapping":
+    let
+      seckey = PrivateKey.random(ECDSA, rng[]).get()
+      multiAddresses = @[MultiAddress.init("/ip4/0.0.0.0/tcp/24").tryGet(), MultiAddress.init("/ip4/0.0.0.0/tcp/25").tryGet()]
+      multiAddresses2 = @[MultiAddress.init("/ip4/8.8.8.8/tcp/33").tryGet()]
+
+    proc addressMapper(input: seq[MultiAddress]): Future[seq[MultiAddress]] {.async.} =
+      check input == multiAddresses
+      await sleepAsync(0.seconds)
+      return multiAddresses2
+    var peerInfo = PeerInfo.new(seckey, multiAddresses, addressMappers = @[addressMapper])
+    waitFor peerInfo.update()
+    check peerInfo.addrs == multiAddresses2

--- a/tests/testrelayv2.nim
+++ b/tests/testrelayv2.nim
@@ -118,7 +118,6 @@ suite "Circuit Relay V2":
     asyncTeardown:
       checkTrackers()
     var
-      addrs {.threadvar.}: MultiAddress
       customProtoCodec {.threadvar.}: string
       proto {.threadvar.}: LPProtocol
       ttl {.threadvar.}: int
@@ -145,9 +144,6 @@ suite "Circuit Relay V2":
       src = createSwitch(srcCl)
       dst = createSwitch(dstCl)
       rel = newStandardSwitch()
-      addrs = MultiAddress.init($rel.peerInfo.addrs[0] & "/p2p/" &
-                                $rel.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                                $dst.peerInfo.peerId).get()
 
     asyncTest "Connection succeed":
       proto.handler = proc(conn: Connection, proto: string) {.async.} =
@@ -166,6 +162,10 @@ suite "Circuit Relay V2":
       await rel.start()
       await src.start()
       await dst.start()
+
+      let addrs = MultiAddress.init($rel.peerInfo.addrs[0] & "/p2p/" &
+                                $rel.peerInfo.peerId & "/p2p-circuit/p2p/" &
+                                $dst.peerInfo.peerId).get()
 
       await src.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
       await dst.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
@@ -199,6 +199,10 @@ suite "Circuit Relay V2":
       await rel.start()
       await src.start()
       await dst.start()
+
+      let addrs = MultiAddress.init($rel.peerInfo.addrs[0] & "/p2p/" &
+                                $rel.peerInfo.peerId & "/p2p-circuit/p2p/" &
+                                $dst.peerInfo.peerId).get()
 
       await src.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
       await dst.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
@@ -245,6 +249,10 @@ take to the ship.""")
       await src.start()
       await dst.start()
 
+      let addrs = MultiAddress.init($rel.peerInfo.addrs[0] & "/p2p/" &
+                                $rel.peerInfo.peerId & "/p2p-circuit/p2p/" &
+                                $dst.peerInfo.peerId).get()
+
       await src.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
       await dst.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
 
@@ -277,6 +285,10 @@ take to the ship.""")
       await src.start()
       await dst.start()
 
+      let addrs = MultiAddress.init($rel.peerInfo.addrs[0] & "/p2p/" &
+                                $rel.peerInfo.peerId & "/p2p-circuit/p2p/" &
+                                $dst.peerInfo.peerId).get()
+
       await src.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
       await dst.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
 
@@ -308,11 +320,6 @@ take to the ship.""")
         rel2Cl = RelayClient.new(canHop = true)
         rel2 = createSwitch(rel2Cl)
         rv2 = Relay.new()
-        addrs = @[ MultiAddress.init($rel.peerInfo.addrs[0] & "/p2p/" &
-                                     $rel.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                                     $rel2.peerInfo.peerId & "/p2p/" &
-                                     $rel2.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                                     $dst.peerInfo.peerId).get() ]
       rv2.setup(rel)
       rel.mount(rv2)
       dst.mount(proto)
@@ -320,6 +327,13 @@ take to the ship.""")
       await rel2.start()
       await src.start()
       await dst.start()
+
+      let
+        addrs = @[ MultiAddress.init($rel.peerInfo.addrs[0] & "/p2p/" &
+                                     $rel.peerInfo.peerId & "/p2p-circuit/p2p/" &
+                                     $rel2.peerInfo.peerId & "/p2p/" &
+                                     $rel2.peerInfo.peerId & "/p2p-circuit/p2p/" &
+                                     $dst.peerInfo.peerId).get() ]
 
       await src.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
       await rel2.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
@@ -367,6 +381,16 @@ take to the ship.""")
         switchA = createSwitch(clientA)
         switchB = createSwitch(clientB)
         switchC = createSwitch(clientC)
+
+      switchA.mount(protoBCA)
+      switchB.mount(protoCAB)
+      switchC.mount(protoABC)
+
+      await switchA.start()
+      await switchB.start()
+      await switchC.start()
+
+      let
         addrsABC = MultiAddress.init($switchB.peerInfo.addrs[0] & "/p2p/" &
                                      $switchB.peerInfo.peerId & "/p2p-circuit/p2p/" &
                                      $switchC.peerInfo.peerId).get()
@@ -376,13 +400,6 @@ take to the ship.""")
         addrsCAB = MultiAddress.init($switchA.peerInfo.addrs[0] & "/p2p/" &
                                      $switchA.peerInfo.peerId & "/p2p-circuit/p2p/" &
                                      $switchB.peerInfo.peerId).get()
-      switchA.mount(protoBCA)
-      switchB.mount(protoCAB)
-      switchC.mount(protoABC)
-
-      await switchA.start()
-      await switchB.start()
-      await switchC.start()
 
       await switchA.connect(switchB.peerInfo.peerId, switchB.peerInfo.addrs)
       await switchB.connect(switchC.peerInfo.peerId, switchC.peerInfo.addrs)


### PR DESCRIPTION
closes #450, #429, #556

`switch.peerInfo.addrs` is now read-only
To modify addresses, you should use a mapper instead

It may break stuff, because `switch.peerInfo.addrs` is empty before `switch.start()` (previously it was not empty, but potentially invalid, which seems worst)