### PR TITLE
Add libp2p label to chronicles log topics

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -19,6 +19,9 @@ import ".."/[pubsubpeer, peertable, timedcache, mcache, floodsub, pubsub]
 import "../rpc"/[messages]
 import "../../.."/[peerid, multiaddress, utility, switch, routing_record, signed_envelope, utils/heartbeat]
 
+logScope:
+  topics = "libp2p gossipsub"
+
 declareGauge(libp2p_gossipsub_cache_window_size, "the number of messages in the cache")
 declareGauge(libp2p_gossipsub_peers_per_topic_mesh, "gossipsub peers per topic in mesh", labels = ["topic"])
 declareGauge(libp2p_gossipsub_peers_per_topic_fanout, "gossipsub peers per topic in fanout", labels = ["topic"])

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -18,6 +18,9 @@ import "."/[types]
 import ".."/[pubsubpeer]
 import "../../.."/[peerid, multiaddress, utility, switch, utils/heartbeat]
 
+logScope:
+  topics = "libp2p gossipsub"
+
 declareGauge(libp2p_gossipsub_peers_scores, "the scores of the peers in gossipsub", labels = ["agent"])
 declareCounter(libp2p_gossipsub_bad_score_disconnection, "the number of peers disconnected by gossipsub", labels = ["agent"])
 declareGauge(libp2p_gossipsub_peers_score_firstMessageDeliveries, "Detailed gossipsub scoring metric", labels = ["agent"])

--- a/libp2p/protocols/pubsub/rpc/protobuf.nim
+++ b/libp2p/protocols/pubsub/rpc/protobuf.nim
@@ -22,7 +22,7 @@ import messages,
 
 
 logScope:
-  topics = "pubsubprotobuf"
+  topics = "libp2p pubsubprotobuf"
 
 when defined(libp2p_protobuf_metrics):
   import metrics


### PR DESCRIPTION
Added `libp2p` topic to the chronicles topics list. For consistency and because this is necessary to filter out all the logs with `-d:"chronicles_disabled_topics=libp2p"`.