### PR TITLE
Rate limit fixes

### DIFF
--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -319,7 +319,7 @@ proc validateAndRelay(g: GossipSub,
     of ValidationResult.Reject:
       debug "Dropping message after validation, reason: reject",
         msgId = shortLog(msgId), peer
-      g.punishInvalidMessage(peer, msg)
+      await g.punishInvalidMessage(peer, msg)
       return
     of ValidationResult.Ignore:
       debug "Dropping message after validation, reason: ignore",
@@ -496,14 +496,14 @@ method rpcHandler*(g: GossipSub,
       # always validate if signature is present or required
       debug "Dropping message due to failed signature verification",
         msgId = shortLog(msgId), peer
-      g.punishInvalidMessage(peer, msg)
+      await g.punishInvalidMessage(peer, msg)
       continue
 
     if msg.seqno.len > 0 and msg.seqno.len != 8:
       # if we have seqno should be 8 bytes long
       debug "Dropping message due to invalid seqno length",
         msgId = shortLog(msgId), peer
-      g.punishInvalidMessage(peer, msg)
+      await g.punishInvalidMessage(peer, msg)
       continue
 
     # g.anonymize needs no evaluation when receiving messages

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -952,6 +952,10 @@ suite "GossipSub":
     gossip1.subscribe("foobar", handle)
     await waitSubGraph(nodes, "foobar")
 
+    # Avoid being disconnected by failing signature verification
+    gossip0.verifySignature = false
+    gossip1.verifySignature = false
+
     return (nodes, gossip0,  gossip1)
 
   proc currentRateLimitHits(): float64 =
@@ -963,10 +967,6 @@ suite "GossipSub":
   asyncTest "e2e - GossipSub should not rate limit decodable messages below the size allowed":
     let rateLimitHits = currentRateLimitHits()
     let (nodes, gossip0, gossip1) = await initializeGossipTest()
-
-    # Avoid being disconnected by failing signature verification
-    gossip0.verifySignature = false
-    gossip1.verifySignature = false
 
     gossip0.broadcast(gossip0.mesh["foobar"], RPCMsg(messages: @[Message(topicIDs: @["foobar"], data: newSeq[byte](10))]))
     await sleepAsync(300.millis)


### PR DESCRIPTION
- "e2e - GossipSub should not rate limit decodable messages below the size allowed" test was flaky because sometimes the test would behave differently from what was expected due to failed signature verification. Always disabling the signature hopefully will fix it. 
- Another test was added for the case when the rate limit happens due to invalid domain messages. 