### PR TITLE
Populate peerstore before triggering events

### DIFF
--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -191,8 +191,8 @@ proc internalConnect(
       raise newException(DialFailedError, "Unable to establish outgoing link")
 
     try:
-      self.connManager.storeMuxer(muxed)
       await self.peerStore.identify(muxed)
+      self.connManager.storeMuxer(muxed)      
     except CatchableError as exc:
       trace "Failed to finish outgoung upgrade", err=exc.msg
       await muxed.close()

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -217,8 +217,8 @@ proc mount*[T: LPProtocol](s: Switch, proto: T, matcher: Matcher = nil)
 
 proc upgrader(switch: Switch, trans: Transport, conn: Connection) {.async.} =
   let muxed = await trans.upgrade(conn, Direction.In, Opt.none(PeerId))
-  switch.connManager.storeMuxer(muxed)
   await switch.peerStore.identify(muxed)
+  switch.connManager.storeMuxer(muxed)
   trace "Connection upgrade succeeded"
 
 proc upgradeMonitor(


### PR DESCRIPTION
* Peerstore was populated after triggering peer connection events. This caused that when reading the peerstore `addPeerEventHandler` handler for the inbound connecting `peerId`, its fields were not yet populated.
* Add testcase showcasing the issue. Without the changes made in this PR, that test would fail.