### PR TITLE
avoid importing `ecnist` when not needed

### DIFF
--- a/libp2p/crypto/crypto.nim
+++ b/libp2p/crypto/crypto.nim
@@ -71,9 +71,6 @@ when supported(PKScheme.ECDSA):
   # These used to be declared in `crypto` itself
   export ecnist.ephemeral, ecnist.ECDHEScheme
 
-# We are still importing `ecnist` because, it is used for SECIO handshake,
-# but it will be impossible to create ECNIST keys or import ECNIST keys.
-
 import bearssl/rand, bearssl/hash as bhash
 import ../protobuf/minprotobuf, ../vbuffer, ../multihash, ../multicodec
 import nimcrypto/[rijndael, twofish, sha2, hash, hmac]

--- a/libp2p/crypto/ecnist.nim
+++ b/libp2p/crypto/ecnist.nim
@@ -994,3 +994,33 @@ proc verify*[T: byte|char](sig: EcSignature, message: openArray[T],
     # Clear context with initial value
     kv.init(addr hc.vtable)
     result = (res == 1)
+
+type ECDHEScheme* = EcCurveKind
+
+proc ephemeral*(
+    scheme: ECDHEScheme,
+    rng: var HmacDrbgContext): EcResult[EcKeyPair] =
+  ## Generate ephemeral keys used to perform ECDHE.
+  var keypair: EcKeyPair
+  if scheme == Secp256r1:
+    keypair = ? EcKeyPair.random(Secp256r1, rng)
+  elif scheme == Secp384r1:
+    keypair = ? EcKeyPair.random(Secp384r1, rng)
+  elif scheme == Secp521r1:
+    keypair = ? EcKeyPair.random(Secp521r1, rng)
+  ok(keypair)
+
+proc ephemeral*(
+    scheme: string, rng: var HmacDrbgContext): EcResult[EcKeyPair] =
+  ## Generate ephemeral keys used to perform ECDHE using string encoding.
+  ##
+  ## Currently supported encoding strings are P-256, P-384, P-521, if encoding
+  ## string is not supported P-521 key will be generated.
+  if scheme == "P-256":
+    ephemeral(Secp256r1, rng)
+  elif scheme == "P-384":
+    ephemeral(Secp384r1, rng)
+  elif scheme == "P-521":
+    ephemeral(Secp521r1, rng)
+  else:
+    ephemeral(Secp521r1, rng)


### PR DESCRIPTION
`secio` can get its helpers directly from the `ecnist` module - but that doesn't really matter because it's also deprecated

this (significantly) reduces libp2p dependencies on bearssl speeding up compile times when not used