### PR TITLE
increase tolerance of `simple heartbeat` test

### DIFF
--- a/tests/testheartbeat.nim
+++ b/tests/testheartbeat.nim
@@ -22,10 +22,10 @@ when not defined(macosx):
     asyncTest "simple heartbeat":
       var i = 0
       proc t() {.async.} =
-        heartbeat "shouldn't see this", 30.milliseconds:
+        heartbeat "shouldn't see this", 50.milliseconds:
           i.inc()
       let hb = t()
-      await sleepAsync(300.milliseconds)
+      await sleepAsync(500.milliseconds)
       await hb.cancelAndWait()
       check:
         i in 9..11


### PR DESCRIPTION
The `simple heartbeat` test is flaky:

```
================
  /home/runner/work/nim-libp2p/nim-libp2p/tests/testnative 'Heartbeat::simple heartbeat'
----------------
    /home/runner/work/nim-libp2p/nim-libp2p/tests/testheartbeat.nim(31, 10): Check failed: i in 9 .. 11
    i was 12
    9 .. 11 was 9 .. 11

  [FAILED ] (  0.33s) simple heartbeat
```

Increase its timing tolerances to reduce the likelihood of this happening under load.