### PR TITLE
libp2p/multiaddress.nim: use of IpAddress instead of ValidIpAddress

### DIFF
--- a/libp2p/multiaddress.nim
+++ b/libp2p/multiaddress.nim
@@ -958,7 +958,7 @@ proc init*(mtype: typedesc[MultiAddress]): MultiAddress =
   ## Initialize empty MultiAddress.
   result.data = initVBuffer()
 
-proc init*(mtype: typedesc[MultiAddress], address: ValidIpAddress,
+proc init*(mtype: typedesc[MultiAddress], address: IpAddress,
            protocol: IpTransportProtocol, port: Port): MultiAddress =
   var res: MultiAddress
   res.data = initVBuffer()


### PR DESCRIPTION
Simple PR to avoid using the deprecated type `ValidIpAddress`, in favour of `IpAddress`.