### PR TITLE
wstransport.nim: avoid re-raising 'TransportOsError' to avoid stopping `switch.accept`

### DIFF
--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -284,8 +284,7 @@ method accept*(self: WsTransport): Future[Connection] {.async, gcsafe.} =
   except CancelledError as exc:
     raise exc
   except TransportOsError as exc:
-    info "OS Error", exc = exc.msg
-    raise exc
+    debug "OS Error", exc = exc.msg
   except CatchableError as exc:
     info "Unexpected error accepting connection", exc = exc.msg
     raise exc


### PR DESCRIPTION
### Description

We found that a 'TransportOsError' can be raised by the next:

https://github.com/status-im/nim-libp2p/blob/224f92e17251464984d6906316c54d2e1108ae43/libp2p/transports/wstransport.nim#L260

     let req = await finished

Then, that 'TransportOsError' exception was re-raised in `wstransport` and caught by the `switch.accept` proc, which made the main accept loop end accepting new upcoming connections because 'TransportOsError' is 'CatchableError'.

https://github.com/status-im/nim-libp2p/blob/224f92e17251464984d6906316c54d2e1108ae43/libp2p/switch.nim#L277

### Future enhancements
https://github.com/status-im/nim-libp2p/issues/927