### PR TITLE
Fix PubSub subscribe on connection race condition

### DIFF
--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -121,8 +121,6 @@ proc handle*(p: PubSubPeer, conn: Connection) {.async.} =
     conn, peer = p, closed = conn.closed
   try:
     try:
-      # wait for bidirectional connection
-      await p.connectedFut
       while not conn.atEof:
         trace "waiting for data", conn, peer = p, closed = conn.closed
 
@@ -168,6 +166,8 @@ proc handle*(p: PubSubPeer, conn: Connection) {.async.} =
 
 proc connectOnce(p: PubSubPeer): Future[void] {.async.} =
   try:
+    if p.connectedFut.finished:
+      p.connectedFut = newFuture[void]()
     let newConn = await p.getConn()
     if newConn.isNil:
       raise (ref LPError)(msg: "Cannot establish send connection")
@@ -186,8 +186,6 @@ proc connectOnce(p: PubSubPeer): Future[void] {.async.} =
 
     await handle(p, newConn)
   finally:
-    if not p.connectedFut.finished():
-      p.connectedFut.fail(newException(LPError, "can't establish conn"))
     if p.sendConn != nil:
       trace "Removing send connection", p, conn = p.sendConn
       await p.sendConn.close()
@@ -214,27 +212,10 @@ proc connectImpl(p: PubSubPeer) {.async.} =
     debug "Could not establish send connection", msg = exc.msg
 
 proc connect*(p: PubSubPeer) =
+  if p.connected:
+    return
+
   asyncSpawn connectImpl(p)
-
-proc sendImpl(conn: Connection, encoded: seq[byte]): Future[void] {.raises: [Defect].} =
-  trace "sending encoded msgs to peer", conn, encoded = shortLog(encoded)
-
-  let fut = conn.writeLp(encoded) # Avoid copying `encoded` into future
-  proc sendWaiter(): Future[void] {.async.} =
-    try:
-      await fut
-      trace "sent pubsub message to remote", conn
-
-    except CatchableError as exc: # never cancelled
-      # Because we detach the send call from the currently executing task using
-      # asyncSpawn, no exceptions may leak out of it
-      trace "Unable to send to remote", conn, msg = exc.msg
-      # Next time sendConn is used, it will be have its close flag set and thus
-      # will be recycled
-
-      await conn.close() # This will clean up the send connection
-
-  return sendWaiter()
 
 template sendMetrics(msg: RPCMsg): untyped =
   when defined(libp2p_expensive_metrics):
@@ -243,7 +224,7 @@ template sendMetrics(msg: RPCMsg): untyped =
         # metrics
         libp2p_pubsub_sent_messages.inc(labelValues = [$p.peerId, t])
 
-proc sendEncoded*(p: PubSubPeer, msg: seq[byte]) {.raises: [Defect].} =
+proc sendEncoded*(p: PubSubPeer, msg: seq[byte]) {.raises: [Defect], async.} =
   doAssert(not isNil(p), "pubsubpeer nil!")
 
   if msg.len <= 0:
@@ -254,14 +235,27 @@ proc sendEncoded*(p: PubSubPeer, msg: seq[byte]) {.raises: [Defect].} =
     info "trying to send a too big for pubsub", maxSize=p.maxMessageSize, msgSize=msg.len
     return
 
-  let conn = p.sendConn
+  if p.sendConn == nil:
+    discard await p.connectedFut.withTimeout(1.seconds)
+
+  var conn = p.sendConn
   if conn == nil or conn.closed():
-    trace "No send connection, skipping message", p, msg = shortLog(msg)
+    debug "No send connection, skipping message", p, msg = shortLog(msg)
     return
 
-  # To limit the size of the closure, we only pass the encoded message and
-  # connection to the spawned send task
-  asyncSpawn sendImpl(conn, msg)
+  trace "sending encoded msgs to peer", conn, encoded = shortLog(encoded)
+
+  try:
+    await conn.writeLp(msg)
+    trace "sent pubsub message to remote", conn
+  except CatchableError as exc: # never cancelled
+    # Because we detach the send call from the currently executing task using
+    # asyncSpawn, no exceptions may leak out of it
+    trace "Unable to send to remote", conn, msg = exc.msg
+    # Next time sendConn is used, it will be have its close flag set and thus
+    # will be recycled
+
+    await conn.close() # This will clean up the send connection
 
 proc send*(p: PubSubPeer, msg: RPCMsg, anonymize: bool) {.raises: [Defect].} =
   trace "sending msg to peer", peer = p, rpcMsg = shortLog(msg)
@@ -283,7 +277,7 @@ proc send*(p: PubSubPeer, msg: RPCMsg, anonymize: bool) {.raises: [Defect].} =
     sendMetrics(msg)
     encodeRpcMsg(msg, anonymize)
 
-  p.sendEncoded(encoded)
+  asyncSpawn p.sendEncoded(encoded)
 
 proc new*(
   T: typedesc[PubSubPeer],

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -243,7 +243,7 @@ proc sendEncoded*(p: PubSubPeer, msg: seq[byte]) {.raises: [Defect], async.} =
     debug "No send connection, skipping message", p, msg = shortLog(msg)
     return
 
-  trace "sending encoded msgs to peer", conn, encoded = shortLog(encoded)
+  trace "sending encoded msgs to peer", conn, encoded = shortLog(msg)
 
   try:
     await conn.writeLp(msg)


### PR DESCRIPTION
This PR fixes a subtle race condition that I discovered while working on https://github.com/status-im/nim-libp2p/pull/807. Since 807 renders the upgrade "faster" (less callback and asyncSpawn etc), it's highlights some bugs, which is cool

I think this race condition can also happen without 807.
1 - A peer connect to us, and opens the pubsub stream very fast, preloaded with the list of topic its subscribed to
2 - We see that we have a topic in common, so we GRAFT him
3 - "sendConn" stream is setup.

Most of the time, 3 happens before 2. But when 2 happens first, the GRAFT is simply swallowed by this:
https://github.com/status-im/nim-libp2p/blob/1711c204eab2596e4bd42b162d630bc262704daf/libp2p/protocols/pubsub/pubsubpeer.nim#L253
and we end up with an assymetric mesh.

This PR simply wait for both direction to be setup before handling the peer messages.
It's a simplistic fix, and doesn't handle more complex cases (ie, the send stream getting closed, but not the receive one)
The better fix would be to get rid of this silent swallow, and make sure it never happens, but that's a much bigger effort