### PR TITLE
fix(yamux): yamux uses wrong direction during dcutr

### DIFF
--- a/libp2p/builders.nim
+++ b/libp2p/builders.nim
@@ -111,7 +111,7 @@ proc withMplex*(
     maxChannCount = 200): SwitchBuilder {.public.} =
   ## | Uses `Mplex <https://docs.libp2p.io/concepts/stream-multiplexing/#mplex>`_ as a multiplexer
   ## | `Timeout` is the duration after which a inactive connection will be closed
-  proc newMuxer(conn: Connection): Muxer =
+  proc newMuxer(conn: Connection, direction: Opt[Direction] = Opt.none(Direction)): Muxer =
     Mplex.new(
       conn,
       inTimeout,
@@ -123,7 +123,7 @@ proc withMplex*(
   b
 
 proc withYamux*(b: SwitchBuilder): SwitchBuilder =
-  proc newMuxer(conn: Connection): Muxer = Yamux.new(conn)
+  proc newMuxer(conn: Connection, dir: Opt[Direction] = Opt.none(Direction)): Muxer = Yamux.new(conn, dir)
 
   assert b.muxers.countIt(it.codec == YamuxCodec) == 0, "Yamux build multiple times"
   b.muxers.add(MuxerProvider.new(newMuxer, YamuxCodec))

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -75,9 +75,7 @@ proc dialAndUpgrade(
 
       let mux =
         try:
-          let m = await transport.upgrade(dialed, upgradeDir, peerId)
-          m.connection.dir = upgradeDir
-          m
+          await transport.upgrade(dialed, upgradeDir, peerId)
         except CatchableError as exc:
           # If we failed to establish the connection through one transport,
           # we won't succeeded through another - no use in trying again

--- a/libp2p/dialer.nim
+++ b/libp2p/dialer.nim
@@ -75,8 +75,9 @@ proc dialAndUpgrade(
 
       let mux =
         try:
-          dialed.transportDir = upgradeDir
-          await transport.upgrade(dialed, upgradeDir, peerId)
+          let m = await transport.upgrade(dialed, upgradeDir, peerId)
+          m.connection.dir = upgradeDir
+          m
         except CatchableError as exc:
           # If we failed to establish the connection through one transport,
           # we won't succeeded through another - no use in trying again

--- a/libp2p/muxers/muxer.nim
+++ b/libp2p/muxers/muxer.nim
@@ -10,6 +10,7 @@
 {.push raises: [].}
 
 import chronos, chronicles
+import stew/results
 import ../stream/connection,
        ../errors
 
@@ -32,7 +33,7 @@ type
     connection*: Connection
 
   # user provider proc that returns a constructed Muxer
-  MuxerConstructor* = proc(conn: Connection): Muxer {.gcsafe, closure, raises: [].}
+  MuxerConstructor* = proc(conn: Connection, direction: Opt[Direction] = Opt.none(Direction)): Muxer {.gcsafe, closure, raises: [].}
 
   # this wraps a creator proc that knows how to make muxers
   MuxerProvider* = object

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -389,7 +389,14 @@ proc createStream(m: Yamux, id: uint32, isSrc: bool): YamuxChannel =
     closedRemotely: newFuture[void]()
   )
   result.objName = "YamuxStream"
-  result.dir = if isSrc: Direction.Out else: Direction.In
+  result.dir =
+    if isSrc:
+      if m.connection.transportDir == Direction.In:
+        Direction.In
+      else:
+        Direction.Out
+    else:
+      Direction.In
   result.timeoutHandler = proc(): Future[void] {.gcsafe.} =
     trace "Idle timeout expired, resetting YamuxChannel"
     result.reset()

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -391,7 +391,7 @@ proc createStream(m: Yamux, id: uint32, isSrc: bool): YamuxChannel =
   result.objName = "YamuxStream"
   result.dir =
     if isSrc:
-      if m.connection.transportDir == Direction.In:
+      if m.connection.dir == Direction.In:
         Direction.In
       else:
         Direction.Out
@@ -534,6 +534,6 @@ method newStream*(
 proc new*(T: type[Yamux], conn: Connection, maxChannCount: int = MaxChannelCount): T =
   T(
     connection: conn,
-    currentId: if conn.transportDir == Out: 1 else: 2,
+    currentId: if conn.dir == Out: 1 else: 2,
     maxChannCount: maxChannCount
   )

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -534,6 +534,6 @@ method newStream*(
 proc new*(T: type[Yamux], conn: Connection, maxChannCount: int = MaxChannelCount): T =
   T(
     connection: conn,
-    currentId: if conn.dir == Out: 1 else: 2,
+    currentId: if conn.transportDir == Out: 1 else: 2,
     maxChannCount: maxChannCount
   )

--- a/libp2p/upgrademngrs/muxedupgrade.nim
+++ b/libp2p/upgrademngrs/muxedupgrade.nim
@@ -52,7 +52,7 @@ proc mux*(
   trace "Found a muxer", conn, muxerName
 
   # create new muxer for connection
-  let muxer = self.getMuxerByCodec(muxerName).newMuxer(conn)
+  let muxer = self.getMuxerByCodec(muxerName).newMuxer(conn, Opt.some(direction))
 
   # install stream handler
   muxer.streamHandler = self.streamHandler

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -58,7 +58,7 @@ proc createSwitch(ma: MultiAddress; outgoing: bool, secio: bool = false): (Switc
     privateKey = PrivateKey.random(ECDSA, rng[]).get()
     peerInfo = PeerInfo.new(privateKey, @[ma])
 
-  proc createMplex(conn: Connection): Muxer =
+  proc createMplex(conn: Connection, direction: Opt[Direction] = Opt.none(Direction)): Muxer =
     result = Mplex.new(conn)
 
   let


### PR DESCRIPTION
During DCUtR, the listener initiates the direct connection attempt and must connect to the other peer as the incoming upgrade direction. Yamux must use this direction to decide on using odd or even stream IDs, not the underlying connection direction -which in this case is TCP (or another transport) outgoing as the peer is initiating the connection.

This is an unusual case where a peer initiates a connection, but should treat it as incoming. The reason is probably that DCUtR happens when the other remote peer dials this peer relayed address, therefore the original connection was in fact incoming. 

Related:
https://github.com/libp2p/specs/tree/master/yamux
https://github.com/libp2p/specs/blob/master/relay/DCUtR.md