### PR TITLE
chore: improve CI workflow stability

### DIFF
--- a/.github/actions/install_nim/action.yml
+++ b/.github/actions/install_nim/action.yml
@@ -12,6 +12,8 @@ inputs:
   shell:
     description: "Shell to run commands in"
     default: "bash --noprofile --norc -e -o pipefail"
+  nimble_commit:
+    description: "Nimble commit hash"
 
 runs:
   using: "composite"
@@ -112,20 +114,12 @@ runs:
         echo "MAKE_CMD=${MAKE_CMD}" >> $GITHUB_ENV
         echo '${{ github.workspace }}/nim/bin' >> $GITHUB_PATH
 
-    - name: Restore Nim from cache
-      id: nim-cache
-      uses: actions/cache@v3
-      with:
-        path: '${{ github.workspace }}/nim'
-        key: ${{ inputs.os }}-${{ inputs.cpu }}-nim-${{ inputs.nim_branch }}-cache-${{ env.cache_nonce }}
-
     - name: Build Nim and Nimble
       shell: ${{ inputs.shell }}
-      if: ${{ steps.nim-cache.outputs.cache-hit != 'true' }}
       run: |
         # We don't want partial matches of the cache restored
         rm -rf nim
-        curl -O -L -s -S https://raw.githubusercontent.com/status-im/nimbus-build-system/master/scripts/build_nim.sh
+        cp ./scripts/build_nim.sh .
         env MAKE="${MAKE_CMD} -j${ncpu}" ARCH_OVERRIDE=${PLATFORM} NIM_COMMIT=${{ inputs.nim_branch }} \
-          QUICK_AND_DIRTY_COMPILER=1 QUICK_AND_DIRTY_NIMBLE=1 CC=gcc \
+          QUICK_AND_DIRTY_COMPILER=1 QUICK_AND_DIRTY_NIMBLE=1 CC=gcc NIMBLE_COMMIT=${{ inputs.nimble_commit }} \
           bash build_nim.sh nim csources dist/nimble NimBinaries

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
-name: CI
+name: CI - Test
 on:
   push:
     branches:
-      - master
-      - unstable
-  pull_request:
+      #      - master
+      #      - unstable
+      - 'chore-improve-ci-workflow-stability'
+  #pull_request:
   workflow_dispatch:
 
 concurrency:
@@ -26,8 +27,7 @@ jobs:
             cpu: amd64
           - os: windows
             cpu: amd64
-          #- os: windows
-            #cpu: i386
+
         branch: [version-1-6]
         include:
           - target:
