### PR TITLE
Defining pubsub's max message size as a global const

### DIFF
--- a/libp2p/protocols/pubsub/pubsub.nim
+++ b/libp2p/protocols/pubsub/pubsub.nim
@@ -46,6 +46,7 @@ logScope:
 const
   KnownLibP2PTopics* {.strdefine.} = ""
   KnownLibP2PTopicsSeq* = KnownLibP2PTopics.toLowerAscii().split(",")
+  MaxMessageSize* = 1024 * 1024 # Maximum message size in bytes
 
 declareGauge(libp2p_pubsub_peers, "pubsub peer instances")
 declareGauge(libp2p_pubsub_topics, "pubsub subscribed topics")
@@ -553,7 +554,7 @@ proc init*[PubParams: object | bool](
   sign: bool = true,
   msgIdProvider: MsgIdProvider = defaultMsgIdProvider,
   subscriptionValidator: SubscriptionValidator = nil,
-  maxMessageSize: int = 1024 * 1024,
+  maxMessageSize: int = MaxMessageSize,
   rng: ref HmacDrbgContext = newRng(),
   parameters: PubParams = false): P
   {.raises: [InitializationError], public.} =


### PR DESCRIPTION
Moving the maximum message size value as a global constant so the value can be accessed and reused across the codebase