### PR TITLE
Autonat and HP changes

### DIFF
--- a/libp2p/services/autorelayservice.nim
+++ b/libp2p/services/autorelayservice.nim
@@ -35,6 +35,9 @@ type
     addressMapper: AddressMapper
     rng: ref HmacDrbgContext
 
+proc isRunning*(self: AutoRelayService): bool =
+  return self.running
+
 proc addressMapper(
   self: AutoRelayService,
   listenAddrs: seq[MultiAddress]): Future[seq[MultiAddress]] {.gcsafe, async.} =

--- a/libp2p/services/hpservice.nim
+++ b/libp2p/services/hpservice.nim
@@ -108,9 +108,9 @@ method setup*(self: HPService, switch: Switch): Future[bool] {.async.} =
     switch.connManager.addPeerEventHandler(self.newConnectedPeerHandler, PeerEventKind.Joined)
 
     self.onNewStatusHandler = proc (networkReachability: NetworkReachability, confidence: Option[float]) {.gcsafe, async.} =
-      if networkReachability == NetworkReachability.NotReachable:
+      if networkReachability == NetworkReachability.NotReachable and not self.autoRelayService.isRunning():
         discard await self.autoRelayService.setup(switch)
-      elif networkReachability == NetworkReachability.Reachable:
+      elif networkReachability == NetworkReachability.Reachable and self.autoRelayService.isRunning():
         discard await self.autoRelayService.stop(switch)
 
       # We do it here instead of in the AutonatService because this is useful only when hole punching.

--- a/tests/testautonatservice.nim
+++ b/tests/testautonatservice.nim
@@ -407,7 +407,8 @@ suite "Autonat Service":
     # switch1 is now full, should stick to last observation
     awaiter = newFuture[void]()
     await autonatService.run(switch1)
-    await awaiter
+
+    await sleepAsync(200.millis)
 
     check autonatService.networkReachability == NetworkReachability.Reachable
     check libp2p_autonat_reachability_confidence.value(["Reachable"]) == 1


### PR DESCRIPTION
The motivation is to make it cheaper to always run the Hole Punching Service

* Execute callHandler only if there was a change in reachability or confidence
* Setup autorelay service only if it isn't running and stop it only if it is running
