### PR TITLE
remove redundant gcsafe annotations

### DIFF
--- a/examples/helloworld.nim
+++ b/examples/helloworld.nim
@@ -13,7 +13,7 @@ type
 proc new(T: typedesc[TestProto]): T =
 
   # every incoming connections will be in handled in this closure
-  proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+  proc handle(conn: Connection, proto: string) {.async.} =
     echo "Got from remote - ", string.fromBytes(await conn.readLp(1024))
     await conn.writeLp("Roger p2p!")
 
@@ -40,7 +40,7 @@ proc createSwitch(ma: MultiAddress, rng: ref HmacDrbgContext): Switch =
 ##
 # The actual application
 ##
-proc main() {.async, gcsafe.} =
+proc main() {.async.} =
   let
     rng = newRng() # Single random number source for the whole application
     # port 0 will take a random available port

--- a/examples/tutorial_1_connect.nim
+++ b/examples/tutorial_1_connect.nim
@@ -53,7 +53,7 @@ proc createSwitch(ma: MultiAddress, rng: ref HmacDrbgContext): Switch =
 ##
 ##
 ## Let's now start to create our main procedure:
-proc main() {.async, gcsafe.} =
+proc main() {.async.} =
   let
     rng = newRng()
     localAddress = MultiAddress.init("/ip4/0.0.0.0/tcp/0").tryGet()

--- a/examples/tutorial_2_customproto.nim
+++ b/examples/tutorial_2_customproto.nim
@@ -25,7 +25,7 @@ type TestProto = ref object of LPProtocol
 
 proc new(T: typedesc[TestProto]): T =
   # every incoming connections will in be handled in this closure
-  proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+  proc handle(conn: Connection, proto: string) {.async.} =
     # Read up to 1024 bytes from this connection, and transform them into
     # a string
     echo "Got from remote - ", string.fromBytes(await conn.readLp(1024))
@@ -44,7 +44,7 @@ proc hello(p: TestProto, conn: Connection) {.async.} =
 ## Again, pretty straight-forward, we just send a message on the connection.
 ##
 ## We can now create our main procedure:
-proc main() {.async, gcsafe.} =
+proc main() {.async.} =
   let
     rng = newRng()
     testProto = TestProto.new()

--- a/examples/tutorial_3_protobuf.nim
+++ b/examples/tutorial_3_protobuf.nim
@@ -108,7 +108,7 @@ type
 
 proc new(_: typedesc[MetricProto], cb: MetricCallback): MetricProto =
   var res: MetricProto
-  proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+  proc handle(conn: Connection, proto: string) {.async.} =
     let
       metrics = await res.metricGetter()
       asProtobuf = metrics.encode()
@@ -126,7 +126,7 @@ proc fetch(p: MetricProto, conn: Connection): Future[MetricList] {.async.} =
   return MetricList.decode(protobuf).tryGet()
 
 ## We can now create our main procedure:
-proc main() {.async, gcsafe.} =
+proc main() {.async.} =
   let rng = newRng()
   proc randomMetricGenerator: Future[MetricList] {.async.} =
     let metricCount = rng[].generate(uint32) mod 16

--- a/examples/tutorial_5_discovery.nim
+++ b/examples/tutorial_5_discovery.nim
@@ -33,7 +33,7 @@ proc createSwitch(rdv: RendezVous = RendezVous.new()): Switch =
 const DumbCodec = "/dumb/proto/1.0.0"
 type DumbProto = ref object of LPProtocol
 proc new(T: typedesc[DumbProto], nodeNumber: int): T =
-  proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+  proc handle(conn: Connection, proto: string) {.async.} =
     echo "Node", nodeNumber, " received: ", string.fromBytes(await conn.readLp(1024))
     await conn.close()
   return T.new(codecs = @[DumbCodec], handler = handle)
@@ -49,7 +49,7 @@ proc new(T: typedesc[DumbProto], nodeNumber: int): T =
 ## (rendezvous in this case) as a bootnode. For this example, we'll
 ## create a bootnode, and then every peer will advertise itself on the
 ## bootnode, and use it to find other peers
-proc main() {.async, gcsafe.} =
+proc main() {.async.} =
   let bootNode = createSwitch()
   await bootNode.start()
 

--- a/examples/tutorial_6_game.nim
+++ b/examples/tutorial_6_game.nim
@@ -143,7 +143,7 @@ proc draw(g: Game) =
 ## peer know that we are available, check that he is also available,
 ## and launch the game.
 proc new(T: typedesc[GameProto], g: Game): T =
-  proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+  proc handle(conn: Connection, proto: string) {.async.} =
     defer: await conn.closeWithEof()
     if g.peerFound.finished or g.hasCandidate:
       await conn.close()

--- a/libp2p/connmanager.nim
+++ b/libp2p/connmanager.nim
@@ -128,7 +128,7 @@ proc removeConnEventHandler*(c: ConnManager,
 
 proc triggerConnEvent*(c: ConnManager,
                        peerId: PeerId,
-                       event: ConnEvent) {.async, gcsafe.} =
+                       event: ConnEvent) {.async.} =
   try:
     trace "About to trigger connection events", peer = peerId
     if c.connEvents[event.kind].len() > 0:
@@ -160,7 +160,7 @@ proc removePeerEventHandler*(c: ConnManager,
 
 proc triggerPeerEvents*(c: ConnManager,
                         peerId: PeerId,
-                        event: PeerEvent) {.async, gcsafe.} =
+                        event: PeerEvent) {.async.} =
 
   trace "About to trigger peer events", peer = peerId
   if c.peerEvents[event.kind].len == 0:
@@ -379,7 +379,7 @@ proc trackMuxer*(cs: ConnectionSlot, mux: Muxer) =
   cs.trackConnection(mux.connection)
 
 proc getStream*(c: ConnManager,
-                muxer: Muxer): Future[Connection] {.async, gcsafe.} =
+                muxer: Muxer): Future[Connection] {.async.} =
   ## get a muxed stream for the passed muxer
   ##
 
@@ -387,7 +387,7 @@ proc getStream*(c: ConnManager,
     return await muxer.newStream()
 
 proc getStream*(c: ConnManager,
-                peerId: PeerId): Future[Connection] {.async, gcsafe.} =
+                peerId: PeerId): Future[Connection] {.async.} =
   ## get a muxed stream for the passed peer from any connection
   ##
 
@@ -395,7 +395,7 @@ proc getStream*(c: ConnManager,
 
 proc getStream*(c: ConnManager,
                 peerId: PeerId,
-                dir: Direction): Future[Connection] {.async, gcsafe.} =
+                dir: Direction): Future[Connection] {.async.} =
   ## get a muxed stream for the passed peer from a connection with `dir`
   ##
 

