### PR TITLE
fix(multiaddress): add quic-v1 multiaddress support

### DIFF
--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -399,6 +399,9 @@ const
       mcodec: multiCodec("quic"), kind: Marker, size: 0
     ),
     MAProtocol(
+      mcodec: multiCodec("quic-v1"), kind: Marker, size: 0
+    ),
+    MAProtocol(
       mcodec: multiCodec("ip6zone"), kind: Length, size: 0,
       coder: TranscoderIP6Zone
     ),

--- a/libp2p/multicodec.nim
+++ b/libp2p/multicodec.nim
@@ -193,6 +193,7 @@ const MultiCodecList = [
   ("https", 0x01BB),
   ("tls", 0x01C0),
   ("quic", 0x01CC),
+  ("quic-v1", 0x01CD),
   ("ws", 0x01DD),
   ("wss", 0x01DE),
   ("p2p-websocket-star", 0x01DF), # not in multicodec list

--- a/tests/testmultiaddress.nim
+++ b/tests/testmultiaddress.nim
@@ -60,6 +60,7 @@ const
     "/ip4/127.0.0.1/tcp/1234",
     "/ip4/127.0.0.1/tcp/1234/",
     "/ip4/127.0.0.1/udp/1234/quic",
+    "/ip4/192.168.80.3/udp/33422/quic-v1",
     "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",
     "/ip4/127.0.0.1/ipfs/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC/tcp/1234",
     "/ip4/127.0.0.1/p2p/QmcgpsyWgH8Y8ajJz1Cu72KnS5uo2Aa2LpzU7kinSupNKC",


### PR DESCRIPTION
The initial implementation of QUIC in go-libp2p was based on draft-ietf-quic-transport-29 (or simply, draft-29). At the time, draft-29 was implemented because RFC 9000 was yet to be finalized. Eventually go-libp2p added support for RFC 9000 in addition to draft-29, supporting two QUIC versions. However, the multiaddresses for these versions used the same format and thus were indistinguishable in the past.

 By using different code points, quic-v1 for RFC 9000 and quic for draft-29, libp2p can now distinguish between the two versions.

 The multiaddress for a QUIC listener accepting RFC 9000 connections looks like this: /ip4/192.0.2.0/udp/65432/quic-v1/, whereas the for the draft version, the multiaddress would be /ip4/192.0.2.0/udp/65432/quic/.

 Nodes that support multiple versions can offer them on the same port. QUIC long header packets contain the version number, which enables the QUIC stack to handle multiple versions.