### PR TITLE
Gossipsub scoring improvements

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -155,6 +155,9 @@ method onNewPeer(g: GossipSub, peer: PubSubPeer) =
     peer.appScore = stats.appScore
     peer.behaviourPenalty = stats.behaviourPenalty
 
+    # Check if the score is below the threshold and disconnect the peer if necessary
+    g.disconnectBadPeerCheck(peer, stats.score)
+
   peer.iHaveBudget = IHavePeerBudget
   peer.pingBudget = PingsPeerBudget
 

--- a/libp2p/protocols/pubsub/gossipsub/scoring.nim
+++ b/libp2p/protocols/pubsub/gossipsub/scoring.nim
@@ -104,6 +104,11 @@ proc disconnectPeer(g: GossipSub, peer: PubSubPeer) {.async.} =
   except CatchableError as exc: # Never cancelled
     trace "Failed to close connection", peer, error = exc.name, msg = exc.msg
 
+proc disconnectBadPeerCheck*(g: GossipSub, peer: PubSubPeer, score: float64) =
+  if g.parameters.disconnectBadPeers and score < g.parameters.graylistThreshold and
+     peer.peerId notin g.parameters.directPeers:
+    debug "disconnecting bad score peer", peer, score = peer.score
+    asyncSpawn(g.disconnectPeer(peer))
 
 proc updateScores*(g: GossipSub) = # avoid async
   ## https://github.com/libp2p/specs/blob/master/pubsub/gossipsub/gossipsub-v1.1.md#the-score-function
@@ -244,10 +249,7 @@ proc updateScores*(g: GossipSub) = # avoid async
 
     trace "updated peer's score", peer, score = peer.score, n_topics, is_grafted
 
-    if g.parameters.disconnectBadPeers and stats.score < g.parameters.graylistThreshold and
-        peer.peerId notin g.parameters.directPeers:
-      debug "disconnecting bad score peer", peer, score = peer.score
-      asyncSpawn(g.disconnectPeer(peer))
+    g.disconnectBadPeerCheck(peer, stats.score)
 
     libp2p_gossipsub_peers_scores.inc(peer.score, labelValues = [agent])
 


### PR DESCRIPTION
When a score is restored from the in-memory peer stats, we should check it instantly and kick the peer if it's below the threshold.