--- a/libp2p/daemon/daemonapi.nim
+++ b/libp2p/daemon/daemonapi.nim
@@ -553,7 +553,7 @@ proc getSocket(pattern: string,
     closeSocket(sock)
 
 # This is forward declaration needed for newDaemonApi()
-proc listPeers*(api: DaemonAPI): Future[seq[PeerInfo]] {.async, gcsafe.}
+proc listPeers*(api: DaemonAPI): Future[seq[PeerInfo]] {.async.}
 
 proc copyEnv(): StringTableRef =
   ## This procedure copy all environment variables into StringTable.
@@ -755,7 +755,7 @@ proc newDaemonApi*(flags: set[P2PDaemonFlags] = {},
 
   # Starting daemon process
   # echo "Starting ", cmd, " ", args.join(" ")
-  api.process = 
+  api.process =
     exceptionToAssert:
       startProcess(cmd, "", args, env, {poParentStreams})
   # Waiting until daemon will not be bound to control socket.
@@ -1032,7 +1032,7 @@ proc enterDhtMessage(pb: ProtoBuffer, rt: DHTResponseType): ProtoBuffer
     var value: seq[byte]
     if pbDhtResponse.getRequiredField(3, value).isErr():
       raise newException(DaemonLocalError, "Missing required DHT field `value`!")
-    
+
     return initProtoBuffer(value)
   else:
     raise newException(DaemonLocalError, "Wrong message type!")

--- a/libp2p/multistream.nim
+++ b/libp2p/multistream.nim
@@ -131,7 +131,7 @@ proc handle*(
   protos: seq[string],
   matchers = newSeq[Matcher](),
   active: bool = false,
-  ): Future[string] {.async, gcsafe.} =
+  ): Future[string] {.async.} =
   trace "Starting multistream negotiation", conn, handshaked = active
   var handshaked = active
   while not conn.atEof:
@@ -172,10 +172,9 @@ proc handle*(
       trace "no handlers", conn, protocol = ms
       await conn.writeLp(Na)
 
-proc handle*(m: MultistreamSelect, conn: Connection, active: bool = false) {.async, gcsafe.} =
+proc handle*(m: MultistreamSelect, conn: Connection, active: bool = false) {.async.} =
   trace "Starting multistream handler", conn, handshaked = active
   var
-    handshaked = active
     protos: seq[string]
     matchers: seq[Matcher]
   for h in m.handlers:

--- a/libp2p/muxers/mplex/coder.nim
+++ b/libp2p/muxers/mplex/coder.nim
@@ -42,7 +42,7 @@ const MaxMsgSize* = 1 shl 20 # 1mb
 proc newInvalidMplexMsgType*(): ref InvalidMplexMsgType =
   newException(InvalidMplexMsgType, "invalid message type")
 
-proc readMsg*(conn: Connection): Future[Msg] {.async, gcsafe.} =
+proc readMsg*(conn: Connection): Future[Msg] {.async.} =
   let header = await conn.readVarint()
   trace "read header varint", varint = header, conn
 

--- a/libp2p/muxers/mplex/lpchannel.nim
+++ b/libp2p/muxers/mplex/lpchannel.nim
@@ -73,7 +73,7 @@ func shortLog*(s: LPChannel): auto =
 
 chronicles.formatIt(LPChannel): shortLog(it)
 
-proc open*(s: LPChannel) {.async, gcsafe.} =
+proc open*(s: LPChannel) {.async.} =
   trace "Opening channel", s, conn = s.conn
   if s.conn.isClosed:
     return
@@ -95,7 +95,7 @@ proc closeUnderlying(s: LPChannel): Future[void] {.async.} =
   if s.closedLocal and s.atEof():
     await procCall BufferStream(s).close()
 
-proc reset*(s: LPChannel) {.async, gcsafe.} =
+proc reset*(s: LPChannel) {.async.} =
   if s.isClosed:
     trace "Already closed", s
     return
@@ -123,7 +123,7 @@ proc reset*(s: LPChannel) {.async, gcsafe.} =
 
   trace "Channel reset", s
 
-method close*(s: LPChannel) {.async, gcsafe.} =
+method close*(s: LPChannel) {.async.} =
   ## Close channel for writing - a message will be sent to the other peer
   ## informing them that the channel is closed and that we're waiting for
   ## their acknowledgement.

--- a/libp2p/muxers/mplex/mplex.nim
+++ b/libp2p/muxers/mplex/mplex.nim
@@ -122,7 +122,7 @@ proc handleStream(m: Mplex, chann: LPChannel) {.async.} =
     trace "Exception in mplex stream handler", m, chann, msg = exc.msg
     await chann.reset()
 
-method handle*(m: Mplex) {.async, gcsafe.} =
+method handle*(m: Mplex) {.async.} =
   trace "Starting mplex handler", m
   try:
     while not m.connection.atEof:
@@ -211,7 +211,7 @@ proc new*(M: type Mplex,
 
 method newStream*(m: Mplex,
                   name: string = "",
-                  lazy: bool = false): Future[Connection] {.async, gcsafe.} =
+                  lazy: bool = false): Future[Connection] {.async.} =
   let channel = m.newStreamInternal(timeout = m.inChannTimeout)
 
   if not lazy:
@@ -219,7 +219,7 @@ method newStream*(m: Mplex,
 
   return Connection(channel)
 
-method close*(m: Mplex) {.async, gcsafe.} =
+method close*(m: Mplex) {.async.} =
   if m.isClosed:
     trace "Already closed", m
     return

--- a/libp2p/muxers/muxer.nim
+++ b/libp2p/muxers/muxer.nim
@@ -46,11 +46,11 @@ chronicles.formatIt(Muxer): shortLog(it)
 
 # muxer interface
 method newStream*(m: Muxer, name: string = "", lazy: bool = false):
-  Future[Connection] {.base, async, gcsafe.} = discard
-method close*(m: Muxer) {.base, async, gcsafe.} =
+  Future[Connection] {.base, async.} = discard
+method close*(m: Muxer) {.base, async.} =
   if not isNil(m.connection):
     await m.connection.close()
-method handle*(m: Muxer): Future[void] {.base, async, gcsafe.} = discard
+method handle*(m: Muxer): Future[void] {.base, async.} = discard
 
 proc new*(
   T: typedesc[MuxerProvider],

--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -59,7 +59,7 @@ type
     streamId: uint32
     length: uint32
 
-proc readHeader(conn: LPStream): Future[YamuxHeader] {.async, gcsafe.} =
+proc readHeader(conn: LPStream): Future[YamuxHeader] {.async.} =
   var buffer: array[12, byte]
   await conn.readExactly(addr buffer[0], 12)
 
@@ -183,7 +183,7 @@ proc remoteClosed(channel: YamuxChannel) {.async.} =
     channel.closedRemotely.complete()
     await channel.actuallyClose()
 
-method closeImpl*(channel: YamuxChannel) {.async, gcsafe.} =
+method closeImpl*(channel: YamuxChannel) {.async.} =
   if not channel.closedLocally:
     channel.closedLocally = true
 
@@ -346,7 +346,7 @@ method write*(channel: YamuxChannel, msg: seq[byte]): Future[void] =
     libp2p_yamux_recv_queue.observe(channel.sendQueueBytes().int64)
   asyncSpawn channel.trySend()
 
-proc open*(channel: YamuxChannel) {.async, gcsafe.} =
+proc open*(channel: YamuxChannel) {.async.} =
   if channel.opened:
     trace "Try to open channel twice"
     return
@@ -429,7 +429,7 @@ proc handleStream(m: Yamux, channel: YamuxChannel) {.async.} =
     trace "Exception in yamux stream handler", msg = exc.msg
     await channel.reset()
 
-method handle*(m: Yamux) {.async, gcsafe.} =
+method handle*(m: Yamux) {.async.} =
   trace "Starting yamux handler", pid=m.connection.peerId
   try:
     while not m.connection.atEof:
@@ -511,7 +511,7 @@ method getStreams*(m: Yamux): seq[Connection] =
 method newStream*(
   m: Yamux,
   name: string = "",
-  lazy: bool = false): Future[Connection] {.async, gcsafe.} =
+  lazy: bool = false): Future[Connection] {.async.} =
 
   if m.channels.len > m.maxChannCount - 1:
     raise newException(TooManyChannels, "max allowed channel count exceeded")

--- a/libp2p/nameresolving/nameresolver.nim
+++ b/libp2p/nameresolving/nameresolver.nim
@@ -52,7 +52,7 @@ proc resolveOneAddress(
   ma: MultiAddress,
   domain: Domain = Domain.AF_UNSPEC,
   prefix = ""): Future[seq[MultiAddress]]
-  {.async, raises: [MaError, TransportAddressError].} =
+  {.async.} =
   #Resolve a single address
   var pbuf: array[2, byte]
 

--- a/libp2p/protocols/connectivity/autonat/server.nim
+++ b/libp2p/protocols/connectivity/autonat/server.nim
@@ -140,7 +140,7 @@ proc handleDial(autonat: Autonat, conn: Connection, msg: AutonatMsg): Future[voi
 
 proc new*(T: typedesc[Autonat], switch: Switch, semSize: int = 1, dialTimeout = 15.seconds): T =
   let autonat = T(switch: switch, sem: newAsyncSemaphore(semSize), dialTimeout: dialTimeout)
-  proc handleStream(conn: Connection, proto: string) {.async, gcsafe.} =
+  proc handleStream(conn: Connection, proto: string) {.async.} =
     try:
       let msg = AutonatMsg.decode(await conn.readLp(1024)).valueOr:
         raise newException(AutonatError, "Received malformed message")

--- a/libp2p/protocols/connectivity/autonat/service.nim
+++ b/libp2p/protocols/connectivity/autonat/service.nim
@@ -162,7 +162,7 @@ proc schedule(service: AutonatService, switch: Switch, interval: Duration) {.asy
 proc addressMapper(
   self: AutonatService,
   peerStore: PeerStore,
-  listenAddrs: seq[MultiAddress]): Future[seq[MultiAddress]] {.gcsafe, async.} =
+  listenAddrs: seq[MultiAddress]): Future[seq[MultiAddress]] {.async.} =
 
   if self.networkReachability != NetworkReachability.Reachable:
     return listenAddrs
@@ -179,7 +179,7 @@ proc addressMapper(
   return addrs
 
 method setup*(self: AutonatService, switch: Switch): Future[bool] {.async.} =
-  self.addressMapper = proc (listenAddrs: seq[MultiAddress]): Future[seq[MultiAddress]] {.gcsafe, async.} =
+  self.addressMapper = proc (listenAddrs: seq[MultiAddress]): Future[seq[MultiAddress]] {.async.} =
     return await addressMapper(self, switch.peerStore, listenAddrs)
 
   info "Setting up AutonatService"

--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -29,7 +29,7 @@ logScope:
 
 proc new*(T: typedesc[Dcutr], switch: Switch, connectTimeout = 15.seconds, maxDialableAddrs = 8): T =
 
-  proc handleStream(stream: Connection, proto: string) {.async, gcsafe.} =
+  proc handleStream(stream: Connection, proto: string) {.async.} =
     var peerDialableAddrs: seq[MultiAddress]
     try:
       let connectMsg = DcutrMsg.decode(await stream.readLp(1024))

--- a/libp2p/protocols/connectivity/relay/client.nim
+++ b/libp2p/protocols/connectivity/relay/client.nim
@@ -189,7 +189,7 @@ proc dialPeerV2*(
   conn.limitData = msgRcvFromRelay.limit.data
   return conn
 
-proc handleStopStreamV2(cl: RelayClient, conn: Connection) {.async, gcsafe.} =
+proc handleStopStreamV2(cl: RelayClient, conn: Connection) {.async.} =
   let msg = StopMessage.decode(await conn.readLp(RelayClientMsgSize)).valueOr:
     await sendHopStatus(conn, MalformedMessage)
     return
@@ -201,7 +201,7 @@ proc handleStopStreamV2(cl: RelayClient, conn: Connection) {.async, gcsafe.} =
     trace "Unexpected client / relayv2 handshake", msgType=msg.msgType
     await sendStopError(conn, MalformedMessage)
 
-proc handleStop(cl: RelayClient, conn: Connection, msg: RelayMessage) {.async, gcsafe.} =
+proc handleStop(cl: RelayClient, conn: Connection, msg: RelayMessage) {.async.} =
   let src = msg.srcPeer.valueOr:
     await sendStatus(conn, StatusV1.StopSrcMultiaddrInvalid)
     return
@@ -226,7 +226,7 @@ proc handleStop(cl: RelayClient, conn: Connection, msg: RelayMessage) {.async, g
   if cl.onNewConnection != nil: await cl.onNewConnection(conn, 0, 0)
   else: await conn.close()
 
-proc handleStreamV1(cl: RelayClient, conn: Connection) {.async, gcsafe.} =
+proc handleStreamV1(cl: RelayClient, conn: Connection) {.async.} =
   let msg = RelayMessage.decode(await conn.readLp(RelayClientMsgSize)).valueOr:
     await sendStatus(conn, StatusV1.MalformedMessage)
     return
@@ -266,7 +266,7 @@ proc new*(T: typedesc[RelayClient], canHop: bool = false,
              maxCircuitPerPeer: maxCircuitPerPeer,
              msgSize: msgSize,
              isCircuitRelayV1: circuitRelayV1)
-  proc handleStream(conn: Connection, proto: string) {.async, gcsafe.} =
+  proc handleStream(conn: Connection, proto: string) {.async.} =
     try:
       case proto:
       of RelayV1Codec: await cl.handleStreamV1(conn)

--- a/libp2p/protocols/connectivity/relay/relay.nim
+++ b/libp2p/protocols/connectivity/relay/relay.nim
@@ -105,7 +105,7 @@ proc isRelayed*(conn: Connection): bool =
     wrappedConn = wrappedConn.getWrapped()
   return false
 
-proc handleReserve(r: Relay, conn: Connection) {.async, gcsafe.} =
+proc handleReserve(r: Relay, conn: Connection) {.async.} =
   if conn.isRelayed():
     trace "reservation attempt over relay connection", pid = conn.peerId
     await sendHopStatus(conn, PermissionDenied)
@@ -128,7 +128,7 @@ proc handleReserve(r: Relay, conn: Connection) {.async, gcsafe.} =
 
 proc handleConnect(r: Relay,
                    connSrc: Connection,
-                   msg: HopMessage) {.async, gcsafe.} =
+                   msg: HopMessage) {.async.} =
   if connSrc.isRelayed():
     trace "connection attempt over relay connection"
     await sendHopStatus(connSrc, PermissionDenied)
@@ -200,7 +200,7 @@ proc handleConnect(r: Relay,
     await rconnDst.close()
   await bridge(rconnSrc, rconnDst)
 
-proc handleHopStreamV2*(r: Relay, conn: Connection) {.async, gcsafe.} =
+proc handleHopStreamV2*(r: Relay, conn: Connection) {.async.} =
   let msg = HopMessage.decode(await conn.readLp(r.msgSize)).valueOr:
     await sendHopStatus(conn, MalformedMessage)
     return
@@ -214,7 +214,7 @@ proc handleHopStreamV2*(r: Relay, conn: Connection) {.async, gcsafe.} =
 
 # Relay V1
 
-proc handleHop*(r: Relay, connSrc: Connection, msg: RelayMessage) {.async, gcsafe.} =
+proc handleHop*(r: Relay, connSrc: Connection, msg: RelayMessage) {.async.} =
   r.streamCount.inc()
   defer: r.streamCount.dec()
   if r.streamCount + r.rsvp.len() >= r.maxCircuit:
@@ -293,7 +293,7 @@ proc handleHop*(r: Relay, connSrc: Connection, msg: RelayMessage) {.async, gcsaf
   trace "relaying connection", src, dst
   await bridge(connSrc, connDst)
 
-proc handleStreamV1(r: Relay, conn: Connection) {.async, gcsafe.} =
+proc handleStreamV1(r: Relay, conn: Connection) {.async.} =
   let msg = RelayMessage.decode(await conn.readLp(r.msgSize)).valueOr:
     await sendStatus(conn, StatusV1.MalformedMessage)
     return
@@ -336,7 +336,7 @@ proc new*(T: typedesc[Relay],
             msgSize: msgSize,
             isCircuitRelayV1: circuitRelayV1)
 
-  proc handleStream(conn: Connection, proto: string) {.async, gcsafe.} =
+  proc handleStream(conn: Connection, proto: string) {.async.} =
     try:
       case proto:
       of RelayV2HopCodec: await r.handleHopStreamV2(conn)

--- a/libp2p/protocols/connectivity/relay/rtransport.nim
+++ b/libp2p/protocols/connectivity/relay/rtransport.nim
@@ -37,24 +37,24 @@ method start*(self: RelayTransport, ma: seq[MultiAddress]) {.async.} =
   self.client.onNewConnection = proc(
     conn: Connection,
     duration: uint32 = 0,
-    data: uint64 = 0) {.async, gcsafe, raises: [].} =
+    data: uint64 = 0) {.async.} =
       await self.queue.addLast(RelayConnection.new(conn, duration, data))
       await conn.join()
   self.selfRunning = true
   await procCall Transport(self).start(ma)
   trace "Starting Relay transport"
 
-method stop*(self: RelayTransport) {.async, gcsafe.} =
+method stop*(self: RelayTransport) {.async.} =
   self.running = false
   self.selfRunning = false
   self.client.onNewConnection = nil
   while not self.queue.empty():
     await self.queue.popFirstNoWait().close()
 
-method accept*(self: RelayTransport): Future[Connection] {.async, gcsafe.} =
+method accept*(self: RelayTransport): Future[Connection] {.async.} =
   result = await self.queue.popFirst()
 
-proc dial*(self: RelayTransport, ma: MultiAddress): Future[Connection] {.async, gcsafe.} =
+proc dial*(self: RelayTransport, ma: MultiAddress): Future[Connection] {.async.} =
   let
     sma = toSeq(ma.items())
     relayAddrs = sma[0..sma.len-4].mapIt(it.tryGet()).foldl(a & b)
@@ -90,7 +90,7 @@ method dial*(
   self: RelayTransport,
   hostname: string,
   ma: MultiAddress,
-  peerId: Opt[PeerId] = Opt.none(PeerId)): Future[Connection] {.async, gcsafe.} =
+  peerId: Opt[PeerId] = Opt.none(PeerId)): Future[Connection] {.async.} =
   peerId.withValue(pid):
     let address = MultiAddress.init($ma & "/p2p/" & $pid).tryGet()
     result = await self.dial(address)

--- a/libp2p/protocols/connectivity/relay/utils.nim
+++ b/libp2p/protocols/connectivity/relay/utils.nim
@@ -21,14 +21,14 @@ const
   RelayV2HopCodec* = "/libp2p/circuit/relay/0.2.0/hop"
   RelayV2StopCodec* = "/libp2p/circuit/relay/0.2.0/stop"
 
-proc sendStatus*(conn: Connection, code: StatusV1) {.async, gcsafe.} =
+proc sendStatus*(conn: Connection, code: StatusV1) {.async.} =
   trace "send relay/v1 status", status = $code & "(" & $ord(code) & ")"
   let
     msg = RelayMessage(msgType: Opt.some(RelayType.Status), status: Opt.some(code))
     pb = encode(msg)
   await conn.writeLp(pb.buffer)
 
-proc sendHopStatus*(conn: Connection, code: StatusV2) {.async, gcsafe.} =
+proc sendHopStatus*(conn: Connection, code: StatusV2) {.async.} =
   trace "send hop relay/v2 status", status = $code & "(" & $ord(code) & ")"
   let
     msg = HopMessage(msgType: HopMessageType.Status, status: Opt.some(code))

--- a/libp2p/protocols/identify.nim
+++ b/libp2p/protocols/identify.nim
@@ -150,7 +150,7 @@ proc new*(
   identify
 
 method init*(p: Identify) =
-  proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
+  proc handle(conn: Connection, proto: string) {.async.} =
     try:
       trace "handling identify request", conn
       var pb = encodeMsg(p.peerInfo, conn.observedAddr, p.sendSignedPeerRecord)
@@ -168,7 +168,7 @@ method init*(p: Identify) =
 
 proc identify*(self: Identify,
                conn: Connection,
-               remotePeerId: PeerId): Future[IdentifyInfo] {.async, gcsafe.} =
+               remotePeerId: PeerId): Future[IdentifyInfo] {.async.} =
   trace "initiating identify", conn
   var message = await conn.readLp(64*1024)
   if len(message) == 0:
@@ -198,7 +198,7 @@ proc new*(T: typedesc[IdentifyPush], handler: IdentifyPushHandler = nil): T {.pu
   identifypush
 
 proc init*(p: IdentifyPush) =
-  proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
+  proc handle(conn: Connection, proto: string) {.async.} =
     trace "handling identify push", conn
     try:
       var message = await conn.readLp(64*1024)

--- a/libp2p/protocols/perf/server.nim
+++ b/libp2p/protocols/perf/server.nim
@@ -27,7 +27,7 @@ type Perf* = ref object of LPProtocol
 
 proc new*(T: typedesc[Perf]): T {.public.} =
   var p = T()
-  proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
+  proc handle(conn: Connection, proto: string) {.async.} =
     var bytesRead = 0
     try:
       trace "Received benchmark performance check", conn

--- a/libp2p/protocols/ping.nim
+++ b/libp2p/protocols/ping.nim
@@ -51,7 +51,7 @@ proc new*(T: typedesc[Ping], handler: PingHandler = nil, rng: ref HmacDrbgContex
   ping
 
 method init*(p: Ping) =
-  proc handle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
+  proc handle(conn: Connection, proto: string) {.async.} =
     try:
       trace "handling ping", conn
       var buf: array[PingSize, byte]
@@ -71,7 +71,7 @@ method init*(p: Ping) =
 proc ping*(
   p: Ping,
   conn: Connection,
-  ): Future[Duration] {.async, gcsafe, public.} =
+  ): Future[Duration] {.async, public.} =
   ## Sends ping to `conn`, returns the delay
 
   trace "initiating ping", conn

--- a/libp2p/protocols/pubsub/gossipsub.nim
+++ b/libp2p/protocols/pubsub/gossipsub.nim
@@ -384,7 +384,7 @@ proc validateAndRelay(g: GossipSub,
 proc dataAndTopicsIdSize(msgs: seq[Message]): int =
   msgs.mapIt(it.data.len + it.topicIds.mapIt(it.len).foldl(a + b, 0)).foldl(a + b, 0)
 
-proc rateLimit*(g: GossipSub, peer: PubSubPeer, rpcMsgOpt: Opt[RPCMsg], msgSize: int) {.raises:[PeerRateLimitError, CatchableError], async.} =
+proc rateLimit*(g: GossipSub, peer: PubSubPeer, rpcMsgOpt: Opt[RPCMsg], msgSize: int) {.async.} =
   # In this way we count even ignored fields by protobuf
 
   var rmsg = rpcMsgOpt.valueOr:

--- a/libp2p/protocols/pubsub/pubsubpeer.nim
+++ b/libp2p/protocols/pubsub/pubsubpeer.nim
@@ -234,7 +234,7 @@ template sendMetrics(msg: RPCMsg): untyped =
         # metrics
         libp2p_pubsub_sent_messages.inc(labelValues = [$p.peerId, t])
 
-proc sendEncoded*(p: PubSubPeer, msg: seq[byte]) {.raises: [], async.} =
+proc sendEncoded*(p: PubSubPeer, msg: seq[byte]) {.async.} =
   doAssert(not isNil(p), "pubsubpeer nil!")
 
   if msg.len <= 0:

--- a/libp2p/protocols/rendezvous.nim
+++ b/libp2p/protocols/rendezvous.nim
@@ -636,7 +636,7 @@ proc new*(T: typedesc[RendezVous],
     sema: newAsyncSemaphore(SemaphoreDefaultSize)
   )
   logScope: topics = "libp2p discovery rendezvous"
-  proc handleStream(conn: Connection, proto: string) {.async, gcsafe.} =
+  proc handleStream(conn: Connection, proto: string) {.async.} =
     try:
       let
         buf = await conn.readLp(4096)

--- a/libp2p/protocols/secure/plaintext.nim
+++ b/libp2p/protocols/secure/plaintext.nim
@@ -19,7 +19,7 @@ type
 
 method init(p: PlainText) {.gcsafe.} =
   proc handle(conn: Connection, proto: string)
-    {.async, gcsafe.} = discard
+    {.async.} = discard
     ## plain text doesn't do anything
 
   p.codec = PlainTextCodec

--- a/libp2p/services/hpservice.nim
+++ b/libp2p/services/hpservice.nim
@@ -94,7 +94,7 @@ method setup*(self: HPService, switch: Switch): Future[bool] {.async.} =
 
     switch.connManager.addPeerEventHandler(self.newConnectedPeerHandler, PeerEventKind.Joined)
 
-    self.onNewStatusHandler = proc (networkReachability: NetworkReachability, confidence: Opt[float]) {.gcsafe, async.} =
+    self.onNewStatusHandler = proc (networkReachability: NetworkReachability, confidence: Opt[float]) {.async.} =
       if networkReachability == NetworkReachability.NotReachable and not self.autoRelayService.isRunning():
         discard await self.autoRelayService.setup(switch)
       elif networkReachability == NetworkReachability.Reachable and self.autoRelayService.isRunning():

--- a/libp2p/stream/chronosstream.nim
+++ b/libp2p/stream/chronosstream.nim
@@ -50,7 +50,7 @@ method initStream*(s: ChronosStream) =
   if s.objName.len == 0:
     s.objName = ChronosStreamTrackerName
 
-  s.timeoutHandler = proc() {.async, gcsafe.} =
+  s.timeoutHandler = proc() {.async.} =
     trace "Idle timeout expired, closing ChronosStream", s
     await s.close()
 

--- a/libp2p/stream/connection.nim
+++ b/libp2p/stream/connection.nim
@@ -41,7 +41,7 @@ type
     when defined(libp2p_agents_metrics):
       shortAgent*: string
 
-proc timeoutMonitor(s: Connection) {.async, gcsafe.}
+proc timeoutMonitor(s: Connection) {.async.}
 
 func shortLog*(conn: Connection): string =
   try:
@@ -110,7 +110,7 @@ proc pollActivity(s: Connection): Future[bool] {.async.} =
 
   return false
 
-proc timeoutMonitor(s: Connection) {.async, gcsafe.} =
+proc timeoutMonitor(s: Connection) {.async.} =
   ## monitor the channel for inactivity
   ##
   ## if the timeout was hit, it means that

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -246,7 +246,7 @@ proc readLine*(s: LPStream,
       if len(result) == lim:
         break
 
-proc readVarint*(conn: LPStream): Future[uint64] {.async, gcsafe, public.} =
+proc readVarint*(conn: LPStream): Future[uint64] {.async, public.} =
   var
     buffer: array[10, byte]
 
@@ -264,7 +264,7 @@ proc readVarint*(conn: LPStream): Future[uint64] {.async, gcsafe, public.} =
   if true: # can't end with a raise apparently
     raise (ref InvalidVarintError)(msg: "Cannot parse varint")
 
-proc readLp*(s: LPStream, maxSize: int): Future[seq[byte]] {.async, gcsafe, public.} =
+proc readLp*(s: LPStream, maxSize: int): Future[seq[byte]] {.async, public.} =
   ## read length prefixed msg, with the length encoded as a varint
   let
     length = await s.readVarint()

--- a/libp2p/switch.nim
+++ b/libp2p/switch.nim
@@ -71,17 +71,17 @@ type
       inUse: bool
 
 
-method setup*(self: Service, switch: Switch): Future[bool] {.base, async, gcsafe.} =
+method setup*(self: Service, switch: Switch): Future[bool] {.base, async.} =
   if self.inUse:
     warn "service setup has already been called"
     return false
   self.inUse = true
   return true
 
-method run*(self: Service, switch: Switch) {.base, async, gcsafe.} =
+method run*(self: Service, switch: Switch) {.base, async.} =
   doAssert(false, "Not implemented!")
 
-method stop*(self: Service, switch: Switch): Future[bool] {.base, async, gcsafe.} =
+method stop*(self: Service, switch: Switch): Future[bool] {.base, async.} =
   if not self.inUse:
     warn "service is already stopped"
     return false
@@ -321,7 +321,7 @@ proc stop*(s: Switch) {.async, public.} =
 
   trace "Switch stopped"
 
-proc start*(s: Switch) {.async, gcsafe, public.} =
+proc start*(s: Switch) {.async, public.} =
   ## Start listening on every transport
 
   if s.started:

--- a/libp2p/transports/tcptransport.nim
+++ b/libp2p/transports/tcptransport.nim
@@ -174,7 +174,7 @@ method start*(
 
     trace "Listening on", address = ma
 
-method stop*(self: TcpTransport) {.async, gcsafe.} =
+method stop*(self: TcpTransport) {.async.} =
   ## stop the transport
   ##
   try:
@@ -210,7 +210,7 @@ method stop*(self: TcpTransport) {.async, gcsafe.} =
   except CatchableError as exc:
     trace "Error shutting down tcp transport", exc = exc.msg
 
-method accept*(self: TcpTransport): Future[Connection] {.async, gcsafe.} =
+method accept*(self: TcpTransport): Future[Connection] {.async.} =
   ## accept a new TCP connection
   ##
 
@@ -260,7 +260,7 @@ method dial*(
   self: TcpTransport,
   hostname: string,
   address: MultiAddress,
-  peerId: Opt[PeerId] = Opt.none(PeerId)): Future[Connection] {.async, gcsafe.} =
+  peerId: Opt[PeerId] = Opt.none(PeerId)): Future[Connection] {.async.} =
   ## dial a peer
   ##
 

--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -173,7 +173,7 @@ method start*(
 
   self.running = true
 
-method stop*(self: WsTransport) {.async, gcsafe.} =
+method stop*(self: WsTransport) {.async.} =
   ## stop the transport
   ##
 
@@ -237,7 +237,7 @@ proc connHandler(self: WsTransport,
   asyncSpawn onClose()
   return conn
 
-method accept*(self: WsTransport): Future[Connection] {.async, gcsafe.} =
+method accept*(self: WsTransport): Future[Connection] {.async.} =
   ## accept a new WS connection
   ##
 
@@ -295,7 +295,7 @@ method dial*(
   self: WsTransport,
   hostname: string,
   address: MultiAddress,
-  peerId: Opt[PeerId] = Opt.none(PeerId)): Future[Connection] {.async, gcsafe.} =
+  peerId: Opt[PeerId] = Opt.none(PeerId)): Future[Connection] {.async.} =
   ## dial a peer
   ##
 

--- a/libp2p/upgrademngrs/muxedupgrade.nim
+++ b/libp2p/upgrademngrs/muxedupgrade.nim
@@ -33,7 +33,7 @@ proc getMuxerByCodec(self: MuxedUpgrade, muxerName: string): MuxerProvider =
 proc mux*(
   self: MuxedUpgrade,
   conn: Connection,
-  direction: Direction): Future[Muxer] {.async, gcsafe.} =
+  direction: Direction): Future[Muxer] {.async.} =
   ## mux connection
 
   trace "Muxing connection", conn
@@ -98,8 +98,7 @@ proc new*(
     secureManagers: @secureManagers,
     ms: ms)
 
-  upgrader.streamHandler = proc(conn: Connection)
-    {.async, gcsafe, raises: [].} =
+  upgrader.streamHandler = proc(conn: Connection) {.async.} =
     trace "Starting stream handler", conn
     try:
       await upgrader.ms.handle(conn) # handle incoming connection

--- a/libp2p/upgrademngrs/upgrade.nim
+++ b/libp2p/upgrademngrs/upgrade.nim
@@ -48,7 +48,7 @@ proc secure*(
   self: Upgrade,
   conn: Connection,
   direction: Direction,
-  peerId: Opt[PeerId]): Future[Connection] {.async, gcsafe.} =
+  peerId: Opt[PeerId]): Future[Connection] {.async.} =
   if self.secureManagers.len <= 0:
     raise newException(UpgradeFailedError, "No secure managers registered!")
 

--- a/tests/asyncunit.nim
+++ b/tests/asyncunit.nim
@@ -5,21 +5,21 @@ export unittest2, chronos
 template asyncTeardown*(body: untyped): untyped =
   teardown:
     waitFor((
-      proc() {.async, gcsafe.} =
+      proc() {.async.} =
         body
     )())
 
 template asyncSetup*(body: untyped): untyped =
   setup:
     waitFor((
-      proc() {.async, gcsafe.} =
+      proc() {.async.} =
         body
     )())
 
 template asyncTest*(name: string, body: untyped): untyped =
   test name:
     waitFor((
-      proc() {.async, gcsafe.} =
+      proc() {.async.} =
         body
     )())
 
@@ -31,7 +31,7 @@ template flakyAsyncTest*(name: string, attempts: int, body: untyped): untyped =
       inc attemptNumber
       try:
         waitFor((
-          proc() {.async, gcsafe.} =
+          proc() {.async.} =
             body
         )())
       except Exception as e:

--- a/tests/commoninterop.nim
+++ b/tests/commoninterop.nim
@@ -20,7 +20,7 @@ proc writeLp(s: StreamTransport, msg: string | seq[byte]): Future[int] {.gcsafe.
   buf.finish()
   result = s.write(buf.buffer)
 
-proc readLp(s: StreamTransport): Future[seq[byte]] {.async, gcsafe.} =
+proc readLp(s: StreamTransport): Future[seq[byte]] {.async.} =
   ## read length prefixed msg
   var
     size: uint

--- a/tests/commontransport.nim
+++ b/tests/commontransport.nim
@@ -30,7 +30,7 @@ template commonTransportTest*(prov: TransportProvider, ma1: string, ma2: string 
 
       let transport2 = transpProvider()
 
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         if conn.observedAddr.isSome():
           check transport1.handles(conn.observedAddr.get())
@@ -58,7 +58,7 @@ template commonTransportTest*(prov: TransportProvider, ma1: string, ma2: string 
       let transport1 = transpProvider()
       await transport1.start(ma)
 
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         await conn.write("Hello!")
         await conn.close()
@@ -85,7 +85,7 @@ template commonTransportTest*(prov: TransportProvider, ma1: string, ma2: string 
       let transport1 = transpProvider()
       await transport1.start(ma)
 
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         var msg = newSeq[byte](6)
         await conn.readExactly(addr msg[0], 6)
@@ -147,7 +147,7 @@ template commonTransportTest*(prov: TransportProvider, ma1: string, ma2: string 
       let transport1 = transpProvider()
       await transport1.start(addrs)
 
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         while true:
           let conn = await transport1.accept()
           await conn.write(newSeq[byte](0))
@@ -214,7 +214,7 @@ template commonTransportTest*(prov: TransportProvider, ma1: string, ma2: string 
       let transport1 = transpProvider()
       await transport1.start(ma)
 
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         await conn.close()
 

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -111,7 +111,7 @@ proc bridgedConnections*: (Connection, Connection) =
   return (connA, connB)
 
 
-proc checkExpiringInternal(cond: proc(): bool {.raises: [], gcsafe.} ): Future[bool] {.async, gcsafe.} =
+proc checkExpiringInternal(cond: proc(): bool {.raises: [], gcsafe.} ): Future[bool] {.async.} =
   let start = Moment.now()
   while true:
     if Moment.now() > (start + chronos.seconds(5)):
@@ -146,8 +146,8 @@ proc default*(T: typedesc[MockResolver]): T =
   resolver.ipResponses[("localhost", true)] = @["::1"]
   resolver
 
-proc setDNSAddr*(switch: Switch) {.gcsafe, async.} =
-  proc addressMapper(listenAddrs: seq[MultiAddress]): Future[seq[MultiAddress]] {.gcsafe, async.} =
+proc setDNSAddr*(switch: Switch) {.async.} =
+  proc addressMapper(listenAddrs: seq[MultiAddress]): Future[seq[MultiAddress]] {.async.} =
       return @[MultiAddress.init("/dns4/localhost/").tryGet() & listenAddrs[0][1].tryGet()]
   switch.peerInfo.addressMappers.add(addressMapper)
   await switch.peerInfo.update()

--- a/tests/pubsub/testfloodsub.nim
+++ b/tests/pubsub/testfloodsub.nim
@@ -26,7 +26,7 @@ import ../../libp2p/protocols/pubsub/errors as pubsub_errors
 
 import ../helpers
 
-proc waitSub(sender, receiver: auto; key: string) {.async, gcsafe.} =
+proc waitSub(sender, receiver: auto; key: string) {.async.} =
   # turn things deterministic
   # this is for testing purposes only
   var ceil = 15
@@ -43,7 +43,7 @@ suite "FloodSub":
 
   asyncTest "FloodSub basic publish/subscribe A -> B":
     var completionFut = newFuture[bool]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
       completionFut.complete(true)
 
@@ -81,7 +81,7 @@ suite "FloodSub":
 
   asyncTest "FloodSub basic publish/subscribe B -> A":
     var completionFut = newFuture[bool]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
       completionFut.complete(true)
 
@@ -113,7 +113,7 @@ suite "FloodSub":
 
   asyncTest "FloodSub validation should succeed":
     var handlerFut = newFuture[bool]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
       handlerFut.complete(true)
 
@@ -151,7 +151,7 @@ suite "FloodSub":
     await allFuturesThrowing(nodesFut)
 
   asyncTest "FloodSub validation should fail":
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check false # if we get here, it should fail
 
     let
@@ -186,7 +186,7 @@ suite "FloodSub":
 
   asyncTest "FloodSub validation one fails and one succeeds":
     var handlerFut = newFuture[bool]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foo"
       handlerFut.complete(true)
 
@@ -235,7 +235,7 @@ suite "FloodSub":
           counter = new int
         futs[i] = (
           fut,
-          (proc(topic: string, data: seq[byte]) {.async, gcsafe.} =
+          (proc(topic: string, data: seq[byte]) {.async.} =
             check topic == "foobar"
             inc counter[]
             if counter[] == runs - 1:
@@ -283,7 +283,7 @@ suite "FloodSub":
           counter = new int
         futs[i] = (
           fut,
-          (proc(topic: string, data: seq[byte]) {.async, gcsafe.} =
+          (proc(topic: string, data: seq[byte]) {.async.} =
             check topic == "foobar"
             inc counter[]
             if counter[] == runs - 1:
@@ -333,7 +333,7 @@ suite "FloodSub":
 
   asyncTest "FloodSub message size validation":
     var messageReceived = 0
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check data.len < 50
       inc(messageReceived)
 
@@ -375,7 +375,7 @@ suite "FloodSub":
 
   asyncTest "FloodSub message size validation 2":
     var messageReceived = 0
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       inc(messageReceived)
 
     let

--- a/tests/pubsub/testgossipinternal.nim
+++ b/tests/pubsub/testgossipinternal.nim
@@ -24,7 +24,7 @@ import utils
 
 import ../helpers
 
-proc noop(data: seq[byte]) {.async, gcsafe.} = discard
+proc noop(data: seq[byte]) {.async.} = discard
 
 const MsgIdSuccess = "msg id gen success"
 
@@ -730,10 +730,10 @@ suite "GossipSub internal":
 
     var receivedMessages = new(HashSet[seq[byte]])
 
-    proc handlerA(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handlerA(topic: string, data: seq[byte]) {.async.} =
       receivedMessages[].incl(data)
 
-    proc handlerB(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handlerB(topic: string, data: seq[byte]) {.async.} =
       discard
 
     nodes[0].subscribe("foobar", handlerA)

--- a/tests/pubsub/testgossipsub.nim
+++ b/tests/pubsub/testgossipsub.nim
@@ -47,7 +47,7 @@ suite "GossipSub":
 
   asyncTest "GossipSub validation should succeed":
     var handlerFut = newFuture[bool]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
       handlerFut.complete(true)
 
@@ -92,7 +92,7 @@ suite "GossipSub":
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "GossipSub validation should fail (reject)":
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check false # if we get here, it should fail
 
     let
@@ -138,7 +138,7 @@ suite "GossipSub":
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "GossipSub validation should fail (ignore)":
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check false # if we get here, it should fail
 
     let
@@ -185,7 +185,7 @@ suite "GossipSub":
 
   asyncTest "GossipSub validation one fails and one succeeds":
     var handlerFut = newFuture[bool]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foo"
       handlerFut.complete(true)
 
@@ -238,7 +238,7 @@ suite "GossipSub":
 
   asyncTest "GossipSub unsub - resub faster than backoff":
     var handlerFut = newFuture[bool]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
       handlerFut.complete(true)
 
@@ -289,7 +289,7 @@ suite "GossipSub":
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "e2e - GossipSub should add remote peer topic subscriptions":
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       discard
 
     let
@@ -323,7 +323,7 @@ suite "GossipSub":
     await allFuturesThrowing(nodesFut.concat())
 
   asyncTest "e2e - GossipSub should add remote peer topic subscriptions if both peers are subscribed":
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       discard
 
     let
@@ -374,7 +374,7 @@ suite "GossipSub":
 
   asyncTest "e2e - GossipSub send over fanout A -> B":
     var passed = newFuture[void]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
       passed.complete()
 
@@ -428,7 +428,7 @@ suite "GossipSub":
 
   asyncTest "e2e - GossipSub send over fanout A -> B for subscribed topic":
     var passed = newFuture[void]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
       passed.complete()
 
@@ -481,7 +481,7 @@ suite "GossipSub":
 
   asyncTest "e2e - GossipSub send over mesh A -> B":
     var passed: Future[bool] = newFuture[bool]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
       passed.complete(true)
 
@@ -548,11 +548,11 @@ suite "GossipSub":
     var
       aReceived = 0
       cReceived = 0
-    proc handlerA(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handlerA(topic: string, data: seq[byte]) {.async.} =
       inc aReceived
       check aReceived < 2
-    proc handlerB(topic: string, data: seq[byte]) {.async, gcsafe.} = discard
-    proc handlerC(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handlerB(topic: string, data: seq[byte]) {.async.} = discard
+    proc handlerC(topic: string, data: seq[byte]) {.async.} =
       inc cReceived
       check cReceived < 2
       cRelayed.complete()
@@ -596,7 +596,7 @@ suite "GossipSub":
 
   asyncTest "e2e - GossipSub send over floodPublish A -> B":
     var passed: Future[bool] = newFuture[bool]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
       passed.complete(true)
 
@@ -653,7 +653,7 @@ suite "GossipSub":
     )
 
   proc connectNodes(nodes: seq[PubSub], target: PubSub) {.async.} =
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
 
     for node in nodes:
@@ -661,7 +661,7 @@ suite "GossipSub":
       await node.switch.connect(target.peerInfo.peerId, target.peerInfo.addrs)
 
   proc baseTestProcedure(nodes: seq[PubSub], gossip1: GossipSub, numPeersFirstMsg: int, numPeersSecondMsg: int) {.async.} =
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
 
     block setup:
@@ -727,7 +727,7 @@ suite "GossipSub":
       var handler: TopicHandler
       closureScope:
         var peerName = $dialer.peerInfo.peerId
-        handler = proc(topic: string, data: seq[byte]) {.async, gcsafe, closure.} =
+        handler = proc(topic: string, data: seq[byte]) {.async, closure.} =
           if peerName notin seen:
             seen[peerName] = 0
           seen[peerName].inc
@@ -778,7 +778,7 @@ suite "GossipSub":
       var handler: TopicHandler
       capture dialer, i:
         var peerName = $dialer.peerInfo.peerId
-        handler = proc(topic: string, data: seq[byte]) {.async, gcsafe, closure.} =
+        handler = proc(topic: string, data: seq[byte]) {.async, closure.} =
           if peerName notin seen:
             seen[peerName] = 0
           seen[peerName].inc
@@ -819,7 +819,7 @@ suite "GossipSub":
     # PX to A & C
     #
     # C sent his SPR, not A
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       discard # not used in this test
 
     let
@@ -895,9 +895,9 @@ suite "GossipSub":
     await nodes[1].switch.connect(nodes[2].switch.peerInfo.peerId, nodes[2].switch.peerInfo.addrs)
 
     let bFinished = newFuture[void]()
-    proc handlerA(topic: string, data: seq[byte]) {.async, gcsafe.} = discard
-    proc handlerB(topic: string, data: seq[byte]) {.async, gcsafe.} = bFinished.complete()
-    proc handlerC(topic: string, data: seq[byte]) {.async, gcsafe.} = doAssert false
+    proc handlerA(topic: string, data: seq[byte]) {.async.} = discard
+    proc handlerB(topic: string, data: seq[byte]) {.async.} = bFinished.complete()
+    proc handlerC(topic: string, data: seq[byte]) {.async.} = doAssert false
 
     nodes[0].subscribe("foobar", handlerA)
     nodes[1].subscribe("foobar", handlerB)
@@ -943,7 +943,7 @@ suite "GossipSub":
 
     await subscribeNodes(nodes)
 
-    proc handle(topic: string, data: seq[byte]) {.async, gcsafe.} = discard
+    proc handle(topic: string, data: seq[byte]) {.async.} = discard
 
     let gossip0 = GossipSub(nodes[0])
     let gossip1 = GossipSub(nodes[1])

--- a/tests/pubsub/testgossipsub2.nim
+++ b/tests/pubsub/testgossipsub2.nim
@@ -59,7 +59,7 @@ suite "GossipSub":
       var handler: TopicHandler
       closureScope:
         var peerName = $dialer.peerInfo.peerId
-        handler = proc(topic: string, data: seq[byte]) {.async, gcsafe, closure.} =
+        handler = proc(topic: string, data: seq[byte]) {.async, closure.} =
           if peerName notin seen:
             seen[peerName] = 0
           seen[peerName].inc
@@ -93,7 +93,7 @@ suite "GossipSub":
 
   asyncTest "GossipSub invalid topic subscription":
     var handlerFut = newFuture[bool]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
       handlerFut.complete(true)
 
@@ -155,7 +155,7 @@ suite "GossipSub":
     # DO NOT SUBSCRIBE, CONNECTION SHOULD HAPPEN
     ### await subscribeNodes(nodes)
 
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} = discard
+    proc handler(topic: string, data: seq[byte]) {.async.} = discard
     nodes[1].subscribe("foobar", handler)
 
     await invalidDetected.wait(10.seconds)
@@ -182,10 +182,10 @@ suite "GossipSub":
     await GossipSub(nodes[2]).addDirectPeer(nodes[1].switch.peerInfo.peerId, nodes[1].switch.peerInfo.addrs)
 
     var handlerFut = newFuture[void]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
       handlerFut.complete()
-    proc noop(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc noop(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
 
     nodes[0].subscribe("foobar", noop)
@@ -226,7 +226,7 @@ suite "GossipSub":
     GossipSub(nodes[1]).parameters.graylistThreshold = 100000
 
     var handlerFut = newFuture[void]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
       handlerFut.complete()
 
@@ -272,7 +272,7 @@ suite "GossipSub":
       var handler: TopicHandler
       closureScope:
         var peerName = $dialer.peerInfo.peerId
-        handler = proc(topic: string, data: seq[byte]) {.async, gcsafe, closure.} =
+        handler = proc(topic: string, data: seq[byte]) {.async, closure.} =
           if peerName notin seen:
             seen[peerName] = 0
           seen[peerName].inc
@@ -324,7 +324,7 @@ suite "GossipSub":
 
     # Adding again subscriptions
 
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       check topic == "foobar"
 
     for i in 0..<runs:
@@ -368,7 +368,7 @@ suite "GossipSub":
       )
 
     var handlerFut = newFuture[void]()
-    proc handler(topic: string, data: seq[byte]) {.async, gcsafe.} =
+    proc handler(topic: string, data: seq[byte]) {.async.} =
       handlerFut.complete()
 
     await subscribeNodes(nodes)

--- a/tests/pubsub/utils.nim
+++ b/tests/pubsub/utils.nim
@@ -128,7 +128,7 @@ proc subscribeRandom*(nodes: seq[PubSub]) {.async.} =
           await dialer.switch.connect(node.peerInfo.peerId, node.peerInfo.addrs)
           dialed.add(node.peerInfo.peerId)
 
-proc waitSub*(sender, receiver: auto; key: string) {.async, gcsafe.} =
+proc waitSub*(sender, receiver: auto; key: string) {.async.} =
   if sender == receiver:
     return
   let timeout = Moment.now() + 5.seconds
@@ -148,7 +148,7 @@ proc waitSub*(sender, receiver: auto; key: string) {.async, gcsafe.} =
     await sleepAsync(5.milliseconds)
     doAssert Moment.now() < timeout, "waitSub timeout!"
 
-proc waitSubGraph*(nodes: seq[PubSub], key: string) {.async, gcsafe.} =
+proc waitSubGraph*(nodes: seq[PubSub], key: string) {.async.} =
   let timeout = Moment.now() + 5.seconds
   while true:
     var

--- a/tests/stubs/switchstub.nim
+++ b/tests/stubs/switchstub.nim
@@ -24,7 +24,7 @@ type
                            addrs: seq[MultiAddress],
                            forceDial = false,
                            reuseConnection = true,
-                           upgradeDir = Direction.Out): Future[void]  {.gcsafe, async.}
+                           upgradeDir = Direction.Out): Future[void]  {.async.}
 
 method connect*(
  self: SwitchStub,

--- a/tests/testautonat.nim
+++ b/tests/testautonat.nim
@@ -39,7 +39,7 @@ proc createAutonatSwitch(nameResolver: NameResolver = nil): Switch =
 
 proc makeAutonatServicePrivate(): Switch =
   var autonatProtocol = new LPProtocol
-  autonatProtocol.handler = proc (conn: Connection, proto: string) {.async, gcsafe.} =
+  autonatProtocol.handler = proc (conn: Connection, proto: string) {.async.} =
     discard await conn.readLp(1024)
     await conn.writeLp(AutonatDialResponse(
       status: DialError,

--- a/tests/testautonatservice.nim
+++ b/tests/testautonatservice.nim
@@ -87,7 +87,7 @@ suite "Autonat Service":
 
     let awaiter = newFuture[void]()
 
-    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.gcsafe, async.} =
+    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.async.} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and confidence.get() >= 0.3:
         if not awaiter.finished:
           awaiter.complete()
@@ -131,7 +131,7 @@ suite "Autonat Service":
 
     let awaiter = newFuture[void]()
 
-    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.gcsafe, async.} =
+    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.async.} =
       if networkReachability == NetworkReachability.NotReachable and confidence.isSome() and confidence.get() >= 0.3:
         if not awaiter.finished:
           autonatClientStub.answer = Reachable
@@ -173,7 +173,7 @@ suite "Autonat Service":
 
     let awaiter = newFuture[void]()
 
-    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.gcsafe, async.} =
+    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.async.} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and confidence.get() == 1:
         if not awaiter.finished:
           awaiter.complete()
@@ -213,7 +213,7 @@ suite "Autonat Service":
 
     let awaiter = newFuture[void]()
 
-    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.gcsafe, async.} =
+    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.async.} =
       if networkReachability == NetworkReachability.NotReachable and confidence.isSome() and confidence.get() >= 0.3:
         if not awaiter.finished:
           autonatClientStub.answer = Unknown
@@ -267,7 +267,7 @@ suite "Autonat Service":
 
     let awaiter = newFuture[void]()
 
-    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.gcsafe, async.} =
+    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.async.} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and confidence.get() == 1:
         if not awaiter.finished:
           awaiter.complete()
@@ -302,12 +302,12 @@ suite "Autonat Service":
     let awaiter2 = newFuture[void]()
     let awaiter3 = newFuture[void]()
 
-    proc statusAndConfidenceHandler1(networkReachability: NetworkReachability, confidence: Opt[float]) {.gcsafe, async.} =
+    proc statusAndConfidenceHandler1(networkReachability: NetworkReachability, confidence: Opt[float]) {.async.} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and confidence.get() == 1:
         if not awaiter1.finished:
           awaiter1.complete()
 
-    proc statusAndConfidenceHandler2(networkReachability: NetworkReachability, confidence: Opt[float]) {.gcsafe, async.} =
+    proc statusAndConfidenceHandler2(networkReachability: NetworkReachability, confidence: Opt[float]) {.async.} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and confidence.get() == 1:
         if not awaiter2.finished:
           awaiter2.complete()
@@ -345,7 +345,7 @@ suite "Autonat Service":
 
     let awaiter1 = newFuture[void]()
 
-    proc statusAndConfidenceHandler1(networkReachability: NetworkReachability, confidence: Opt[float]) {.gcsafe, async.} =
+    proc statusAndConfidenceHandler1(networkReachability: NetworkReachability, confidence: Opt[float]) {.async.} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and confidence.get() == 1:
         if not awaiter1.finished:
           awaiter1.complete()
@@ -388,7 +388,7 @@ suite "Autonat Service":
 
     var awaiter = newFuture[void]()
 
-    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.gcsafe, async.} =
+    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.async.} =
       if networkReachability == NetworkReachability.Reachable and confidence.isSome() and confidence.get() == 1:
         if not awaiter.finished:
           awaiter.complete()
@@ -428,7 +428,7 @@ suite "Autonat Service":
     let switch1 = createSwitch(autonatService)
     let switch2 = createSwitch()
 
-    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.gcsafe, async.} =
+    proc statusAndConfidenceHandler(networkReachability: NetworkReachability, confidence: Opt[float]) {.async.} =
       fail()
 
     check autonatService.networkReachability == NetworkReachability.Unknown

--- a/tests/testconnmngr.nim
+++ b/tests/testconnmngr.nim
@@ -32,7 +32,7 @@ method newStream*(
   m: TestMuxer,
   name: string = "",
   lazy: bool = false):
-  Future[Connection] {.async, gcsafe.} =
+  Future[Connection] {.async.} =
   result = Connection.new(m.peerId, Direction.Out, Opt.none(MultiAddress))
 
 suite "Connection Manager":

--- a/tests/testhpservice.nim
+++ b/tests/testhpservice.nim
@@ -65,7 +65,7 @@ suite "Hole Punching":
 
     let publicPeerSwitch = createSwitch(RelayClient.new())
 
-    proc addressMapper(listenAddrs: seq[MultiAddress]): Future[seq[MultiAddress]] {.gcsafe, async.} =
+    proc addressMapper(listenAddrs: seq[MultiAddress]): Future[seq[MultiAddress]] {.async.} =
         return @[MultiAddress.init("/dns4/localhost/").tryGet() & listenAddrs[0][1].tryGet()]
     publicPeerSwitch.peerInfo.addressMappers.add(addressMapper)
     await publicPeerSwitch.peerInfo.update()

--- a/tests/testidentify.nim
+++ b/tests/testidentify.nim
@@ -73,7 +73,7 @@ suite "Identify":
 
     asyncTest "default agent version":
       msListen.addHandler(IdentifyCodec, identifyProto1)
-      proc acceptHandler(): Future[void] {.async, gcsafe.} =
+      proc acceptHandler(): Future[void] {.async.} =
         let c = await transport1.accept()
         await msListen.handle(c)
 
@@ -95,7 +95,7 @@ suite "Identify":
       remotePeerInfo.agentVersion = customAgentVersion
       msListen.addHandler(IdentifyCodec, identifyProto1)
 
-      proc acceptHandler(): Future[void] {.async, gcsafe.} =
+      proc acceptHandler(): Future[void] {.async.} =
         let c = await transport1.accept()
         await msListen.handle(c)
 
@@ -136,7 +136,7 @@ suite "Identify":
     asyncTest "can send signed peer record":
       msListen.addHandler(IdentifyCodec, identifyProto1)
       identifyProto1.sendSignedPeerRecord = true
-      proc acceptHandler(): Future[void] {.async, gcsafe.} =
+      proc acceptHandler(): Future[void] {.async.} =
         let c = await transport1.accept()
         await msListen.handle(c)
 

--- a/tests/testmplex.nim
+++ b/tests/testmplex.nim
@@ -97,7 +97,7 @@ suite "Mplex":
 
   suite "channel half-closed":
     asyncTest "(local close) - should close for write":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(1, conn, true)
@@ -112,7 +112,7 @@ suite "Mplex":
     asyncTest "(local close) - should allow reads until remote closes":
       let
         conn = TestBufferStream.new(
-          proc (data: seq[byte]) {.gcsafe, async.} =
+          proc (data: seq[byte]) {.async.} =
             discard,
         )
         chann = LPChannel.init(1, conn, true)
@@ -139,7 +139,7 @@ suite "Mplex":
     asyncTest "(remote close) - channel should close for reading by remote":
       let
         conn = TestBufferStream.new(
-          proc (data: seq[byte]) {.gcsafe, async.} =
+          proc (data: seq[byte]) {.async.} =
             discard,
         )
         chann = LPChannel.init(1, conn, true)
@@ -162,7 +162,7 @@ suite "Mplex":
       let
         testData = "Hello!".toBytes
         conn = TestBufferStream.new(
-          proc (data: seq[byte]) {.gcsafe, async.} =
+          proc (data: seq[byte]) {.async.} =
             discard
         )
         chann = LPChannel.init(1, conn, true)
@@ -175,7 +175,7 @@ suite "Mplex":
         await conn.close()
 
     asyncTest "should not allow pushing data to channel when remote end closed":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(1, conn, true)
@@ -192,7 +192,7 @@ suite "Mplex":
   suite "channel reset":
 
     asyncTest "channel should fail reading":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(1, conn, true)
@@ -205,7 +205,7 @@ suite "Mplex":
       await conn.close()
 
     asyncTest "reset should complete read":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(1, conn, true)
@@ -220,7 +220,7 @@ suite "Mplex":
       await conn.close()
 
     asyncTest "reset should complete pushData":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(1, conn, true)
@@ -239,7 +239,7 @@ suite "Mplex":
       await conn.close()
 
     asyncTest "reset should complete both read and push":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(1, conn, true)
@@ -254,7 +254,7 @@ suite "Mplex":
       await conn.close()
 
     asyncTest "reset should complete both read and pushes":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(1, conn, true)
@@ -279,7 +279,7 @@ suite "Mplex":
       await conn.close()
 
     asyncTest "reset should complete both read and push with cancel":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(1, conn, true)
@@ -293,7 +293,7 @@ suite "Mplex":
       await conn.close()
 
     asyncTest "should complete both read and push after reset":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(1, conn, true)
@@ -311,7 +311,7 @@ suite "Mplex":
       await conn.close()
 
     asyncTest "reset should complete ongoing push without reader":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(1, conn, true)
@@ -323,7 +323,7 @@ suite "Mplex":
       await conn.close()
 
     asyncTest "reset should complete ongoing read without a push":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(1, conn, true)
@@ -335,7 +335,7 @@ suite "Mplex":
       await conn.close()
 
     asyncTest "reset should allow all reads and pushes to complete":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(1, conn, true)
@@ -364,7 +364,7 @@ suite "Mplex":
       await conn.close()
 
     asyncTest "channel should fail writing":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(1, conn, true)
@@ -376,7 +376,7 @@ suite "Mplex":
       await conn.close()
 
     asyncTest "channel should reset on timeout":
-      proc writeHandler(data: seq[byte]) {.async, gcsafe.} = discard
+      proc writeHandler(data: seq[byte]) {.async.} = discard
       let
         conn = TestBufferStream.new(writeHandler)
         chann = LPChannel.init(
@@ -392,11 +392,11 @@ suite "Mplex":
       let transport1: TcpTransport = TcpTransport.new(upgrade = Upgrade())
       let listenFut = transport1.start(ma)
 
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
         mplexListen.streamHandler = proc(stream: Connection)
-          {.async, gcsafe.} =
+          {.async.} =
           let msg = await stream.readLp(1024)
           check string.fromBytes(msg) == "HELLO"
           await stream.close()
@@ -429,11 +429,11 @@ suite "Mplex":
       let transport1: TcpTransport = TcpTransport.new(upgrade = Upgrade())
       let listenFut = transport1.start(ma)
 
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
         mplexListen.streamHandler = proc(stream: Connection)
-          {.async, gcsafe.} =
+          {.async.} =
           let msg = await stream.readLp(1024)
           check string.fromBytes(msg) == "HELLO"
           await stream.close()
@@ -473,12 +473,12 @@ suite "Mplex":
       let transport1: TcpTransport = TcpTransport.new(upgrade = Upgrade())
       let listenFut = transport1.start(ma)
 
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         try:
           let conn = await transport1.accept()
           let mplexListen = Mplex.new(conn)
           mplexListen.streamHandler = proc(stream: Connection)
-            {.async, gcsafe.} =
+            {.async.} =
             let msg = await stream.readLp(MaxMsgSize)
             check msg == bigseq
             trace "Bigseq check passed!"
@@ -520,11 +520,11 @@ suite "Mplex":
       let transport1: TcpTransport = TcpTransport.new(upgrade = Upgrade())
       let listenFut = transport1.start(ma)
 
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
         mplexListen.streamHandler = proc(stream: Connection)
-          {.async, gcsafe.} =
+          {.async.} =
           await stream.writeLp("Hello from stream!")
           await stream.close()
 
@@ -557,12 +557,12 @@ suite "Mplex":
       let listenFut = transport1.start(ma)
 
       let done = newFuture[void]()
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         var count = 1
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
         mplexListen.streamHandler = proc(stream: Connection)
-          {.async, gcsafe.} =
+          {.async.} =
           let msg = await stream.readLp(1024)
           check string.fromBytes(msg) == &"stream {count}!"
           count.inc
@@ -601,12 +601,12 @@ suite "Mplex":
       let listenFut = transport1.start(ma)
 
       let done = newFuture[void]()
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         var count = 1
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
         mplexListen.streamHandler = proc(stream: Connection)
-          {.async, gcsafe.} =
+          {.async.} =
           let msg = await stream.readLp(1024)
           check string.fromBytes(msg) == &"stream {count} from dialer!"
           await stream.writeLp(&"stream {count} from listener!")
@@ -646,12 +646,12 @@ suite "Mplex":
 
       let transport1 = TcpTransport.new(upgrade = Upgrade())
       var listenStreams: seq[Connection]
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
 
         mplexListen.streamHandler = proc(stream: Connection)
-          {.async, gcsafe.} =
+          {.async.} =
           listenStreams.add(stream)
           try:
             discard await stream.readLp(1024)
@@ -697,11 +697,11 @@ suite "Mplex":
       var count = 0
       var done = newFuture[void]()
       var listenStreams: seq[Connection]
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
         mplexListen.streamHandler = proc(stream: Connection)
-          {.async, gcsafe.} =
+          {.async.} =
           listenStreams.add(stream)
           count.inc()
           if count == 10:
@@ -761,11 +761,11 @@ suite "Mplex":
       let transport1 = TcpTransport.new(upgrade = Upgrade())
 
       var listenStreams: seq[Connection]
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
         mplexListen.streamHandler = proc(stream: Connection)
-          {.async, gcsafe.} =
+          {.async.} =
             listenStreams.add(stream)
             await stream.join()
 
@@ -805,11 +805,11 @@ suite "Mplex":
 
       var mplexListen: Mplex
       var listenStreams: seq[Connection]
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         mplexListen = Mplex.new(conn)
         mplexListen.streamHandler = proc(stream: Connection)
-          {.async, gcsafe.} =
+          {.async.} =
             listenStreams.add(stream)
             await stream.join()
 
@@ -851,11 +851,11 @@ suite "Mplex":
 
       var mplexHandle: Future[void]
       var listenStreams: seq[Connection]
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
         mplexListen.streamHandler = proc(stream: Connection)
-          {.async, gcsafe.} =
+          {.async.} =
             listenStreams.add(stream)
             await stream.join()
 
@@ -896,11 +896,11 @@ suite "Mplex":
       let transport1 = TcpTransport.new(upgrade = Upgrade())
 
       var listenStreams: seq[Connection]
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         let conn = await transport1.accept()
         let mplexListen = Mplex.new(conn)
         mplexListen.streamHandler = proc(stream: Connection)
-          {.async, gcsafe.} =
+          {.async.} =
             listenStreams.add(stream)
             await stream.join()
 
@@ -943,11 +943,11 @@ suite "Mplex":
 
       var listenConn: Connection
       var listenStreams: seq[Connection]
-      proc acceptHandler() {.async, gcsafe.} =
+      proc acceptHandler() {.async.} =
         listenConn = await transport1.accept()
         let mplexListen = Mplex.new(listenConn)
         mplexListen.streamHandler = proc(stream: Connection)
-          {.async, gcsafe.} =
+          {.async.} =
             listenStreams.add(stream)
             await stream.join()
 
@@ -992,11 +992,11 @@ suite "Mplex":
 
         var complete = newFuture[void]()
         const MsgSize = 1024
-        proc acceptHandler() {.async, gcsafe.} =
+        proc acceptHandler() {.async.} =
           let conn = await transport1.accept()
           let mplexListen = Mplex.new(conn)
           mplexListen.streamHandler = proc(stream: Connection)
-            {.async, gcsafe.} =
+            {.async.} =
             try:
               let msg = await stream.readLp(MsgSize)
               check msg.len == MsgSize
@@ -1064,11 +1064,11 @@ suite "Mplex":
 
         var complete = newFuture[void]()
         const MsgSize = 512
-        proc acceptHandler() {.async, gcsafe.} =
+        proc acceptHandler() {.async.} =
           let conn = await transport1.accept()
           let mplexListen = Mplex.new(conn)
           mplexListen.streamHandler = proc(stream: Connection)
-            {.async, gcsafe.} =
+            {.async.} =
             let msg = await stream.readLp(MsgSize)
             check msg.len == MsgSize
             await stream.close()

--- a/tests/testnoise.nim
+++ b/tests/testnoise.nim
@@ -41,7 +41,7 @@ type
 {.push raises: [].}
 
 method init(p: TestProto) {.gcsafe.} =
-  proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+  proc handle(conn: Connection, proto: string) {.async.} =
     let msg = string.fromBytes(await conn.readLp(1024))
     check "Hello!" == msg
     await conn.writeLp("Hello!")
@@ -140,7 +140,7 @@ suite "Noise":
 
     asyncSpawn transport1.start(server)
 
-    proc acceptHandler() {.async, gcsafe.} =
+    proc acceptHandler() {.async.} =
       var conn: Connection
       try:
         conn = await transport1.accept()
@@ -178,7 +178,7 @@ suite "Noise":
     let transport1: TcpTransport = TcpTransport.new(upgrade = Upgrade())
     asyncSpawn transport1.start(server)
 
-    proc acceptHandler() {.async, gcsafe.} =
+    proc acceptHandler() {.async.} =
       let conn = await transport1.accept()
       let sconn = await serverNoise.secure(conn, false, Opt.none(PeerId))
       defer:
@@ -221,7 +221,7 @@ suite "Noise":
       transport1: TcpTransport = TcpTransport.new(upgrade = Upgrade())
       listenFut = transport1.start(server)
 
-    proc acceptHandler() {.async, gcsafe.} =
+    proc acceptHandler() {.async.} =
       let conn = await transport1.accept()
       let sconn = await serverNoise.secure(conn, false, Opt.none(PeerId))
       defer:

--- a/tests/testping.nim
+++ b/tests/testping.nim
@@ -42,7 +42,7 @@ suite "Ping":
     transport1 = TcpTransport.new(upgrade = Upgrade())
     transport2 = TcpTransport.new(upgrade = Upgrade())
 
-    proc handlePing(peer: PeerId) {.async, gcsafe, closure.} =
+    proc handlePing(peer: PeerId) {.async, closure.} =
       inc pingReceivedCount
     pingProto1 = Ping.new()
     pingProto2 = Ping.new(handlePing)
@@ -63,7 +63,7 @@ suite "Ping":
   asyncTest "simple ping":
     msListen.addHandler(PingCodec, pingProto1)
     serverFut = transport1.start(@[ma])
-    proc acceptHandler(): Future[void] {.async, gcsafe.} =
+    proc acceptHandler(): Future[void] {.async.} =
       let c = await transport1.accept()
       await msListen.handle(c)
 
@@ -78,7 +78,7 @@ suite "Ping":
   asyncTest "ping callback":
     msDial.addHandler(PingCodec, pingProto2)
     serverFut = transport1.start(@[ma])
-    proc acceptHandler(): Future[void] {.async, gcsafe.} =
+    proc acceptHandler(): Future[void] {.async.} =
       let c = await transport1.accept()
       discard await msListen.select(c, PingCodec)
       discard await pingProto1.ping(c)
@@ -92,7 +92,7 @@ suite "Ping":
   asyncTest "bad ping data ack":
     type FakePing = ref object of LPProtocol
     let fakePingProto = FakePing()
-    proc fakeHandle(conn: Connection, proto: string) {.async, gcsafe, closure.} =
+    proc fakeHandle(conn: Connection, proto: string) {.async, closure.} =
       var
         buf: array[32, byte]
         fakebuf: array[32, byte]
@@ -103,7 +103,7 @@ suite "Ping":
 
     msListen.addHandler(PingCodec, fakePingProto)
     serverFut = transport1.start(@[ma])
-    proc acceptHandler(): Future[void] {.async, gcsafe.} =
+    proc acceptHandler(): Future[void] {.async.} =
       let c = await transport1.accept()
       await msListen.handle(c)
 

--- a/tests/testswitch.nim
+++ b/tests/testswitch.nim
@@ -46,7 +46,7 @@ suite "Switch":
 
   asyncTest "e2e use switch dial proto string":
     let done = newFuture[void]()
-    proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+    proc handle(conn: Connection, proto: string) {.async.} =
       try:
         let msg = string.fromBytes(await conn.readLp(1024))
         check "Hello!" == msg
@@ -86,7 +86,7 @@ suite "Switch":
 
   asyncTest "e2e use switch dial proto string with custom matcher":
     let done = newFuture[void]()
-    proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+    proc handle(conn: Connection, proto: string) {.async.} =
       try:
         let msg = string.fromBytes(await conn.readLp(1024))
         check "Hello!" == msg
@@ -131,7 +131,7 @@ suite "Switch":
 
   asyncTest "e2e should not leak bufferstreams and connections on channel close":
     let done = newFuture[void]()
-    proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+    proc handle(conn: Connection, proto: string) {.async.} =
       try:
         let msg = string.fromBytes(await conn.readLp(1024))
         check "Hello!" == msg
@@ -171,7 +171,7 @@ suite "Switch":
     check not switch2.isConnected(switch1.peerInfo.peerId)
 
   asyncTest "e2e use connect then dial":
-    proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+    proc handle(conn: Connection, proto: string) {.async.} =
       try:
         let msg = string.fromBytes(await conn.readLp(1024))
         check "Hello!" == msg
@@ -305,7 +305,7 @@ suite "Switch":
 
     var step = 0
     var kinds: set[ConnEventKind]
-    proc hook(peerId: PeerId, event: ConnEvent) {.async, gcsafe.} =
+    proc hook(peerId: PeerId, event: ConnEvent) {.async.} =
       kinds = kinds + {event.kind}
       case step:
       of 0:
@@ -357,7 +357,7 @@ suite "Switch":
 
     var step = 0
     var kinds: set[ConnEventKind]
-    proc hook(peerId: PeerId, event: ConnEvent) {.async, gcsafe.} =
+    proc hook(peerId: PeerId, event: ConnEvent) {.async.} =
       kinds = kinds + {event.kind}
       case step:
       of 0:
@@ -409,7 +409,7 @@ suite "Switch":
 
     var step = 0
     var kinds: set[PeerEventKind]
-    proc handler(peerId: PeerId, event: PeerEvent) {.async, gcsafe.} =
+    proc handler(peerId: PeerId, event: PeerEvent) {.async.} =
       kinds = kinds + {event.kind}
       case step:
       of 0:
@@ -460,7 +460,7 @@ suite "Switch":
 
     var step = 0
     var kinds: set[PeerEventKind]
-    proc handler(peerId: PeerId, event: PeerEvent) {.async, gcsafe.} =
+    proc handler(peerId: PeerId, event: PeerEvent) {.async.} =
       kinds = kinds + {event.kind}
       case step:
       of 0:
@@ -521,7 +521,7 @@ suite "Switch":
 
     var step = 0
     var kinds: set[PeerEventKind]
-    proc handler(peerId: PeerId, event: PeerEvent) {.async, gcsafe.} =
+    proc handler(peerId: PeerId, event: PeerEvent) {.async.} =
       kinds = kinds + {event.kind}
       case step:
       of 0:
@@ -581,7 +581,7 @@ suite "Switch":
     var switches: seq[Switch]
     var done = newFuture[void]()
     var onConnect: Future[void]
-    proc hook(peerId: PeerId, event: ConnEvent) {.async, gcsafe.} =
+    proc hook(peerId: PeerId, event: ConnEvent) {.async.} =
       case event.kind:
       of ConnEventKind.Connected:
         await onConnect
@@ -619,7 +619,7 @@ suite "Switch":
     var switches: seq[Switch]
     var done = newFuture[void]()
     var onConnect: Future[void]
-    proc hook(peerId2: PeerId, event: ConnEvent) {.async, gcsafe.} =
+    proc hook(peerId2: PeerId, event: ConnEvent) {.async.} =
       case event.kind:
       of ConnEventKind.Connected:
         if conns == 5:
@@ -662,7 +662,7 @@ suite "Switch":
     let transport = TcpTransport.new(upgrade = Upgrade())
     await transport.start(ma)
 
-    proc acceptHandler() {.async, gcsafe.} =
+    proc acceptHandler() {.async.} =
       let conn = await transport.accept()
       await conn.closeWithEOF()
 
@@ -686,7 +686,7 @@ suite "Switch":
       switch.stop())
 
   asyncTest "e2e calling closeWithEOF on the same stream should not assert":
-    proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+    proc handle(conn: Connection, proto: string) {.async.} =
       discard await conn.readLp(100)
 
     let testProto = new TestProto
@@ -832,7 +832,7 @@ suite "Switch":
 
   asyncTest "e2e peer store":
     let done = newFuture[void]()
-    proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+    proc handle(conn: Connection, proto: string) {.async.} =
       try:
         let msg = string.fromBytes(await conn.readLp(1024))
         check "Hello!" == msg
@@ -882,7 +882,7 @@ suite "Switch":
       # this randomly locks the Windows CI job
       skip()
       return
-    proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+    proc handle(conn: Connection, proto: string) {.async.} =
       try:
         let msg = string.fromBytes(await conn.readLp(1024))
         check "Hello!" == msg
@@ -1019,7 +1019,7 @@ suite "Switch":
     await srcTcpSwitch.stop()
 
   asyncTest "mount unstarted protocol":
-    proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+    proc handle(conn: Connection, proto: string) {.async.} =
       check "test123" == string.fromBytes(await conn.readLp(1024))
       await conn.writeLp("test456")
       await conn.close()

--- a/tests/testtcptransport.nim
+++ b/tests/testtcptransport.nim
@@ -30,7 +30,7 @@ suite "TCP transport":
     let transport: TcpTransport = TcpTransport.new(upgrade = Upgrade())
     asyncSpawn transport.start(ma)
 
-    proc acceptHandler() {.async, gcsafe.} =
+    proc acceptHandler() {.async.} =
       let conn = await transport.accept()
       await conn.write("Hello!")
       await conn.close()
@@ -52,7 +52,7 @@ suite "TCP transport":
     let transport: TcpTransport = TcpTransport.new(upgrade = Upgrade())
     asyncSpawn transport.start(ma)
 
-    proc acceptHandler() {.async, gcsafe.} =
+    proc acceptHandler() {.async.} =
       var msg = newSeq[byte](6)
       let conn = await transport.accept()
       await conn.readExactly(addr msg[0], 6)
@@ -73,7 +73,7 @@ suite "TCP transport":
     let address = initTAddress("0.0.0.0:0")
     let handlerWait = newFuture[void]()
     proc serveClient(server: StreamServer,
-                      transp: StreamTransport) {.async, gcsafe.} =
+                      transp: StreamTransport) {.async.} =
       var wstream = newAsyncStreamWriter(transp)
       await wstream.write("Hello!")
       await wstream.finish()
@@ -106,7 +106,7 @@ suite "TCP transport":
     let address = initTAddress("0.0.0.0:0")
     let handlerWait = newFuture[void]()
     proc serveClient(server: StreamServer,
-                      transp: StreamTransport) {.async, gcsafe.} =
+                      transp: StreamTransport) {.async.} =
       var rstream = newAsyncStreamReader(transp)
       let msg = await rstream.read(6)
       check string.fromBytes(msg) == "Hello!"
@@ -179,7 +179,7 @@ suite "TCP transport":
     let transport: TcpTransport = TcpTransport.new(upgrade = Upgrade(), connectionsTimeout=1.milliseconds)
     asyncSpawn transport.start(ma)
 
-    proc acceptHandler() {.async, gcsafe.} =
+    proc acceptHandler() {.async.} =
       let conn = await transport.accept()
       await conn.join()
 

--- a/tests/testtortransport.nim
+++ b/tests/testtortransport.nim
@@ -56,7 +56,7 @@ suite "Tor transport":
       check string.fromBytes(resp) == "server"
       await client.stop()
 
-    proc serverAcceptHandler() {.async, gcsafe.} =
+    proc serverAcceptHandler() {.async.} =
       let conn = await server.accept()
       var resp: array[6, byte]
       await conn.readExactly(addr resp, 6)
@@ -87,7 +87,7 @@ suite "Tor transport":
     proc new(T: typedesc[TestProto]): T =
 
       # every incoming connections will be in handled in this closure
-      proc handle(conn: Connection, proto: string) {.async, gcsafe.} =
+      proc handle(conn: Connection, proto: string) {.async.} =
 
         var resp: array[6, byte]
         await conn.readExactly(addr resp, 6)

--- a/tests/testwstransport.nim
+++ b/tests/testwstransport.nim
@@ -89,7 +89,7 @@ suite "WebSocket transport":
     const correctPattern = mapAnd(TCP, mapEq("wss"))
     await transport1.start(ma)
     check correctPattern.match(transport1.addrs[0])
-    proc acceptHandler() {.async, gcsafe.} =
+    proc acceptHandler() {.async.} =
       while true:
         let conn = await transport1.accept()
         if not isNil(conn):


### PR DESCRIPTION
`async` already implies `gcsafe` - there's no need to specify it separately.

also, `raises` doesn't do the expected thing in combination with `async`
- for that, chronos v4 and its separate annotation is needed.