### PR TITLE
fix chronos v4 compat

### DIFF
--- a/libp2p/errors.nim
+++ b/libp2p/errors.nim
@@ -19,7 +19,8 @@ func toException*(e: string): ref LPError =
 # sadly nim needs more love for hygienic templates
 # so here goes the macro, its based on the proc/template version
 # and uses quote do so it's quite readable
-macro checkFutures*[T](futs: seq[Future[T]], exclude: untyped = []): untyped =
+# TODO https://github.com/nim-lang/Nim/issues/22936
+macro checkFutures*[F](futs: seq[F], exclude: untyped = []): untyped =
   let nexclude = exclude.len
   case nexclude
   of 0:

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -219,7 +219,7 @@ method accept*(self: TcpTransport): Future[Connection] {.async, gcsafe.} =
 
   try:
     if self.acceptFuts.len <= 0:
-      self.acceptFuts = self.servers.mapIt(it.accept())
+      self.acceptFuts = self.servers.mapIt(Future[StreamTransport](it.accept()))
 
     if self.acceptFuts.len <= 0:
       return


### PR DESCRIPTION
This helps keep libp2p compatible with both chronos v3 and v4 while v4 is being developed (in particular https://github.com/status-im/nim-chronos/pull/470)