### PR TITLE
move store muxer

### DIFF
--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -294,7 +294,7 @@ proc cleanupConn(c: ConnManager, conn: Connection) {.async.} =
 
   trace "Connection cleaned up", conn
 
-proc onConnUpgraded(c: ConnManager, conn: Connection) {.async.} =
+proc onConnUpgraded*(c: ConnManager, conn: Connection) {.async.} =
   try:
     trace "Triggering connect events", conn
     conn.upgrade()
@@ -468,8 +468,6 @@ proc storeMuxer*(c: ConnManager,
 
   trace "Stored muxer",
     muxer, handle = not handle.isNil, connections = c.conns.len
-
-  asyncSpawn c.onConnUpgraded(muxer.connection)
 
 proc getStream*(c: ConnManager,
                 peerId: PeerId,

--- a/libp2p/upgrademngrs/muxedupgrade.nim
+++ b/libp2p/upgrademngrs/muxedupgrade.nim
@@ -71,7 +71,7 @@ proc mux*(
   # install stream handler
   muxer.streamHandler = self.streamHandler
 
-  self.connManager.storeConn(conn)
+  let handler = muxer.handle()
 
   try:
     await self.identify(muxer)
@@ -81,8 +81,10 @@ proc mux*(
     # loop
     debug "Could not identify connection", conn, msg = exc.msg
 
+  self.connManager.storeConn(conn)
+
   # store it in muxed connections if we have a peer for it
-  self.connManager.storeMuxer(muxer, muxer.handle()) # store muxer and start read loop
+  self.connManager.storeMuxer(muxer, handler) # store muxer and start read loop
 
   return muxer
 
@@ -174,12 +176,6 @@ proc muxerHandler(
   let
     conn = muxer.connection
 
-  # store incoming connection
-  self.connManager.storeConn(conn)
-
-  # store muxer and muxed connection
-  self.connManager.storeMuxer(muxer)
-
   try:
     await self.identify(muxer)
     when defined(libp2p_agents_metrics):
@@ -202,6 +198,12 @@ proc muxerHandler(
   except CatchableError as exc:
     await muxer.close()
     trace "Exception in muxer handler", conn, msg = exc.msg
+
+  # store incoming connection
+  self.connManager.storeConn(conn)
+
+  # store muxer and muxed connection
+  self.connManager.storeMuxer(muxer)
 
 proc new*(
   T: type MuxedUpgrade,

--- a/libp2p/upgrademngrs/muxedupgrade.nim
+++ b/libp2p/upgrademngrs/muxedupgrade.nim
@@ -73,9 +73,6 @@ proc mux*(
 
   self.connManager.storeConn(conn)
 
-  # store it in muxed connections if we have a peer for it
-  self.connManager.storeMuxer(muxer, muxer.handle()) # store muxer and start read loop
-
   try:
     await self.identify(muxer)
   except CatchableError as exc:
@@ -83,6 +80,9 @@ proc mux*(
     # the connection was closed already - this will be picked up by the read
     # loop
     debug "Could not identify connection", conn, msg = exc.msg
+
+  # store it in muxed connections if we have a peer for it
+  self.connManager.storeMuxer(muxer, muxer.handle()) # store muxer and start read loop
 
   return muxer
 


### PR DESCRIPTION
The "peer callback" will now get called _after_ identify
This leads to a slight delay, but makes sure that the upgrade is completely finished before going to user code.
We could add an "early callback" in the future if we want to let user get a partially upgraded connection