### PR TITLE
Add the peerId to the transport.dial

### DIFF
--- a/examples/circuitrelay.nim
+++ b/examples/circuitrelay.nim
@@ -57,7 +57,7 @@ proc main() {.async.} =
   let
     # Create a relay address to swDst using swRel as the relay
     addrs = MultiAddress.init($swRel.peerInfo.addrs[0] & "/p2p/" &
-                              $swRel.peerInfo.peerId & "/p2p-circuit/p2p).get()
+                              $swRel.peerInfo.peerId & "/p2p-circuit/p2p").get()
 
   # Connect Dst to the relay
   await swDst.connect(swRel.peerInfo.peerId, swRel.peerInfo.addrs)

--- a/examples/circuitrelay.nim
+++ b/examples/circuitrelay.nim
@@ -57,7 +57,7 @@ proc main() {.async.} =
   let
     # Create a relay address to swDst using swRel as the relay
     addrs = MultiAddress.init($swRel.peerInfo.addrs[0] & "/p2p/" &
-                              $swRel.peerInfo.peerId & "/p2p-circuit/p2p").get()
+                              $swRel.peerInfo.peerId & "/p2p-circuit").get()
 
   # Connect Dst to the relay
   await swDst.connect(swRel.peerInfo.peerId, swRel.peerInfo.addrs)

--- a/examples/circuitrelay.nim
+++ b/examples/circuitrelay.nim
@@ -57,8 +57,7 @@ proc main() {.async.} =
   let
     # Create a relay address to swDst using swRel as the relay
     addrs = MultiAddress.init($swRel.peerInfo.addrs[0] & "/p2p/" &
-                              $swRel.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                              $swDst.peerInfo.peerId).get()
+                              $swRel.peerInfo.peerId & "/p2p-circuit/p2p).get()
 
   # Connect Dst to the relay
   await swDst.connect(swRel.peerInfo.peerId, swRel.peerInfo.addrs)

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -60,7 +60,7 @@ proc dialAndUpgrade(
       let dialed =
         try:
           libp2p_total_dial_attempts.inc()
-          await transport.dial(hostname, address)
+          await transport.dial(hostname, address, peerId)
         except CancelledError as exc:
           debug "Dialing canceled", msg = exc.msg, peerId
           raise exc

--- a/libp2p/services/autorelayservice.nim
+++ b/libp2p/services/autorelayservice.nim
@@ -39,7 +39,7 @@ proc reserveAndUpdate(self: AutoRelayService, relayPid: PeerId, selfPid: PeerId)
     let
       rsvp = await self.client.reserve(relayPid).wait(chronos.seconds(5))
       relayedAddr = rsvp.addrs.mapIt(
-        MultiAddress.init($it & "/p2p-circuit/p2p/" & $selfPid).tryGet())
+        MultiAddress.init($it & "/p2p-circuit").tryGet())
       ttl = rsvp.expire.int64 - times.now().utc.toTime.toUnix
     if ttl <= 60:
       # A reservation under a minute is basically useless

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -246,7 +246,8 @@ method accept*(self: TcpTransport): Future[Connection] {.async, gcsafe.} =
 method dial*(
   self: TcpTransport,
   hostname: string,
-  address: MultiAddress): Future[Connection] {.async, gcsafe.} =
+  address: MultiAddress,
+  peerId: Opt[PeerId] = Opt.none(PeerId)): Future[Connection] {.async, gcsafe.} =
   ## dial a peer
   ##
 

--- a/libp2p/transports/tortransport.nim
+++ b/libp2p/transports/tortransport.nim
@@ -188,7 +188,8 @@ proc dialPeer(
 method dial*(
   self: TorTransport,
   hostname: string,
-  address: MultiAddress): Future[Connection] {.async, gcsafe.} =
+  address: MultiAddress,
+  peerId: Opt[PeerId] = Opt.none(PeerId)): Future[Connection] {.async, gcsafe.} =
   ## dial a peer
   ##
   if not handlesDial(address):

--- a/libp2p/transports/transport.nim
+++ b/libp2p/transports/transport.nim
@@ -65,7 +65,8 @@ method accept*(self: Transport): Future[Connection]
 method dial*(
   self: Transport,
   hostname: string,
-  address: MultiAddress): Future[Connection] {.base, gcsafe.} =
+  address: MultiAddress,
+  peerId: Opt[PeerId] = Opt.none(PeerId)): Future[Connection] {.base, gcsafe.} =
   ## dial a peer
   ##
 