@@ -52,7 +52,7 @@ jobs:
     continue-on-error: ${{ matrix.branch == 'devel' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           submodules: true
 
@@ -63,27 +63,21 @@ jobs:
           cpu: ${{ matrix.target.cpu }}
           shell: ${{ matrix.shell }}
           nim_branch: ${{ matrix.branch }}
+          nimble_commit: "3575fd54a890d910ace56678aa74b4237d604175" #v0.14.2
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: '~1.15.5'
+          cache: false
 
       - name: Install p2pd
         run: |
           V=1 bash scripts/build_p2pd.sh p2pdCache 124530a3
 
-      - name: Restore deps from cache
-        id: deps-cache
-        uses: actions/cache@v3
-        with:
-          path: nimbledeps
-          key: nimbledeps-${{ hashFiles('.pinned') }}
-
       - name: Install deps
-        if: ${{ steps.deps-cache.outputs.cache-hit != 'true' }}
         run: |
-          nimble install_pinned
+          nimble install -y --depsOnly
 
       - name: Run tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,13 @@
-name: CI - Test
+name: CI
 on:
   push:
     branches:
-      #      - master
-      #      - unstable
-      - 'chore-improve-ci-workflow-stability'
-  #pull_request:
+      - master
+      - unstable
+
+  pull_request:
   workflow_dispatch:
+
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/scripts/build_nim.sh
+++ b/scripts/build_nim.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# used in Travis CI and AppVeyor scripts
+
+# Copyright (c) 2018-2020 Status Research & Development GmbH. Licensed under
+# either of:
+# - Apache License, version 2.0
+# - MIT license
+# at your option. This file may not be copied, modified, or distributed except
+# according to those terms.
+
+set -e
+
+# Git commits
+: ${CSOURCES_V1_COMMIT:=a8a5241f9475099c823cfe1a5e0ca4022ac201ff}
+: ${CSOURCES_V2_COMMIT:=86742fb02c6606ab01a532a0085784effb2e753e}
+: ${CSOURCES_V1_REPO:=https://github.com/nim-lang/csources_v1.git}
+: ${CSOURCES_V2_REPO:=https://github.com/nim-lang/csources_v2.git}
+
+# After this Nim commit, use csources v2
+: ${CSOURCES_V2_START_COMMIT:=f7c203fb6c89b5cef83c4f326aeb23ef8c4a2c40}
+# Set Nimble commit in environment to have non default one.
+# e.g. NIMBLE_COMMIT=3575fd54a890d910ace56678aa74b4237d604175 # 0.14.2
+# NIM_COMMIT could be a (partial) commit hash, a tag, a branch name, etc. Empty by default.
+NIM_COMMIT_HASH="" # full hash for NIM_COMMIT, retrieved in "nim_needs_rebuilding()"
+
+# script arguments
+[[ $# -ne 4 ]] && { echo "Usage: $0 nim_dir csources_dir nimble_dir ci_cache_dir"; exit 1; }
+NIM_DIR="$1"
+CSOURCES_DIR="$2" # can be relative to NIM_DIR
+NIMBLE_DIR="$3" # can be relative to NIM_DIR
+CI_CACHE="$4"
+
+## env vars
+# verbosity level
+[[ -z "$V" ]] && V=0
+[[ -z "$CC" ]] && CC="gcc"
+# to build csources in parallel, set MAKE="make -jN"
+[[ -z "$MAKE" ]] && MAKE="make"
+# for 32-bit binaries on a 64-bit host
+UCPU=""
+[[ "$ARCH_OVERRIDE" == "x86" ]] && UCPU="ucpu=i686"
+[[ -z "$NIM_BUILD_MSG" ]] && NIM_BUILD_MSG="Building the Nim compiler"
+[[ -z "$QUICK_AND_DIRTY_COMPILER" ]] && QUICK_AND_DIRTY_COMPILER=0
+[[ -z "$QUICK_AND_DIRTY_NIMBLE" ]] && QUICK_AND_DIRTY_NIMBLE=0
+
+# Windows detection
+if uname | grep -qiE "mingw|msys"; then
+	ON_WINDOWS=1
+	EXE_SUFFIX=".exe"
+	# otherwise it fails in AppVeyor due to https://github.com/git-for-windows/git/issues/2495
+	GIT_TIMESTAMP_ARG="--date=unix" # available since Git 2.9.4
+else
+	ON_WINDOWS=0
+	EXE_SUFFIX=""
+	GIT_TIMESTAMP_ARG="--date=format-local:%s" # available since Git 2.7.0
+fi
+
+NIM_BINARY="${NIM_DIR}/bin/nim${EXE_SUFFIX}"
+MAX_NIM_BINARIES="10" # Old ones get deleted.
+
+nim_needs_rebuilding() {
+	REBUILD=0
+	NO_REBUILD=1
+
+	if [[ ! -e "$NIM_DIR" ]]; then
+		# Shallow clone, optimised for the default NIM_COMMIT value.
+		git clone -q --depth=1 https://github.com/status-im/Nim.git "$NIM_DIR"
+	fi
+
+	pushd "${NIM_DIR}" >/dev/null
+	if [[ -n "${NIM_COMMIT}" ]]; then
+		# support old Git versions, like the one from Ubuntu-18.04
+		git restore . 2>/dev/null || git reset --hard
+		if ! git checkout -q ${NIM_COMMIT} 2>/dev/null; then
+		  echo "Downloading Nim sources..."
+			# Pay the price for a non-default NIM_COMMIT here, by fetching everything.
+			# (This includes upstream branches and tags that might be missing from our fork.)
+			git remote add upstream https://github.com/nim-lang/Nim
+			git fetch --all --tags --quiet
+			git checkout -q ${NIM_COMMIT}
+		fi
+		# In case the local branch diverged and a fast-forward merge is not possible.
+		git fetch || true
+		git reset -q --hard origin/${NIM_COMMIT} 2>/dev/null || true
+		# In case NIM_COMMIT is a local branch that's behind the remote one it's tracking.
+		git pull -q 2>/dev/null || true
+		git checkout -q ${NIM_COMMIT}
+		# We can't use "rev-parse" here, because it would return the tag object's
+		# hash instead of the commit hash, when NIM_COMMIT is a tag.
+		NIM_COMMIT_HASH="$(git rev-list -n 1 ${NIM_COMMIT})"
+	else
+		# NIM_COMMIT is empty, so assume the commit we need is already checked out
+		NIM_COMMIT_HASH="$(git rev-list -n 1 HEAD)"
+	fi
+
+	if [[ ! -d "$NIMBLE_DIR" ]] && [[ -n "$NIMBLE_COMMIT" ]]; then
+    echo "Downloading Nimble sources..."
+    mkdir -p "$NIMBLE_DIR"
+    pushd "$NIMBLE_DIR"
+    git clone https://github.com/nim-lang/nimble.git .
+    git checkout $NIMBLE_COMMIT
+    # we have to delete .git or koch.nim will checkout a branch tip, overriding our target commit
+  	rm -rf .git
+    popd
+  fi
+  if [[ "$NIMBLE_DIR" != "dist/nimble" ]]; then
+    mkdir -p dist
+  	rm -rf dist/nimble
+  	ln -s ../"$NIMBLE_DIR" dist/nimble
+  fi
+
+	popd >/dev/null
+
+	if [[ -n "$CI_CACHE" && -d "$CI_CACHE" ]]; then
+		cp -a "$CI_CACHE"/* "$NIM_DIR"/bin/ || true # let this one fail with an empty cache dir
+	fi
+
+	# Delete old Nim binaries, to put a limit on how much storage we use.
+	for F in "$(ls -t "${NIM_DIR}"/bin/nim_commit_* 2>/dev/null | tail -n +$((MAX_NIM_BINARIES + 1)))"; do
+		if [[ -e "${F}" ]]; then
+			rm "${F}"
+		fi
+	done
+
+	# Compare the last built commit to the one requested.
+	# Handle the scenario where our symlink is manually deleted by the user.
+	if [[ -e "${NIM_DIR}/bin/last_built_commit" && \
+	-e "${NIM_DIR}/bin/nim${EXE_SUFFIX}" && \
+	"$(cat "${NIM_DIR}/bin/last_built_commit")" == "${NIM_COMMIT_HASH}" ]]; then
+		return $NO_REBUILD
+	elif [[ -e "${NIM_DIR}/bin/nim_commit_${NIM_COMMIT_HASH}" ]]; then
+		# we built the requested commit in the past, so we simply reuse it
+		rm -f "${NIM_DIR}/bin/nim${EXE_SUFFIX}"
+		ln -s "nim_commit_${NIM_COMMIT_HASH}" "${NIM_DIR}/bin/nim${EXE_SUFFIX}"
+		echo ${NIM_COMMIT_HASH} > "${NIM_DIR}/bin/last_built_commit"
+		return $NO_REBUILD
+	else
+		return $REBUILD
+	fi
+}
+
+build_nim() {
+	echo -e "$NIM_BUILD_MSG"
+	[[ "$V" == "0" ]] && exec &>/dev/null
+
+	# working directory
+	pushd "$NIM_DIR"
+
+	# Run Nim buildchain
+	. ci/funs.sh
+	NIMCORES=1 nimBuildCsourcesIfNeeded $UCPU
+	bin/nim c --noNimblePath --skipUserCfg --skipParentCfg --warnings:off --hints:off koch
+	./koch --skipIntegrityCheck boot -d:release --skipUserCfg --skipParentCfg --warnings:off --hints:off
+	if [[ "${QUICK_AND_DIRTY_COMPILER}" == "0" ]]; then
+		# We want tools
+		./koch tools -d:release --skipUserCfg --skipParentCfg --warnings:off --hints:off
+	elif [[ "${QUICK_AND_DIRTY_NIMBLE}" != "0" ]]; then
+		# We just want nimble
+		./koch nimble -d:release --skipUserCfg --skipParentCfg --warnings:off --hints:off
+	fi
+
+	if [[ "$QUICK_AND_DIRTY_COMPILER" == "0" || "${QUICK_AND_DIRTY_NIMBLE}" != "0" ]]; then
+		# Nimble needs a CA cert
+		rm -f bin/cacert.pem
+		curl -LsS -o bin/cacert.pem https://curl.se/ca/cacert.pem || echo "Warning: 'curl' failed to download a CA cert needed by Nimble. Ignoring it."
+	fi
+
+	# record the built commit
+	echo ${NIM_COMMIT_HASH} > bin/last_built_commit
+
+	# create the symlink
+	mv bin/nim bin/nim_commit_${NIM_COMMIT_HASH}
+	ln -s nim_commit_${NIM_COMMIT_HASH} bin/nim${EXE_SUFFIX}
+
+	# update the CI cache
+	popd # we were in $NIM_DIR
+	if [[ -n "$CI_CACHE" ]]; then
+		rm -rf "$CI_CACHE"
+		mkdir "$CI_CACHE"
+		cp "$NIM_DIR"/bin/* "$CI_CACHE"/
+	fi
+}
+
+if nim_needs_rebuilding; then
+	build_nim
+fi


### PR DESCRIPTION
I would like to receive team's feedback on several changes I've prepared to address CI workflow stability.

This PR introduces possibility to preset Nimble version during Nim 1.x build. Benefits of such change are:

- Possible to have any version of Nimble even for Nim v1.x.
- Get native Nimble lock functionality for Nim v1.x.
- Keep Nimble versions same across different Nim versions -> simplified troubleshooting
- Get Nimble issues fixed faster - the newest versions usually get preference 

Caching is disabled for CI workflow temporarily. Once we have more stability, we can start tuning for speed. 