### PR TITLE
Various gossipsub fixes

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -130,6 +130,10 @@ proc handleGraft*(g: GossipSub,
 
       continue
 
+    if g.mesh.hasPeer(topic, peer):
+      trace "peer already in mesh", peer, topic
+      continue
+
     # Check backingOff
     # Ignore BackoffSlackTime here, since this only for outbound activity
     # and subtract a second time to avoid race conditions

--- a/libp2p/protocols/pubsub/gossipsub/behavior.nim
+++ b/libp2p/protocols/pubsub/gossipsub/behavior.nim
@@ -180,6 +180,10 @@ proc handleGraft*(g: GossipSub,
           topicID: topic,
           peers: g.peerExchangeList(topic),
           backoff: g.parameters.pruneBackoff.seconds.uint64))
+
+        let backoff = Moment.fromNow(g.parameters.pruneBackoff)
+        g.backingOff
+          .mgetOrPut(topic, initTable[PeerId, Moment]())[peer.peerId] = backoff
     else:
       trace "peer grafting topic we're not interested in", peer, topic
       # gossip 1.1, we do not send a control message prune anymore

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -295,11 +295,11 @@ proc rewardDelivered*(
 
     g.withPeerStats(peer.peerId) do (stats: var PeerStats):
       stats.topicInfos.withValue(tt, tstats):
-        if tstats[].inMesh:
-          if first:
-            tstats[].firstMessageDeliveries.addCapped(
-              1, topicParams.firstMessageDeliveriesCap)
+        if first:
+          tstats[].firstMessageDeliveries.addCapped(
+            1, topicParams.firstMessageDeliveriesCap)
 
+        if tstats[].inMesh:
           tstats[].meshMessageDeliveries.addCapped(
             1, topicParams.meshMessageDeliveriesCap)
       do: # make sure we don't loose this information


### PR DESCRIPTION
## [Fix gossipsub graft race condition](https://github.com/status-im/nim-libp2p/commit/d6c6eafc7bf28b3714b13d1fa6e57baf21235a3c)

When two peers graft themselves at the same time, they both process the graft coming from the other peer.
If, while processing this graft, they decide to prune him for some reason, they will prune him without removing him from the local mesh.
This commit instead ignore grafts from peers already in mesh.

## [Store backoff on graft pruning](https://github.com/status-im/nim-libp2p/commit/bb4df6b78864c4e87f1e35ba3d329a08e4df3096)

When pruning while processing a graft, we send a backoff but don't store it. Not anymore

## [Reward firstMessageDeliveries to peers outside of mesh](https://github.com/status-im/nim-libp2p/commit/ab9be30699b460dad4c3d6b68e7cbc1f0280cb38)

I don't see any reason not to give point to a peer outside of the mesh for being first to deliver.