### PR TITLE
chore: add basic metrics for rendezvous

### DIFF
--- a/libp2p/protocols/rendezvous.nim
+++ b/libp2p/protocols/rendezvous.nim
@@ -13,6 +13,7 @@ else:
   {.push raises: [].}
 
 import tables, sequtils, sugar, sets, options
+import metrics except collect
 import chronos,
        chronicles,
        bearssl/rand,
@@ -29,6 +30,11 @@ export chronicles
 
 logScope:
   topics = "libp2p discovery rendezvous"
+
+declareCounter(libp2p_rendezvous_register, "number of advertise requests")
+declareCounter(libp2p_rendezvous_discover, "number of discovery requests")
+declareGauge(libp2p_rendezvous_registered, "number of registered peers")
+declareGauge(libp2p_rendezvous_namespaces, "number of registered namespaces")
 
 const
   RendezVousCodec* = "/rendezvous/1.0.0"
@@ -378,6 +384,7 @@ proc save(rdv: RendezVous,
 
 proc register(rdv: RendezVous, conn: Connection, r: Register): Future[void] =
   trace "Received Register", peerId = conn.peerId, ns = r.ns
+  libp2p_rendezvous_register.inc()
   if r.ns.len notin 1..255:
     return conn.sendRegisterResponseError(InvalidNamespace)
   let ttl = r.ttl.get(MinimumTTL)
@@ -389,6 +396,8 @@ proc register(rdv: RendezVous, conn: Connection, r: Register): Future[void] =
   if rdv.countRegister(conn.peerId) >= RegistrationLimitPerPeer:
     return conn.sendRegisterResponseError(NotAuthorized, "Registration limit reached")
   rdv.save(r.ns, conn.peerId, r)
+  libp2p_rendezvous_registered.inc()
+  libp2p_rendezvous_namespaces.set(int64(rdv.namespaces.len))
   conn.sendRegisterResponse(ttl)
 
 proc unregister(rdv: RendezVous, conn: Connection, u: Unregister) =
@@ -398,11 +407,13 @@ proc unregister(rdv: RendezVous, conn: Connection, u: Unregister) =
     for index in rdv.namespaces[nsSalted]:
       if rdv.registered[index].peerId == conn.peerId:
         rdv.registered[index].expiration = rdv.defaultDT
+        libp2p_rendezvous_registered.dec()
   except KeyError:
     return
 
 proc discover(rdv: RendezVous, conn: Connection, d: Discover) {.async.} =
   trace "Received Discover", peerId = conn.peerId, ns = d.ns
+  libp2p_rendezvous_discover.inc()
   if d.ns.len notin 0..255:
     await conn.sendDiscoverResponseError(InvalidNamespace)
     return
@@ -657,9 +668,13 @@ proc new*(T: typedesc[RendezVous],
 proc deletesRegister(rdv: RendezVous) {.async.} =
   heartbeat "Register timeout", 1.minutes:
     let n = Moment.now()
+    var total = 0
     rdv.registered.flushIfIt(it.expiration < n)
     for data in rdv.namespaces.mvalues():
       data.keepItIf(it >= rdv.registered.offset)
+      total += data.len
+    libp2p_rendezvous_registered.set(int64(total))
+    libp2p_rendezvous_namespaces.set(int64(rdv.namespaces.len))
 
 method start*(rdv: RendezVous) {.async.} =
   if not rdv.registerDeletionLoop.isNil:


### PR DESCRIPTION
Since we have enabled Rendezvous Discovery in nwaku by default (as long as relay is enabled), we need to be able to measure some basic usage.

This is my attempt to add basic set of metrics:

`libp2p_rendezvous_register` - counter for register/advertise requests
`libp2p_rendezvous_discover` - counter for discover/request requests
`libp2p_rendezvous_registered` - gauge representing number of currently registered peers
`libp2p_rendezvous_namespaces` - gauge representing number of currently known namespaces

I am not sure if my approach to setting these metrics is optimal, so would love any suggestions for improvements