### PR TITLE
Daily CI: run devel with refc

### DIFF
--- a/.github/workflows/multi_nim.yml
+++ b/.github/workflows/multi_nim.yml
@@ -42,12 +42,11 @@ jobs:
 
     name: '${{ matrix.target.os }}-${{ matrix.target.cpu }} (Nim ${{ matrix.branch }})'
     runs-on: ${{ matrix.builder }}
-    continue-on-error: ${{ matrix.branch == 'version-1-6' || matrix.branch == 'devel' }}
+    continue-on-error: ${{ matrix.branch == 'devel' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: unstable
           submodules: true
 
       - name: Install build dependencies (Linux i386)
@@ -163,9 +162,8 @@ jobs:
           nim --version
           nimble --version
           nimble install -y --depsOnly
-          nimble test
-          if [[ "${{ matrix.branch }}" == "version-1-6" || "${{ matrix.branch }}" == "devel" ]]; then
+          NIMFLAGS="${NIMFLAGS} --gc:refc" nimble test
+          if [[ "${{ matrix.branch }}" == "devel" ]]; then
             echo -e "\nTesting with '--gc:orc':\n"
-            export NIMFLAGS="${NIMFLAGS} --gc:orc"
-            nimble test
+            NIMFLAGS="${NIMFLAGS} --gc:orc" nimble test
           fi


### PR DESCRIPTION
Since `orc` became the default, we were not running CI with refc on devel