### PR TITLE
fix typo in `ProtoMessage.toString()`

### DIFF
--- a/libp2p/debugutils.nim
+++ b/libp2p/debugutils.nim
@@ -247,7 +247,7 @@ proc toString*(msg: ProtoMessage, dump = true): string =
         else: "[REMOTE]"
       local & direction & remote
   let seqid = block:
-    msg.seqID.wihValue(seqid): "seqID = " & $seqid & " "
+    msg.seqID.withValue(seqid): "seqID = " & $seqid & " "
     else: ""
   let mtype = block:
     msg.mtype.withValue(typ): "type = " & $typ & " "


### PR DESCRIPTION
The `debugutils.nim` file doesn't compile due to typo in `withValue`. Fix it for now.