@@ -73,7 +74,8 @@ method dial*(
 
 proc dial*(
   self: Transport,
-  address: MultiAddress): Future[Connection] {.gcsafe.} =
+  address: MultiAddress,
+  peerId: Opt[PeerId] = Opt.none(PeerId)): Future[Connection] {.gcsafe.} =
   self.dial("", address)
 
 method upgradeIncoming*(

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -292,7 +292,8 @@ method accept*(self: WsTransport): Future[Connection] {.async, gcsafe.} =
 method dial*(
   self: WsTransport,
   hostname: string,
-  address: MultiAddress): Future[Connection] {.async, gcsafe.} =
+  address: MultiAddress,
+  peerId: Opt[PeerId] = Opt.none(PeerId)): Future[Connection] {.async, gcsafe.} =
   ## dial a peer
   ##
 

--- a/tests/commoninterop.nim
+++ b/tests/commoninterop.nim
@@ -499,7 +499,7 @@ proc relayInteropTests*(name: string, relayCreator: SwitchCreator) =
       await rel.start()
       let daemonNode = await newDaemonApi()
       let daemonPeer = await daemonNode.identity()
-      let maStr = $rel.peerInfo.addrs[0] & "/p2p/" & $rel.peerInfo.peerId & "/p2p-circuit/p2p/" & $daemonPeer.peer
+      let maStr = $rel.peerInfo.addrs[0] & "/p2p/" & $rel.peerInfo.peerId & "/p2p-circuit"
       let maddr = MultiAddress.init(maStr).tryGet()
       await src.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
       await rel.connect(daemonPeer.peer, daemonPeer.addresses)
@@ -542,7 +542,7 @@ proc relayInteropTests*(name: string, relayCreator: SwitchCreator) =
       await dst.start()
       let daemonNode = await newDaemonApi()
       let daemonPeer = await daemonNode.identity()
-      let maStr = $rel.peerInfo.addrs[0] & "/p2p/" & $rel.peerInfo.peerId & "/p2p-circuit/p2p/" & $dst.peerInfo.peerId
+      let maStr = $rel.peerInfo.addrs[0] & "/p2p/" & $rel.peerInfo.peerId & "/p2p-circuit"
       let maddr = MultiAddress.init(maStr).tryGet()
       await daemonNode.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
       await rel.connect(dst.peerInfo.peerId, dst.peerInfo.addrs)
@@ -581,7 +581,7 @@ proc relayInteropTests*(name: string, relayCreator: SwitchCreator) =
       await dst.start()
       let daemonNode = await newDaemonApi({RelayHop})
       let daemonPeer = await daemonNode.identity()
-      let maStr = $daemonPeer.addresses[0] & "/p2p/" & $daemonPeer.peer & "/p2p-circuit/p2p/" & $dst.peerInfo.peerId
+      let maStr = $daemonPeer.addresses[0] & "/p2p/" & $daemonPeer.peer & "/p2p-circuit"
       let maddr = MultiAddress.init(maStr).tryGet()
       await src.connect(daemonPeer.peer, daemonPeer.addresses)
       await daemonNode.connect(dst.peerInfo.peerId, dst.peerInfo.addrs)

--- a/tests/testautorelay.nim
+++ b/tests/testautorelay.nim
@@ -26,8 +26,7 @@ proc createSwitch(r: Relay, autorelay: Service = nil): Switch =
 
 proc buildRelayMA(switchRelay: Switch, switchClient: Switch): MultiAddress =
   MultiAddress.init($switchRelay.peerInfo.addrs[0] & "/p2p/" &
-                    $switchRelay.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                    $switchClient.peerInfo.peerId).get()
+                    $switchRelay.peerInfo.peerId & "/p2p-circuit").get()
 
 suite "Autorelay":
   asyncTeardown:

--- a/tests/testrelayv1.nim
+++ b/tests/testrelayv1.nim
@@ -257,7 +257,7 @@ suite "Circuit Relay":
     await allFutures(dst2.stop())
 
   asyncTest "Dial Peer":
