### PR TITLE
Add codex & waku to autobump

### DIFF
--- a/.github/workflows/bumper.yml
+++ b/.github/workflows/bumper.yml
@@ -7,14 +7,21 @@ on:
   workflow_dispatch:
 
 jobs:
-  bumpNimbus:
+  bumpProjects:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [
+          { repo: status-im/nimbus-eth2, branch: unstable },
+          { repo: status-im/nwaku, branch: master },
+          { repo: status-im/nim-codex, branch: main }
+        ]
     steps:
-      - name: Clone NBC
+      - name: Clone repo
         uses: actions/checkout@v2
         with:
-          repository: status-im/nimbus-eth2
-          ref: unstable
+          repository: ${{ matrix.target.repo }}
+          ref: ${{ matrix.target.branch }}
           path: nbc
           submodules: true
           fetch-depth: 0


### PR DESCRIPTION
Similar to nimbus: https://github.com/status-im/nimbus-eth2/pull/3916
Will run CI on waku & codex for each unstable push on libp2p

Also opens the possibility to run a few nodes of each project with libp2p's unstable at all times, which is very useful