### PR TITLE
Version 1.1.0

### DIFF
--- a/libp2p.nimble
+++ b/libp2p.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName   = "libp2p"
-version       = "1.0.0"
+version       = "1.1.0"
 author        = "Status Research & Development GmbH"
 description   = "LibP2P implementation"
 license       = "MIT"


### PR DESCRIPTION
A lot of things happened since version 1.0, with the largest releases being the Hole-Punching stack, the Tor transport

See the full list here: https://github.com/status-im/nim-libp2p/compare/a3e9d1ed80c048cd5abc839cbe0863cefcedc702...67102873ba958a0ce92837ca86711b7219707f98

Anyway, here we go to version 1.1.0
Version 1.0 was the last version to support nim 1.2, we will now switch to nim 1.6 & 2.0 as our stable targets