-    let maStr = $srelay.peerInfo.addrs[0] & "/p2p/" & $srelay.peerInfo.peerId & "/p2p-circuit/p2p/" & $dst.peerInfo.peerId
+    let maStr = $srelay.peerInfo.addrs[0] & "/p2p/" & $srelay.peerInfo.peerId & "/p2p-circuit"
     let maddr = MultiAddress.init(maStr).tryGet()
     await src.connect(srelay.peerInfo.peerId, srelay.peerInfo.addrs)
     await srelay.connect(dst.peerInfo.peerId, dst.peerInfo.addrs)

--- a/tests/testrelayv2.nim
+++ b/tests/testrelayv2.nim
@@ -98,8 +98,7 @@ suite "Circuit Relay V2":
       let
         rv2add = Relay.new()
         addrs = @[ MultiAddress.init($rel.peerInfo.addrs[0] & "/p2p/" &
-                                     $rel.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                                     $src2.peerInfo.peerId).get() ]
+                                     $rel.peerInfo.peerId & "/p2p-circuit").get() ]
       rv2add.setup(src2)
       await rv2add.start()
       src2.mount(rv2add)
@@ -164,8 +163,7 @@ suite "Circuit Relay V2":
       await dst.start()
 
       let addrs = MultiAddress.init($rel.peerInfo.addrs[0] & "/p2p/" &
-                                $rel.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                                $dst.peerInfo.peerId).get()
+                                $rel.peerInfo.peerId & "/p2p-circuit").get()
 
       await src.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
       await dst.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
@@ -201,8 +199,7 @@ suite "Circuit Relay V2":
       await dst.start()
 
       let addrs = MultiAddress.init($rel.peerInfo.addrs[0] & "/p2p/" &
-                                $rel.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                                $dst.peerInfo.peerId).get()
+                                $rel.peerInfo.peerId & "/p2p-circuit").get()
 
       await src.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
       await dst.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
@@ -250,8 +247,7 @@ take to the ship.""")
       await dst.start()
 
       let addrs = MultiAddress.init($rel.peerInfo.addrs[0] & "/p2p/" &
-                                $rel.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                                $dst.peerInfo.peerId).get()
+                                $rel.peerInfo.peerId & "/p2p-circuit").get()
 
       await src.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
       await dst.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
@@ -286,8 +282,7 @@ take to the ship.""")
       await dst.start()
 
       let addrs = MultiAddress.init($rel.peerInfo.addrs[0] & "/p2p/" &
-                                $rel.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                                $dst.peerInfo.peerId).get()
+                                $rel.peerInfo.peerId & "/p2p-circuit").get()
 
       await src.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
       await dst.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
@@ -332,8 +327,7 @@ take to the ship.""")
         addrs = @[ MultiAddress.init($rel.peerInfo.addrs[0] & "/p2p/" &
                                      $rel.peerInfo.peerId & "/p2p-circuit/p2p/" &
                                      $rel2.peerInfo.peerId & "/p2p/" &
-                                     $rel2.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                                     $dst.peerInfo.peerId).get() ]
+                                     $rel2.peerInfo.peerId & "/p2p-circuit").get() ]
 
       await src.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
       await rel2.connect(rel.peerInfo.peerId, rel.peerInfo.addrs)
@@ -392,14 +386,11 @@ take to the ship.""")
 
       let
         addrsABC = MultiAddress.init($switchB.peerInfo.addrs[0] & "/p2p/" &
-                                     $switchB.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                                     $switchC.peerInfo.peerId).get()
+                                     $switchB.peerInfo.peerId & "/p2p-circuit").get()
         addrsBCA = MultiAddress.init($switchC.peerInfo.addrs[0] & "/p2p/" &
-                                     $switchC.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                                     $switchA.peerInfo.peerId).get()
+                                     $switchC.peerInfo.peerId & "/p2p-circuit").get()
         addrsCAB = MultiAddress.init($switchA.peerInfo.addrs[0] & "/p2p/" &
-                                     $switchA.peerInfo.peerId & "/p2p-circuit/p2p/" &
-                                     $switchB.peerInfo.peerId).get()
+                                     $switchA.peerInfo.peerId & "/p2p-circuit").get()
 
       await switchA.connect(switchB.peerInfo.peerId, switchB.peerInfo.addrs)
       await switchB.connect(switchC.peerInfo.peerId, switchC.peerInfo.addrs)


### PR DESCRIPTION
In order to make the relay transport dial consistent with the others dial.
The PeerId might be useful for Quic and Webrtc aswell. 