### PR TITLE
fix: use a temp var

### DIFF
--- a/libp2p/utility.nim
+++ b/libp2p/utility.nim
@@ -89,8 +89,9 @@ template exceptionToAssert*(body: untyped): untyped =
     res
 
 template withValue*[T](self: Opt[T] | Option[T], value, body: untyped): untyped =
-  if self.isSome:
-    let value {.inject.} = self.get()
+  let temp = (self)
+  if temp.isSome:
+    let value {.inject.} = temp.get()
     body
 
 macro withValue*[T](self: Opt[T] | Option[T], value, body, body2: untyped): untyped =


### PR DESCRIPTION
This avoids a function being called two times when passed to this template.