### PR TITLE
Remove shallow copies

### DIFF
--- a/libp2p/crypto/minasn1.nim
+++ b/libp2p/crypto/minasn1.nim
@@ -528,8 +528,7 @@ proc read*(ab: var Asn1Buffer): Asn1Result[Asn1Field] =
 
         field = Asn1Field(kind: Asn1Tag.Boolean, klass: aclass,
                           index: ttag, offset: int(ab.offset),
-                          length: 1)
-        shallowCopy(field.buffer, ab.buffer)
+                          length: 1, buffer: ab.buffer)
         field.vbool = (b == 0xFF'u8)
         ab.offset += 1
         return ok(field)
@@ -554,8 +553,7 @@ proc read*(ab: var Asn1Buffer): Asn1Result[Asn1Field] =
           # Negative or Positive integer
           field = Asn1Field(kind: Asn1Tag.Integer, klass: aclass,
                             index: ttag, offset: int(ab.offset),
-                            length: int(length))
-          shallowCopy(field.buffer, ab.buffer)
+                            length: int(length), buffer: ab.buffer)
           if (ab.buffer[ab.offset] and 0x80'u8) == 0x80'u8:
             # Negative integer
             if length <= 8:
@@ -579,16 +577,15 @@ proc read*(ab: var Asn1Buffer): Asn1Result[Asn1Field] =
             # Zero value integer
             field = Asn1Field(kind: Asn1Tag.Integer, klass: aclass,
                               index: ttag, offset: int(ab.offset),
-                              length: int(length), vint: 0'u64)
-            shallowCopy(field.buffer, ab.buffer)
+                              length: int(length), vint: 0'u64,
+                              buffer: ab.buffer)
             ab.offset += int(length)
             return ok(field)
           else:
             # Positive integer with leading zero
             field = Asn1Field(kind: Asn1Tag.Integer, klass: aclass,
                               index: ttag, offset: int(ab.offset) + 1,
-                              length: int(length) - 1)
-            shallowCopy(field.buffer, ab.buffer)
+                              length: int(length) - 1, buffer: ab.buffer)
             if length <= 9:
               for i in 1 ..< int(length):
                 field.vint = (field.vint shl 8) or
@@ -610,8 +607,7 @@ proc read*(ab: var Asn1Buffer): Asn1Result[Asn1Field] =
             # Zero-length BIT STRING.
             field = Asn1Field(kind: Asn1Tag.BitString, klass: aclass,
                               index: ttag, offset: int(ab.offset + 1),
-                              length: 0, ubits: 0)
-            shallowCopy(field.buffer, ab.buffer)
+                              length: 0, ubits: 0, buffer: ab.buffer)
             ab.offset += int(length)
             return ok(field)
 
@@ -631,8 +627,8 @@ proc read*(ab: var Asn1Buffer): Asn1Result[Asn1Field] =
 
           field = Asn1Field(kind: Asn1Tag.BitString, klass: aclass,
                             index: ttag, offset: int(ab.offset + 1),
-                            length: int(length - 1), ubits: int(unused))
-          shallowCopy(field.buffer, ab.buffer)
+                            length: int(length - 1), ubits: int(unused),
+                            buffer: ab.buffer)
           ab.offset += int(length)
           return ok(field)
 
@@ -643,8 +639,7 @@ proc read*(ab: var Asn1Buffer): Asn1Result[Asn1Field] =
 
         field = Asn1Field(kind: Asn1Tag.OctetString, klass: aclass,
                           index: ttag, offset: int(ab.offset),
-                          length: int(length))
-        shallowCopy(field.buffer, ab.buffer)
+                          length: int(length), buffer: ab.buffer)
         ab.offset += int(length)
         return ok(field)
 
@@ -654,8 +649,7 @@ proc read*(ab: var Asn1Buffer): Asn1Result[Asn1Field] =
           return err(Asn1Error.Incorrect)
 
         field = Asn1Field(kind: Asn1Tag.Null, klass: aclass, index: ttag,
-                          offset: int(ab.offset), length: 0)
-        shallowCopy(field.buffer, ab.buffer)
+                          offset: int(ab.offset), length: 0, buffer: ab.buffer)
         ab.offset += int(length)
         return ok(field)
 
@@ -666,8 +660,7 @@ proc read*(ab: var Asn1Buffer): Asn1Result[Asn1Field] =
 
         field = Asn1Field(kind: Asn1Tag.Oid, klass: aclass,
                           index: ttag, offset: int(ab.offset),
-                          length: int(length))
-        shallowCopy(field.buffer, ab.buffer)
+                          length: int(length), buffer: ab.buffer)
         ab.offset += int(length)
         return ok(field)
 
