### PR TITLE
fix(dcutr): handle tcp/p2p addresses

### DIFF
--- a/libp2p/protocols/connectivity/dcutr/core.nim
+++ b/libp2p/protocols/connectivity/dcutr/core.nim
@@ -56,5 +56,10 @@ proc send*(conn: Connection, msgType: MsgType, addrs: seq[MultiAddress]) {.async
   let pb = DcutrMsg(msgType: msgType, addrs: addrs).encode()
   await conn.writeLp(pb.buffer)
 
-proc getHolePunchableAddrs*(addrs: seq[MultiAddress]): seq[MultiAddress] =
-  addrs.filterIt(TCP.match(it))
+proc getHolePunchableAddrs*(addrs: seq[MultiAddress]): seq[MultiAddress] {.raises: [LPError]} =
+  var result = newSeq[MultiAddress]()
+  for a in addrs:
+      # This is necessary to also accept addrs like /ip4/198.51.100/tcp/1234/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N
+      if [TCP, mapAnd(TCP_DNS, P2PPattern), mapAnd(TCP_IP, P2PPattern)].anyIt(it.match(a)):
+        result.add(a[0..1].tryGet())
+  return result

--- a/tests/testdcutr.nim
+++ b/tests/testdcutr.nim
@@ -179,3 +179,19 @@ suite "Dcutr":
         raise newException(CatchableError, "error")
 
     await ductrServerTest(connectProc)
+
+  test "should return valid TCP/IP and TCP/DNS addresses only":
+    let testAddrs = @[MultiAddress.init("/ip4/192.0.2.1/tcp/1234").tryGet(),
+                      MultiAddress.init("/ip4/203.0.113.5/tcp/5678/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N").tryGet(),
+                      MultiAddress.init("/ip6/::1/tcp/9012").tryGet(),
+                      MultiAddress.init("/dns4/example.com/tcp/3456/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N").tryGet(),
+                      MultiAddress.init("/ip4/198.51.100.42/udp/7890").tryGet()]
+
+    let expected = @[MultiAddress.init("/ip4/192.0.2.1/tcp/1234").tryGet(),
+                     MultiAddress.init("/ip4/203.0.113.5/tcp/5678").tryGet(),
+                     MultiAddress.init("/ip6/::1/tcp/9012").tryGet(),
+                     MultiAddress.init("/dns4/example.com/tcp/3456").tryGet()]
+
+    let result = getHolePunchableAddrs(testAddrs)
+
+    check result == expected


### PR DESCRIPTION
Accepts addresses like /ip4/198.51.100/tcp/1234/p2p/QmYyQSo1c1Ym7orWxLYvCrM2EmxFTANf8wXmmE7DWjhx5N as a dialable tcp address