### PR TITLE
fix: move workflows for Nim Devel and legacy i386 from "Daily"

### DIFF
--- a/.github/workflows/multi_nim_common.yml
+++ b/.github/workflows/multi_nim_common.yml
@@ -1,0 +1,83 @@
+name: daily-common
+
+on:
+  workflow_call:
+    inputs:
+      nim-branch:
+        description: 'Nim branch'
+        required: true
+        type: string
+      platform:
+        description: 'Platform'
+        required: true
+        type: string
+
+jobs:
+  delete-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: snnaplab/delete-branch-cache-action@v1
+
+  matrix-prep:
+
+  build:
+    needs: delete-cache
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJSON(inputs.platform) }}
+        branch: ${{ fromJSON(inputs.nim-branch) }}
+        include:
+          - target:
+              os: linux
+            builder: ubuntu-20.04
+            shell: bash
+          - target:
+              os: macos
+            builder: macos-12
+            shell: bash
+          - target:
+              os: windows
+            builder: windows-2019
+            shell: msys2 {0}
+
+    defaults:
+      run:
+        shell: ${{ matrix.shell }}
+
+    name: '${{ matrix.target.os }}-${{ matrix.target.cpu }} (Nim ${{ matrix.branch }})'
+    runs-on: ${{ matrix.builder }}
+    continue-on-error: ${{ matrix.branch == 'devel' || matrix.branch == 'version-2-0' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Nim
+        uses: "./.github/actions/install_nim"
+        with:
+          os: ${{ matrix.target.os }}
+          shell: ${{ matrix.shell }}
+          nim_branch: ${{ matrix.branch }}
+          cpu: ${{ matrix.target.cpu }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '~1.15.5'
+          cache: false
+
+      - name: Install p2pd
+        run: |
+          V=1 bash scripts/build_p2pd.sh p2pdCache 124530a3
+
+      - name: Run tests
+        run: |
+          nim --version
+          nimble --version
+          nimble install -y --depsOnly
+          NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test
+          if [[ "${{ matrix.branch }}" == "devel" ]]; then
+            echo -e "\nTesting with '--mm:orc':\n"
+            NIMFLAGS="${NIMFLAGS} --mm:orc" nimble test
+          fi

--- a/.github/workflows/multi_nim_devel.yml
+++ b/.github/workflows/multi_nim_devel.yml
@@ -1,4 +1,4 @@
-name: Daily
+name: Nim Devel
 on:
   schedule:
     - cron: "30 6 * * *"
@@ -8,8 +8,6 @@ jobs:
   call-multi-nim-common:
     uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@unstable
     with:
-      nim-branch: "['version-1-6','version-2-0']"
+      nim-branch: "['devel']"
       platform: "[{'os':'linux','cpu':'amd64'},{'os':'macos','cpu':'amd64'},{'os':'windows','cpu':'amd64'}]"
-
-
 

--- a/.github/workflows/multi_nim_legacy.yml
+++ b/.github/workflows/multi_nim_legacy.yml
@@ -1,4 +1,4 @@
-name: Daily
+name: Legacy Platforms
 on:
   schedule:
     - cron: "30 6 * * *"
@@ -9,7 +9,6 @@ jobs:
     uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@unstable
     with:
       nim-branch: "['version-1-6','version-2-0']"
-      platform: "[{'os':'linux','cpu':'amd64'},{'os':'macos','cpu':'amd64'},{'os':'windows','cpu':'amd64'}]"
-
+      platform: "[{'os':'linux','cpu':'i386'}]"
 
 


### PR DESCRIPTION
We have "unstable" as a default branch. Others may expect from it more stability than its name suggest. I propose to make "Daily" workflow more reliable by moving tests with Nim Devel to separate (experimental?) workflow.  