@@ -678,8 +671,7 @@ proc read*(ab: var Asn1Buffer): Asn1Result[Asn1Field] =
 
         field = Asn1Field(kind: Asn1Tag.Sequence, klass: aclass,
                           index: ttag, offset: int(ab.offset),
-                          length: int(length))
-        shallowCopy(field.buffer, ab.buffer)
+                          length: int(length), buffer: ab.buffer)
         ab.offset += int(length)
         return ok(field)
 

--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -516,15 +516,10 @@ proc trimRight(s: string, ch: char): string =
       break
   result = s[0..(s.high - m)]
 
-proc shcopy*(m1: var MultiAddress, m2: MultiAddress) =
-  shallowCopy(m1.data.buffer, m2.data.buffer)
-  m1.data.offset = m2.data.offset
-
 proc protoCode*(ma: MultiAddress): MaResult[MultiCodec] =
   ## Returns MultiAddress ``ma`` protocol code.
   var header: uint64
-  var vb: MultiAddress
-  shcopy(vb, ma)
+  var vb = ma
   if vb.data.readVarint(header) == -1:
     err("multiaddress: Malformed binary address!")
   else:
@@ -537,8 +532,7 @@ proc protoCode*(ma: MultiAddress): MaResult[MultiCodec] =
 proc protoName*(ma: MultiAddress): MaResult[string] =
   ## Returns MultiAddress ``ma`` protocol name.
   var header: uint64
-  var vb: MultiAddress
-  shcopy(vb, ma)
+  var vb = ma
   if vb.data.readVarint(header) == -1:
     err("multiaddress: Malformed binary address!")
   else:
@@ -555,9 +549,8 @@ proc protoArgument*(ma: MultiAddress,
   ## If current MultiAddress do not have argument value, then result will be
   ## ``0``.
   var header: uint64
-  var vb: MultiAddress
+  var vb = ma
   var buffer: seq[byte]
-  shcopy(vb, ma)
   if vb.data.readVarint(header) == -1:
     err("multiaddress: Malformed binary address!")
   else:
@@ -792,8 +785,7 @@ proc encode*(mbtype: typedesc[MultiBase], encoding: string,
 proc validate*(ma: MultiAddress): bool =
   ## Returns ``true`` if MultiAddress ``ma`` is valid.
   var header: uint64
-  var vb: MultiAddress
-  shcopy(vb, ma)
+  var vb = ma
   while true:
     if vb.data.isEmpty():
       break

--- a/libp2p/peerid.nim
+++ b/libp2p/peerid.nim
@@ -148,7 +148,7 @@ func init*(pid: var PeerId, data: string): bool =
   if Base58.decode(data, p, length) == Base58Status.Success:
     p.setLen(length)
     var opid: PeerId
-    shallowCopy(opid.data, p)
+    opid.data = p
     if opid.validate():
       pid = opid
       result = true

--- a/libp2p/protobuf/minprotobuf.nim
+++ b/libp2p/protobuf/minprotobuf.nim
@@ -124,7 +124,7 @@ proc vsizeof*(field: ProtoField): int {.inline.} =
 proc initProtoBuffer*(data: seq[byte], offset = 0,
                       options: set[ProtoFlags] = {}): ProtoBuffer =
   ## Initialize ProtoBuffer with shallow copy of ``data``.
-  shallowCopy(result.buffer, data)
+  result.buffer = data
   result.offset = offset
   result.options = options
 

--- a/libp2p/vbuffer.nim
+++ b/libp2p/vbuffer.nim
@@ -39,21 +39,9 @@ proc len*(vb: VBuffer): int =
   result = len(vb.buffer) - vb.offset
   doAssert(result >= 0)
 
-proc isLiteral[T](s: seq[T]): bool {.inline.} =
-  when defined(gcOrc) or defined(gcArc):
-    false
-  else:
-    type
-      SeqHeader = object
-        length, reserved: int
-    (cast[ptr SeqHeader](s).reserved and (1 shl (sizeof(int) * 8 - 2))) != 0
-
 proc initVBuffer*(data: seq[byte], offset = 0): VBuffer =
   ## Initialize VBuffer with shallow copy of ``data``.
-  if isLiteral(data):
-    result.buffer = data
-  else:
-    shallowCopy(result.buffer, data)
+  result.buffer = data
   result.offset = offset
 
 proc initVBuffer*(data: openArray[byte], offset = 0): VBuffer =


### PR DESCRIPTION
Beside not being compatible with orc, they can introduce weird / unsafe behaviors.

They seemed to be used only in places with a few bytes (worst case being private keys around 256 bytes), so I doubt we'll see any performance regression, but I have a branch with `when defined(shallowCopy)` everywhere ready if that's the case