### PR TITLE
Limit number of streams per protocol per peer

### DIFF
--- a/examples/tutorial_2_customproto.nim
+++ b/examples/tutorial_2_customproto.nim
@@ -32,7 +32,7 @@ proc new(T: typedesc[TestProto]): T =
     # We must close the connections ourselves when we're done with it
     await conn.close()
 
-  return T(codecs: @[TestCodec], handler: handle)
+  return T.new(codecs = @[TestCodec], handler = handle)
 
 ## This is a constructor for our `TestProto`, that will specify our `codecs` and a `handler`, which will be called for each incoming peer asking for this protocol.
 ## In our handle, we simply read a message from the connection and `echo` it.

--- a/examples/tutorial_5_discovery.nim
+++ b/examples/tutorial_5_discovery.nim
@@ -36,7 +36,7 @@ proc new(T: typedesc[DumbProto], nodeNumber: int): T =
   proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
     echo "Node", nodeNumber, " received: ", string.fromBytes(await conn.readLp(1024))
     await conn.close()
-  return T(codecs: @[DumbCodec], handler: handle)
+  return T.new(codecs = @[DumbCodec], handler = handle)
 
 ## ## Bootnodes
 ## The first time a p2p program is ran, he needs to know how to join

--- a/examples/tutorial_6_game.nim
+++ b/examples/tutorial_6_game.nim
@@ -157,7 +157,7 @@ proc new(T: typedesc[GameProto], g: Game): T =
     # The handler of a protocol must wait for the stream to
     # be finished before returning
     await conn.join()
