### PR TITLE
fix: remove forgotten "matrix-prep" job

### DIFF
--- a/.github/workflows/multi_nim_common.yml
+++ b/.github/workflows/multi_nim_common.yml
@@ -18,8 +18,6 @@ jobs:
     steps:
       - uses: snnaplab/delete-branch-cache-action@v1
 
-  matrix-prep:
-
   build:
     needs: delete-cache
     timeout-minutes: 120


### PR DESCRIPTION
### Description
matrix-prep job has been in multi_nim_common.yml without any additional definitions. Dependent workflows cannot run.

### Fix
Remove useless job matrix-prep