### PR TITLE
fix: make matrix include customizable for daily workflows

### DIFF
--- a/.github/workflows/multi_nim.yml
+++ b/.github/workflows/multi_nim.yml
@@ -1,14 +1,12 @@
-name: Test Daily
+name: Daily
 on:
   schedule:
     - cron: "30 6 * * *"
   workflow_dispatch:
 
-  push:
-
 jobs:
   call-multi-nim-common:
-    uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@fix/make-matrix-include-customizable
+    uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@unstable
     with:
       nim-branch: "[
           'version-1-6',

--- a/.github/workflows/multi_nim.yml
+++ b/.github/workflows/multi_nim.yml
@@ -1,15 +1,49 @@
-name: Daily
+name: Test Daily
 on:
   schedule:
     - cron: "30 6 * * *"
   workflow_dispatch:
 
+  push:
+
 jobs:
   call-multi-nim-common:
     uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@unstable
     with:
-      nim-branch: "['version-1-6','version-2-0']"
-      platform: "[{'os':'linux','cpu':'amd64'},{'os':'macos','cpu':'amd64'},{'os':'windows','cpu':'amd64'}]"
+      nim-branch: "[
+          'version-1-6',
+          'version-2-0'
+        ]"
+      platform: "[
+          {'os':'linux','cpu':'amd64'},
+          {'os':'macos','cpu':'amd64'},
+          {'os':'windows','cpu':'amd64'}
+        ]"
+      extra: "[
+          {
+            'target': {
+              'os': 'linux'
+            },
+            'builder': 'ubuntu-20.04',
+            'shell': 'bash'
+          },
+          {
+            'target': {
+              'os': 'macos'
+            },
+            'builder': 'macos-12',
+            'shell': 'bash'
+          },
+          {
+            'target': {
+              'os': 'windows'
+            },
+            'builder': 'windows-2019',
+            'shell': 'msys2 {0}'
+          }
+        ]"
+
+
 
 
 

--- a/.github/workflows/multi_nim.yml
+++ b/.github/workflows/multi_nim.yml
@@ -19,7 +19,7 @@ jobs:
           {'os':'macos','cpu':'amd64'},
           {'os':'windows','cpu':'amd64'}
         ]"
-      extra: "[
+      includes: "[
           {
             'target': {
               'os': 'linux'

--- a/.github/workflows/multi_nim.yml
+++ b/.github/workflows/multi_nim.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   call-multi-nim-common:
-    uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@unstable
+    uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@fix/make-matrix-include-customizable
     with:
       nim-branch: "[
           'version-1-6',

--- a/.github/workflows/multi_nim_common.yml
+++ b/.github/workflows/multi_nim_common.yml
@@ -11,8 +11,8 @@ on:
         description: 'Platform'
         required: true
         type: string
-      extra:
-        description: 'Include Extra'
+      includes:
+        description: 'Include Params'
         required: true
         type: string
 
@@ -30,7 +30,7 @@ jobs:
       matrix:
         target: ${{ fromJSON(inputs.platform) }}
         branch: ${{ fromJSON(inputs.nim-branch) }}
-        include: ${{ fromJSON(inputs.extra) }}
+        include: ${{ fromJSON(inputs.includes) }}
 
     defaults:
       run:

--- a/.github/workflows/multi_nim_common.yml
+++ b/.github/workflows/multi_nim_common.yml
@@ -11,6 +11,10 @@ on:
         description: 'Platform'
         required: true
         type: string
+      extra:
+        description: 'Include Extra'
+        required: true
+        type: string
 
 jobs:
   delete-cache:
@@ -26,19 +30,7 @@ jobs:
       matrix:
         target: ${{ fromJSON(inputs.platform) }}
         branch: ${{ fromJSON(inputs.nim-branch) }}
-        include:
-          - target:
-              os: linux
-            builder: ubuntu-20.04
-            shell: bash
-          - target:
-              os: macos
-            builder: macos-12
-            shell: bash
-          - target:
-              os: windows
-            builder: windows-2019
-            shell: msys2 {0}
+        include: ${{ fromJSON(inputs.extra) }}
 
     defaults:
       run:

--- a/.github/workflows/multi_nim_devel.yml
+++ b/.github/workflows/multi_nim_devel.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   call-multi-nim-common:
-    uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@unstable
+    uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@fix/make-matrix-include-customizable
     with:
       nim-branch: "[
           'devel'

--- a/.github/workflows/multi_nim_devel.yml
+++ b/.github/workflows/multi_nim_devel.yml
@@ -1,14 +1,12 @@
-name: Test Nim Devel
+name: Nim Devel
 on:
   schedule:
     - cron: "30 6 * * *"
   workflow_dispatch:
 
-  push:
-
 jobs:
   call-multi-nim-common:
-    uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@fix/make-matrix-include-customizable
+    uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@unstable
     with:
       nim-branch: "[
           'devel'

--- a/.github/workflows/multi_nim_devel.yml
+++ b/.github/workflows/multi_nim_devel.yml
@@ -1,13 +1,43 @@
-name: Nim Devel
+name: Test Nim Devel
 on:
   schedule:
     - cron: "30 6 * * *"
   workflow_dispatch:
 
+  push:
+
 jobs:
   call-multi-nim-common:
     uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@unstable
     with:
-      nim-branch: "['devel']"
-      platform: "[{'os':'linux','cpu':'amd64'},{'os':'macos','cpu':'amd64'},{'os':'windows','cpu':'amd64'}]"
-
+      nim-branch: "[
+          'devel'
+        ]"
+      platform: "[
+          {'os':'linux','cpu':'amd64'},
+          {'os':'macos','cpu':'amd64'},
+          {'os':'windows','cpu':'amd64'}
+        ]"
+      extra: "[
+          {
+            'target': {
+              'os': 'linux'
+            },
+            'builder': 'ubuntu-20.04',
+            'shell': 'bash'
+          },
+          {
+            'target': {
+              'os': 'macos'
+            },
+            'builder': 'macos-12',
+            'shell': 'bash'
+          },
+          {
+            'target': {
+              'os': 'windows'
+            },
+            'builder': 'windows-2019',
+            'shell': 'msys2 {0}'
+          }
+        ]"