-  return T(codecs: @["/tron/1.0.0"], handler: handle)
+  return T.new(codecs = @["/tron/1.0.0"], handler = handle)
 
 proc networking(g: Game) {.async.} =
   # Create our switch, similar to the GossipSub example and

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -174,8 +174,7 @@ proc handle*(m: MultistreamSelect, conn: Connection, active: bool = false) {.asy
             trace "found handler", conn, protocol = ms
 
             var protocolHolder = h
-            let maxIncomingStreams =
-                  protocolHolder.protocol.maxIncomingStreams.get(DefaultMaxIncomingStreams)
+            let maxIncomingStreams = protocolHolder.protocol.maxIncomingStreams
             if protocolHolder.openedStreams.getOrDefault(conn.peerId) >= maxIncomingStreams:
               debug "Max streams for protocol reached, blocking new stream",
                 conn, protocol = ms, maxIncomingStreams

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -178,10 +178,11 @@ proc handle*(m: MultistreamSelect, conn: Connection, active: bool = false) {.asy
                                   conn.peerId, initCountTable[LPProtocol]())
             let
               protocol = h.protocol
-              maxStreams = protocol.maxStreams.get(DefaultMaxStreams)
-            if countTable.getOrDefault(protocol) > maxStreams:
+              maxIncomingStreams =
+                protocol.maxIncomingStreams.get(DefaultMaxIncomingStreams)
+            if countTable.getOrDefault(protocol) >= maxIncomingStreams:
               debug "Max streams for protocol reached, blocking new stream",
-                conn, protocol = ms, maxStreams
+                conn, protocol = ms, maxIncomingStreams
               return
             m.openedStreams[conn.peerId].inc(protocol)
             try:

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -12,7 +12,7 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
-import std/[strutils, sequtils, tables]
+import std/[strutils, sequtils]
 import chronos, chronicles, stew/byteutils
 import stream/connection,
        protocols/protocol
@@ -41,12 +41,10 @@ type
   MultistreamSelect* = ref object of RootObj
     handlers*: seq[HandlerHolder]
     codec*: string
-    openedStreams: Table[PeerId, CountTable[LPProtocol]]
 
 proc new*(T: typedesc[MultistreamSelect]): T =
   T(
-    codec: MSCodec,
-    openedStreams: initTable[PeerId, CountTable[LPProtocol]]()
+    codec: MSCodec
   )
 
 template validateSuffix(str: string): untyped =
@@ -173,26 +171,9 @@ proc handle*(m: MultistreamSelect, conn: Connection, active: bool = false) {.asy
         for h in m.handlers:
           if (not isNil(h.match) and h.match(ms)) or h.protos.contains(ms):
             trace "found handler", conn, protocol = ms
-
-            let countTable = m.openedStreams.mgetOrPut(
-                                  conn.peerId, initCountTable[LPProtocol]())
-            let
-              protocol = h.protocol
-              maxIncomingStreams =
-                protocol.maxIncomingStreams.get(DefaultMaxIncomingStreams)
-            if countTable.getOrDefault(protocol) >= maxIncomingStreams:
-              debug "Max streams for protocol reached, blocking new stream",
-                conn, protocol = ms, maxIncomingStreams
-              return
-            m.openedStreams[conn.peerId].inc(protocol)
-            try:
-              await conn.writeLp(ms & "\n")
-              conn.protocol = ms
-              await protocol.handler(conn, ms)
-            finally:
-              m.openedStreams[conn.peerId].inc(protocol, -1)
-              if m.openedStreams[conn.peerId].len == 0:
-                m.openedStreams.del(conn.peerId)
+            await conn.writeLp(ms & "\n")
+            conn.protocol = ms
+            await h.protocol.handleIncoming(conn, ms)
             return
         debug "no handlers", conn, protocol = ms
         await conn.write(Na)

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -12,8 +12,12 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
+import std/hashes
 import chronos
 import ../stream/connection
+
+const
+  DefaultMaxStreams* = 10
 
 type
   LPProtoHandler* = proc (
@@ -26,10 +30,15 @@ type
     codecs*: seq[string]
     handler*: LPProtoHandler ## this handler gets invoked by the protocol negotiator
     started*: bool
+    maxStreams*: Opt[int]
 
 method init*(p: LPProtocol) {.base, gcsafe.} = discard
 method start*(p: LPProtocol) {.async, base.} = p.started = true
 method stop*(p: LPProtocol) {.async, base.} = p.started = false
+
+proc hash*(protocol: LPProtocol): Hash =
+  result = protocol.codecs.hash !& protocol.handler.hash
+  result = !$ result
 
 
 func codec*(p: LPProtocol): string =

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -17,7 +17,7 @@ import chronos
 import ../stream/connection
 
 const
-  DefaultMaxStreams* = 10
+  DefaultMaxIncomingStreams* = 10
 
 type
   LPProtoHandler* = proc (
@@ -30,7 +30,7 @@ type
     codecs*: seq[string]
     handler*: LPProtoHandler ## this handler gets invoked by the protocol negotiator
     started*: bool
-    maxStreams*: Opt[int]
+    maxIncomingStreams*: Opt[int]
 
 method init*(p: LPProtocol) {.base, gcsafe.} = discard
 method start*(p: LPProtocol) {.async, base.} = p.started = true

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -12,7 +12,6 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
-import std/hashes
 import chronos
 import ../stream/connection
 
@@ -35,11 +34,6 @@ type
 method init*(p: LPProtocol) {.base, gcsafe.} = discard
 method start*(p: LPProtocol) {.async, base.} = p.started = true
 method stop*(p: LPProtocol) {.async, base.} = p.started = false
-
-proc hash*(protocol: LPProtocol): Hash =
-  result = protocol.codecs.hash !& protocol.handler.hash
-  result = !$ result
-
 
 func codec*(p: LPProtocol): string =
   assert(p.codecs.len > 0, "Codecs sequence was empty!")

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -12,8 +12,10 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
-import chronos
+import chronos, stew/results
 import ../stream/connection
+
+export results
 
 const
   DefaultMaxIncomingStreams* = 10
@@ -53,8 +55,8 @@ func `codec=`*(p: LPProtocol, codec: string) =
 proc new*(
   T: type LPProtocol,
   codecs: seq[string],
-  handler: LPProtoHandler,
-  maxIncomingStreams: Opt[int] | int = default(Opt[int])): T =
+  handler: LPProtoHandler,  # default(Opt[int]) or Opt.none(int) don't work on 1.2
+  maxIncomingStreams: Opt[int] | int = Opt[int]()): T =
   T(
     codecs: codecs,
     handler: handler,

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -49,3 +49,16 @@ func `codec=`*(p: LPProtocol, codec: string) =
   # always insert as first codec
   # if we use this abstraction
   p.codecs.insert(codec, 0)
+
+proc new*(
+  T: type LPProtocol,
+  codecs: seq[string],
+  handler: LPProtoHandler,
+  maxIncomingStreams: Opt[int] | int = default(Opt[int])): T =
+  T(
+    codecs: codecs,
+    handler: handler,
+    maxIncomingStreams:
+      when maxIncomingStreams is int: Opt.some(maxIncomingStreams)
+      else: maxIncomingStreams
+  )

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -12,9 +12,12 @@ when (NimMajor, NimMinor) < (1, 4):
 else:
   {.push raises: [].}
 
-import std/hashes
-import chronos
+import std/tables
+import chronos, chronicles
 import ../stream/connection
+
+logScope:
+  topics = "libp2p protocol"
 
 const
   DefaultMaxIncomingStreams* = 10
@@ -31,15 +34,21 @@ type
     handler*: LPProtoHandler ## this handler gets invoked by the protocol negotiator
     started*: bool
     maxIncomingStreams*: Opt[int]
+    openedStreams*: CountTable[PeerId]
 
 method init*(p: LPProtocol) {.base, gcsafe.} = discard
 method start*(p: LPProtocol) {.async, base.} = p.started = true
 method stop*(p: LPProtocol) {.async, base.} = p.started = false
 
-proc hash*(protocol: LPProtocol): Hash =
-  result = protocol.codecs.hash !& protocol.handler.hash
-  result = !$ result
-
+proc handleIncoming*(protocol: LPProtocol, conn: Connection, proto: string) {.async.} =
+  let maxIncomingStreams = protocol.maxIncomingStreams.get(DefaultMaxIncomingStreams)
+  if protocol.openedStreams.getOrDefault(conn.peerId) >= maxIncomingStreams:
+    debug "Max streams for protocol reached, blocking new stream",
+      conn, proto, maxIncomingStreams
+    await conn.close()
+  protocol.openedStreams.inc(conn.peerId)
+  defer: protocol.openedStreams.inc(conn.peerId, -1)
+  await protocol.handler(conn, proto)
 
 func codec*(p: LPProtocol): string =
   assert(p.codecs.len > 0, "Codecs sequence was empty!")

--- a/libp2p/protocols/protocol.nim
+++ b/libp2p/protocols/protocol.nim
@@ -29,11 +29,17 @@ type
     codecs*: seq[string]
     handler*: LPProtoHandler ## this handler gets invoked by the protocol negotiator
     started*: bool
-    maxIncomingStreams*: Opt[int]
+    maxIncomingStreams: Opt[int]
 
 method init*(p: LPProtocol) {.base, gcsafe.} = discard
 method start*(p: LPProtocol) {.async, base.} = p.started = true
 method stop*(p: LPProtocol) {.async, base.} = p.started = false
+
+proc maxIncomingStreams*(p: LPProtocol): int =
+  p.maxIncomingStreams.get(DefaultMaxIncomingStreams)
+
+proc `maxIncomingStreams=`*(p: LPProtocol, val: int) =
+  p.maxIncomingStreams = Opt.some(val)
 
 func codec*(p: LPProtocol): string =
   assert(p.codecs.len > 0, "Codecs sequence was empty!")

--- a/tests/testmultistream.nim
+++ b/tests/testmultistream.nim
@@ -285,7 +285,8 @@ suite "Multistream select":
     # Start 5 streams which are blocked by `blocker`
     # Try to start a new one, which should fail
     # Unblock the 5 streams, check that we can open a new one
-    var protocol: LPProtocol = LPProtocol(maxIncomingStreams: Opt.some(5))
+    var protocol: LPProtocol = LPProtocol()
+    protocol.maxIncomingStreams = 5
     proc testHandler(conn: Connection,
                       proto: string):
                       Future[void] {.async, gcsafe.} =

--- a/tests/testmultistream.nim
+++ b/tests/testmultistream.nim
@@ -285,14 +285,18 @@ suite "Multistream select":
     # Start 5 streams which are blocked by `blocker`
     # Try to start a new one, which should fail
     # Unblock the 5 streams, check that we can open a new one
-    var protocol: LPProtocol = LPProtocol()
-    protocol.maxIncomingStreams = 5
     proc testHandler(conn: Connection,
                       proto: string):
                       Future[void] {.async, gcsafe.} =
       await blocker
       await conn.writeLp("Hello!")
       await conn.close()
+
+    var protocol: LPProtocol = LPProtocol.new(
+      @["/test/proto/1.0.0"],
+      testHandler,
+      maxIncomingStreams = 5
+    )
 
     protocol.handler = testHandler
     let msListen = MultistreamSelect.new()

--- a/tests/testmultistream.nim
+++ b/tests/testmultistream.nim
@@ -278,6 +278,68 @@ suite "Multistream select":
 
     await handlerWait.wait(30.seconds)
 
+  asyncTest "e2e - streams limit":
+    let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
+    let blocker = newFuture[void]()
+
+    var protocol: LPProtocol = LPProtocol(maxStreams: Opt.some(5))
+    proc testHandler(conn: Connection,
+                      proto: string):
+                      Future[void] {.async, gcsafe.} =
+      await blocker
+      await conn.writeLp("Hello!")
+      await conn.close()
+
+    protocol.handler = testHandler
+    let msListen = MultistreamSelect.new()
+    msListen.addHandler("/test/proto/1.0.0", protocol)
+
+    let transport1 = TcpTransport.new(upgrade = Upgrade())
+    await transport1.start(ma)
+
+    proc acceptedOne(c: Connection) {.async.} =
+      await msListen.handle(c)
+      await c.close()
+
+    proc acceptHandler() {.async, gcsafe.} =
+      while true:
+        let conn = await transport1.accept()
+        asyncSpawn acceptedOne(conn)
+
+    var handlerWait = acceptHandler()
+
+    let msDial = MultistreamSelect.new()
+    let transport2 = TcpTransport.new(upgrade = Upgrade())
+
+    proc connector {.async.} =
+      let conn = await transport2.dial(transport1.addrs[0])
+      check: (await msDial.select(conn, "/test/proto/1.0.0")) == true
+      check: string.fromBytes(await conn.readLp(1024)) == "Hello!"
+      await conn.close()
+
+    # Fill up the 5 allowed streams
+    var dialers: seq[Future[void]]
+    for _ in 0..5:
+      dialers.add(connector())
+
+    # This one will fail somehow
+    expect(CatchableError):
+      waitFor(connector())
+    # check that the dialers aren't finished
+    check: (await dialers[0].withTimeout(10.milliseconds)) == false
+
+    # unblock the dialers
+    blocker.complete()
+    await allFutures(dialers)
+
+    # now must work
+    waitFor(connector())
+
+    await transport2.stop()
+    await transport1.stop()
+
+    await handlerWait.cancelAndWait()
+
   asyncTest "e2e - ls":
     let ma = @[MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()]
 

--- a/tests/testmultistream.nim
+++ b/tests/testmultistream.nim
@@ -327,7 +327,10 @@ suite "Multistream select":
 
     # This one will fail during negotiation
     expect(CatchableError):
-      waitFor(connector())
+      try: waitFor(connector().wait(1.seconds))
+      except AsyncTimeoutError as exc:
+        check false
+        raise exc
     # check that the dialers aren't finished
     check: (await dialers[0].withTimeout(10.milliseconds)) == false
 


### PR DESCRIPTION
Each protocol can specify a maximum number of (inbounds) streams per Peer (not connection!). Above that, new streams will be closed directly.

This default to 10, could be finer tuned for each libp2p protocol, but I think it's pretty good default