### PR TITLE
Avoid closing connection on channel EOF

### DIFF
--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -244,7 +244,7 @@ proc completeWrite(
   except CancelledError as exc:
     # Chronos may still send the data
     raise exc
-  except LPStreamClosedError as exc:
+  except LPStreamEOFError as exc:
     raise exc
   except CatchableError as exc:
     trace "exception in lpchannel write handler", s, msg = exc.msg

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -244,6 +244,10 @@ proc completeWrite(
   except CancelledError as exc:
     # Chronos may still send the data
     raise exc
+  except LPStreamConnDownError as exc:
+    await s.reset()
+    await s.conn.close()
+    raise exc
   except LPStreamEOFError as exc:
     raise exc
   except CatchableError as exc:

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -177,8 +177,14 @@ method handle*(m: Mplex) {.async, gcsafe.} =
             raise newLPStreamLimitError()
 
           trace "pushing data to channel", m, channel, len = data.len
-          await channel.pushData(data)
-          trace "pushed data to channel", m, channel, len = data.len
+          try:
+            await channel.pushData(data)
+            trace "pushed data to channel", m, channel, len = data.len
+          except LPStreamClosedError as exc:
+            # Channel is being closed, but `cleanupChann` was not yet triggered.
+            trace "pushing data to channel failed", m, channel, len = data.len,
+              msg = exc.msg
+            discard  # Ignore message, same as if `cleanupChann` had completed.
 
         of MessageType.CloseIn, MessageType.CloseOut:
           await channel.pushEof()


### PR DESCRIPTION
While closing an individual channel (e.g., due to cancellation) there is a race where we may still receive messages before we deallocated the channel. Handle that case gracefully to avoid closing down the entire underlying connection (which also holds all other active channels).