--- a/.github/workflows/multi_nim_devel.yml
+++ b/.github/workflows/multi_nim_devel.yml
@@ -18,7 +18,7 @@ jobs:
           {'os':'macos','cpu':'amd64'},
           {'os':'windows','cpu':'amd64'}
         ]"
-      extra: "[
+      includes: "[
           {
             'target': {
               'os': 'linux'

--- a/.github/workflows/multi_nim_legacy.yml
+++ b/.github/workflows/multi_nim_legacy.yml
@@ -17,7 +17,7 @@ jobs:
       platform: "[
           {'os':'linux','cpu':'i386'}
         ]"
-      extra: "[
+      includes: "[
           {
             'target': {
               'os': 'linux'

--- a/.github/workflows/multi_nim_legacy.yml
+++ b/.github/workflows/multi_nim_legacy.yml
@@ -1,14 +1,29 @@
-name: Legacy Platforms
+name: Test Legacy Platforms
 on:
   schedule:
     - cron: "30 6 * * *"
   workflow_dispatch:
 
+  push:
+
 jobs:
   call-multi-nim-common:
     uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@unstable
     with:
-      nim-branch: "['version-1-6','version-2-0']"
-      platform: "[{'os':'linux','cpu':'i386'}]"
-
+      nim-branch: "[
+          'version-1-6',
+          'version-2-0'
+        ]"
+      platform: "[
+          {'os':'linux','cpu':'i386'}
+        ]"
+      extra: "[
+          {
+            'target': {
+              'os': 'linux'
+            },
+            'builder': 'ubuntu-20.04',
+            'shell': 'bash'
+          }
+        ]"
 

--- a/.github/workflows/multi_nim_legacy.yml
+++ b/.github/workflows/multi_nim_legacy.yml
@@ -1,14 +1,12 @@
-name: Test Legacy Platforms
+name: Legacy Platforms
 on:
   schedule:
     - cron: "30 6 * * *"
   workflow_dispatch:
 
-  push:
-
 jobs:
   call-multi-nim-common:
-    uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@fix/make-matrix-include-customizable
+    uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@unstable
     with:
       nim-branch: "[
           'version-1-6',

--- a/.github/workflows/multi_nim_legacy.yml
+++ b/.github/workflows/multi_nim_legacy.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   call-multi-nim-common:
-    uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@unstable
+    uses: status-im/nim-libp2p/.github/workflows/multi_nim_common.yml@fix/make-matrix-include-customizable
     with:
       nim-branch: "[
           'version-1-6',


### PR DESCRIPTION
Move include matrix parameters upwards, so that they can be customizable. Common include params were partially redundant for "Legacy Platforms" workflow as i386 has no desired combination for Mac OS and Windows.