### PR TITLE
wstransport.nim: Rng -> ref HmacDrbgContext. 'nim-websock' did the same.

### DIFF
--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -27,7 +27,8 @@ import transport,
        ../utility,
        ../stream/connection,
        ../upgrademngrs/upgrade,
-       websock/websock
+       websock/websock,
+       bearssl/rand
 
 logScope:
   topics = "libp2p wstransport"
@@ -111,7 +112,7 @@ type
     flags: set[ServerFlags]
     handshakeTimeout: Duration
     factories: seq[ExtFactory]
-    rng: Rng
+    rng: ref HmacDrbgContext
 
 proc secure*(self: WsTransport): bool =
   not (isNil(self.tlsPrivateKey) or isNil(self.tlsCertificate))
@@ -327,7 +328,7 @@ proc new*(
   tlsFlags: set[TLSFlags] = {},
   flags: set[ServerFlags] = {},
   factories: openArray[ExtFactory] = [],
-  rng: Rng = nil,
+  rng: ref HmacDrbgContext = nil,
   handshakeTimeout = DefaultHeadersTimeout): T {.public.} =
   ## Creates a secure WebSocket transport
 
@@ -346,7 +347,7 @@ proc new*(
   upgrade: Upgrade,
   flags: set[ServerFlags] = {},
   factories: openArray[ExtFactory] = [],
-  rng: Rng = nil,
+  rng: ref HmacDrbgContext = nil,
   handshakeTimeout = DefaultHeadersTimeout): T {.public.} =
   ## Creates a clear-text WebSocket transport
 


### PR DESCRIPTION
This PR is aimed to fix a compilation issue in the [nwaku](https://github.com/waku-org/nwaku) repo.

I we update the `nim-websock` vendor to its latest state, then the `nim-libp2p` doesn't compile because the `Rng` type is not found.

The reason why that happens is that the next commit removed the `Rng` type ( `ref HmacDrbgContext`,  websock/utils.nim ) from `nim-websock`:

https://github.com/status-im/nim-websock/commit/f8ed9b40a5ff27ad02a3c237c4905b0924e3f982

Therefore, this PR removes the dependency with `Rng` type and uses the original type: `ref HmacDrbgContext`.

----

This is the compilation error that happens in `nwaku` if `nim-websock` is in f8ed9b40a5ff27ad02a3c237c4905b0924e3f982 and `nim-libp2p` is in 41649f099979e0320a46b013744e5c3d2b6eb9c7:

```
/home/ivansete/workspace/status/nwaku/waku/waku_archive/driver/queue_driver/queue_driver.nim(271, 3) Warning: catch a more precise Exception deriving from CatchableError or Defect. [BareExcept]
/home/ivansete/workspace/status/nwaku/vendor/nim-libp2p/libp2p/transports/wstransport.nim(114, 10) Error: undeclared identifier: 'Rng'
candidates (edit distance, scope distance); see '--spellSuggest': 
 (2, 2): 'And' [enumField declared in /home/ivansete/workspace/status/nwaku/vendor/nim-libp2p/libp2p/multiaddress.nim(43, 13)]
 (2, 2): 'And' [enumField declared in /home/ivansete/workspace/status/nwaku/vendor/nim-libp2p/libp2p/multiaddress.nim(43, 13)]
```