### PR TITLE
GossipSub: stagger sending using TCP internals

### DIFF
--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -16,11 +16,12 @@ import rpc/[messages, message, protobuf],
        ../../peerid,
        ../../peerinfo,
        ../../stream/connection,
+       ../../stream/chronosstream,
        ../../crypto/crypto,
        ../../protobuf/minprotobuf,
        ../../utility
 
-export peerid, connection
+export peerid, connection, chronosstream
 
 logScope:
   topics = "libp2p pubsubpeer"
@@ -77,6 +78,14 @@ when defined(libp2p_agents_metrics):
       #TODO the sendConn is setup before identify,
       #so we have to read the parents short agent..
       p.sendConn.getWrapped().shortAgent
+
+proc getStats*(p: PubSubPeer): ConnStats =
+  var c = p.sendConn
+  while true:
+    let w = c.getWrapped()
+    if isNil(w): break
+    c = w
+  ChronosStream(c).getStats
 
 func hash*(p: PubSubPeer): Hash =
   p.peerId.hash

--- a/tests/testtcptransport.nim
+++ b/tests/testtcptransport.nim
@@ -13,6 +13,7 @@ import chronos, stew/byteutils
 import ../libp2p/[stream/connection,
                   transports/transport,
                   transports/tcptransport,
+                  stream/chronosstream,
                   upgrademngrs/upgrade,
                   multiaddress,
                   multicodec,


### PR DESCRIPTION
An attempt to implement stagger sending (#850) by accessing the TCP internal data instead of trying to compute the bandwidth ourself.

Turns out, this is (probably) not a good idea.

On the open internet, most routers (>90% according to `An Internet-Wide Analysis of Traffic Policing`) will buffer packets before dropping them when they are overloaded.

Since linux & other bases its default congestion algorithm (cubic for TCP) on packet losses, it means that the bandwidth estimate will be completely wrong if we don't reach the threshold of "dropping packets" in the routers connecting us to the other peer.

So if we send a 1MB at 1gbits to a router limited to 1mbps, he will actually buffer that data, and send it at 1mbps. TCP, seeing no loss, will think it has 1gbits available. We need to send more data than the router can buffer to actually have losses, and for TCP to realize it has less bandwidth than 1gbits. The exception to this is if the network supports [ECN](https://en.wikipedia.org/wiki/Explicit_Congestion_Notification), but it seems it's not widespread enough to rely on it

We would need more measurement on real networks, but from my limited testing, the intermediary buffers are always big enough to store a full block for each peer, ie ethereum is not using enough bandwidth to overload them.

So seems the only way to implement stagger sending is to use a congestion algorithm based on latency instead of loss (like BBR), or re-implement a latency-based bandwidth estimator on top of TCP (like https://github.com/status-im/nim-libp2p/commit/fd6874e6474518a475595260996530dda8a358ff)