### PR TITLE
GossipSub: remove peer if we can't establish sendConn

### DIFF
--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -174,7 +174,7 @@ proc connectOnce(p: PubSubPeer): Future[void] {.async.} =
   try:
     if p.connectedFut.finished:
       p.connectedFut = newFuture[void]()
-    let newConn = await p.getConn()
+    let newConn = await p.getConn().withTimeout(5.seconds)
     if newConn.isNil:
       raise (ref LPError)(msg: "Cannot establish send connection")
 

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -174,7 +174,7 @@ proc connectOnce(p: PubSubPeer): Future[void] {.async.} =
   try:
     if p.connectedFut.finished:
       p.connectedFut = newFuture[void]()
-    let newConn = await p.getConn().withTimeout(5.seconds)
+    let newConn = await p.getConn().wait(5.seconds)
     if newConn.isNil:
       raise (ref LPError)(msg: "Cannot establish send connection")
 
@@ -200,6 +200,9 @@ proc connectOnce(p: PubSubPeer): Future[void] {.async.} =
       trace "Removing send connection", p, conn = p.sendConn
       await p.sendConn.close()
       p.sendConn = nil
+
+    if not p.connectedFut.finished:
+      p.connectedFut.complete()
 
     try:
       if p.onEvent != nil:
@@ -249,11 +252,13 @@ proc sendEncoded*(p: PubSubPeer, msg: seq[byte]) {.raises: [Defect], async.} =
     return
 
   if p.sendConn == nil:
-    discard await p.connectedFut.withTimeout(1.seconds)
+    # Wait for a send conn to be setup. `connectOnce` will
+    # complete this even if the sendConn setup failed
+    await p.connectedFut
 
   var conn = p.sendConn
   if conn == nil or conn.closed():
-    debug "No send connection, skipping message", p, msg = shortLog(msg)
+    debug "No send connection", p, msg = shortLog(msg)
     return
 
   trace "sending encoded msgs to peer", conn, encoded = shortLog(msg)


### PR DESCRIPTION
Currently, if we can't establish a sendConn, we will swallow messages, which can lead to asymmetric mesh and useless memory usage
This PR changes the behavior to consider the peer disconnected if we can't establish a sendConn in 5 seconds