### PR TITLE
Transports: handle TransportAbortedError properly

### DIFF
--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -262,8 +262,8 @@ proc accept(s: Switch, transport: Transport) {.async.} = # noraises
         # be careful to not end up in a thigh loop that
         # will starve the main event loop, thus we sleep
         # here before retrying.
-        trace "Unable to get a connection, sleeping"
-        await sleepAsync(100.millis) # TODO: should be configurable?
+        debug "Unable to get a connection, sleeping"
+        await sleepAsync(500.millis) # TODO: should be configurable?
         upgrades.release()
         continue
 

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -258,13 +258,8 @@ proc accept(s: Switch, transport: Transport) {.async.} = # noraises
       if isNil(conn):
         # A nil connection means that we might have hit a
         # file-handle limit (or another non-fatal error),
-        # we can get one on the next try, but we should
-        # be careful to not end up in a thigh loop that
-        # will starve the main event loop, thus we sleep
-        # here before retrying.
-        debug "Unable to get a connection, sleeping"
-        await sleepAsync(500.millis) # TODO: should be configurable?
-        upgrades.release()
+        # we can get one on the next try
+        debug "Unable to get a connection"
         continue
 
       # set the direction of this bottom level transport
@@ -278,7 +273,7 @@ proc accept(s: Switch, transport: Transport) {.async.} = # noraises
       trace "releasing semaphore on cancellation"
       upgrades.release() # always release the slot
     except CatchableError as exc:
-      debug "Exception in accept loop, exiting", exc = exc.msg
+      error "Exception in accept loop, exiting", exc = exc.msg
       upgrades.release() # always release the slot
       if not isNil(conn):
         await conn.close()

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -249,14 +249,19 @@ method accept*(self: TcpTransport): Future[Connection] {.async, gcsafe.} =
     debug "OS Error", exc = exc.msg
   except TransportTooManyError as exc:
     debug "Too many files opened", exc = exc.msg
+  except TransportAbortedError as exc:
+    debug "Connection aborted", exc = exc.msg
   except TransportUseClosedError as exc:
     debug "Server was closed", exc = exc.msg
     raise newTransportClosedError(exc)
   except CancelledError as exc:
     raise exc
   except CatchableError as exc:
-    debug "Unexpected error accepting connection", exc = exc.msg
-    raise exc
+    info "Unexpected error accepting connection", exc = exc.msg
+    # The above except should catch all relevant exceptions
+    # returning nil will pause the accept loop for a few ms to avoid
+    # tight loops
+    return nil
 
 method dial*(
   self: TcpTransport,

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -268,8 +268,6 @@ method accept*(self: WsTransport): Future[Connection] {.async, gcsafe.} =
     except CatchableError as exc:
       await req.stream.closeWait()
       raise exc
-  except TransportOsError as exc:
-    debug "OS Error", exc = exc.msg
   except WebSocketError as exc:
     debug "Websocket Error", exc = exc.msg
   except HttpError as exc:
@@ -284,10 +282,12 @@ method accept*(self: WsTransport): Future[Connection] {.async, gcsafe.} =
     debug "Server was closed", exc = exc.msg
     raise newTransportClosedError(exc)
   except CancelledError as exc:
-    # bubble up silently
+    raise exc
+  except TransportOsError as exc:
+    info "OS Error", exc = exc.msg
     raise exc
   except CatchableError as exc:
-    warn "Unexpected error accepting connection", exc = exc.msg
+    info "Unexpected error accepting connection", exc = exc.msg
     raise exc
 
 method dial*(


### PR DESCRIPTION
Ref https://github.com/status-im/nimbus-eth2/issues/5004

Updated according to @cheatfate: `TransportTooManyError` & `TransportAbortedError`: log & continue instantly, everything else: crash the loop