### PR TITLE
move `allFutureThrowing` helper to tests

### DIFF
--- a/libp2p/errors.nim
+++ b/libp2p/errors.nim
@@ -45,28 +45,6 @@ macro checkFutures*[F](futs: seq[F], exclude: untyped = []): untyped =
             debug "A future has failed, enable trace logging for details", error=exc.name
             trace "Exception details", msg=exc.msg
 
-proc allFuturesThrowing*[F: FutureBase](args: varargs[F]): Future[void] =
-  var futs: seq[F]
-  for fut in args:
-    futs &= fut
-  proc call() {.async.} =
-    var first: ref CatchableError = nil
-    futs = await allFinished(futs)
-    for fut in futs:
-      if fut.failed:
-        let err = fut.readError()
-        if err of Defect:
-          raise err
-        else:
-          if err of CancelledError:
-            raise err
-          if isNil(first):
-            first = err
-    if not isNil(first):
-      raise first
-
-  return call()
-
 template tryAndWarn*(message: static[string]; body: untyped): untyped =
   try:
     body

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -91,21 +91,33 @@ proc handleConn(s: Secure,
   # we require this information in for example gossipsub
   sconn.transportDir = if initiator: Direction.Out else: Direction.In
 
-  proc cleanup() {.async.} =
+  proc cleanup() {.async: (raises: []).} =
     try:
-      let futs = [conn.join(), sconn.join()]
-      await futs[0] or futs[1]
-      for f in futs:
-        if not f.finished: await f.cancelAndWait() # cancel outstanding join()
+      block:
+        let
+          fut1 = conn.join()
+          fut2 = sconn.join()
+        await fut1 or fut2  # one join() completes, cancel outstanding join()
+        if not fut1.finished: await fut1.cancelAndWait()
+        if not fut2.finished: await fut2.cancelAndWait()
+      block:
+        let
+          fut1 = sconn.close()
+          fut2 = conn.close()
+        await allFutures(fut1, fut2)
+        if fut1.failed:
+          let err = fut1.error()
+          if not (err of CancelledError):
+            debug "error cleaning up secure connection", err = exc.msg, sconn
+        if fut2.failed:
+          let err = fut2.error()
+          if not (err of CancelledError):
+            debug "error cleaning up secure connection", err = exc.msg, sconn
 
-      await allFuturesThrowing(
-        sconn.close(), conn.close())
     except CancelledError:
       # This is top-level procedure which will work as separate task, so it
       # do not need to propagate CancelledError.
       discard
-    except CatchableError as exc:
-      debug "error cleaning up secure connection", err = exc.msg, sconn
 
   if not isNil(sconn):
     # All the errors are handled inside `cleanup()` procedure.

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -108,11 +108,11 @@ proc handleConn(s: Secure,
         if fut1.failed:
           let err = fut1.error()
           if not (err of CancelledError):
-            debug "error cleaning up secure connection", err = exc.msg, sconn
+            debug "error cleaning up secure connection", err = err.msg, sconn
         if fut2.failed:
           let err = fut2.error()
           if not (err of CancelledError):
-            debug "error cleaning up secure connection", err = exc.msg, sconn
+            debug "error cleaning up secure connection", err = err.msg, sconn
 
     except CancelledError:
       # This is top-level procedure which will work as separate task, so it

--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -160,7 +160,9 @@ method initStream*(s: LPStream) {.base.} =
   inc getStreamTracker(s.objName).opened
   trace "Stream created", s, objName = s.objName, dir = $s.dir
 
-proc join*(s: LPStream): Future[void] {.public.} =
+proc join*(
+    s: LPStream
+): Future[void] {.async: (raises: [CancelledError], raw: true), public.} =
   ## Wait for the stream to be closed
   s.closeEvent.wait()
 

--- a/tests/errorhelpers.nim
+++ b/tests/errorhelpers.nim
@@ -1,0 +1,27 @@
+import chronos
+
+proc allFuturesThrowing*[F: FutureBase](args: varargs[F]): Future[void] =
+  # This proc is only meant for use in tests / not suitable for general use.
+  # - Swallowing errors arbitrarily instead of aggregating them is bad design
+  # - It raises `CatchableError` instead of the union of the `futs` errors,
+  #   inflating the caller's `raises` list unnecessarily. `macro` could fix it
+  var futs: seq[F]
+  for fut in args:
+    futs &= fut
+  proc call() {.async.} =
+    var first: ref CatchableError = nil
+    futs = await allFinished(futs)
+    for fut in futs:
+      if fut.failed:
+        let err = fut.readError()
+        if err of Defect:
+          raise err
+        else:
+          if err of CancelledError:
+            raise err
+          if isNil(first):
+            first = err
+    if not isNil(first):
+      raise first
+
+  return call()

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -17,6 +17,32 @@ import ../libp2p/nameresolving/[nameresolver, mockresolver]
 import ./asyncunit
 export asyncunit, mockresolver
 
+proc allFuturesThrowing*[F: FutureBase](args: varargs[F]): Future[void] =
+  # This proc is only meant for use in tests / not suitable for general use.
+  # - Swallowing errors arbitrarily instead of aggregating them is bad design
+  # - It raises `CatchableError` instead of the union of the `futs` errors,
+  #   inflating the caller's `raises` list unnecessarily. `macro` could fix it
+  var futs: seq[F]
+  for fut in args:
+    futs &= fut
+  proc call() {.async.} =
+    var first: ref CatchableError = nil
+    futs = await allFinished(futs)
+    for fut in futs:
+      if fut.failed:
+        let err = fut.readError()
+        if err of Defect:
+          raise err
+        else:
+          if err of CancelledError:
+            raise err
+          if isNil(first):
+            first = err
+    if not isNil(first):
+      raise first
+
+  return call()
+
 const
   StreamTransportTrackerName = "stream.transport"
   StreamServerTrackerName = "stream.server"

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -14,34 +14,8 @@ import ../libp2p/protocols/secure/secure
 import ../libp2p/switch
 import ../libp2p/nameresolving/[nameresolver, mockresolver]
 
-import ./asyncunit
-export asyncunit, mockresolver
-
-proc allFuturesThrowing*[F: FutureBase](args: varargs[F]): Future[void] =
-  # This proc is only meant for use in tests / not suitable for general use.
-  # - Swallowing errors arbitrarily instead of aggregating them is bad design
-  # - It raises `CatchableError` instead of the union of the `futs` errors,
-  #   inflating the caller's `raises` list unnecessarily. `macro` could fix it
-  var futs: seq[F]
-  for fut in args:
-    futs &= fut
-  proc call() {.async.} =
-    var first: ref CatchableError = nil
-    futs = await allFinished(futs)
-    for fut in futs:
-      if fut.failed:
-        let err = fut.readError()
-        if err of Defect:
-          raise err
-        else:
-          if err of CancelledError:
-            raise err
-          if isNil(first):
-            first = err
-    if not isNil(first):
-      raise first
-
-  return call()
+import "."/[asyncunit, errorhelpers]
+export asyncunit, errorhelpers, mockresolver
 
 const
   StreamTransportTrackerName = "stream.transport"

--- a/tests/hole-punching-interop/hole_punching.nim
+++ b/tests/hole-punching-interop/hole_punching.nim
@@ -12,7 +12,7 @@ import ../../libp2p/[builders,
                   protocols/connectivity/autonat/service,
                   protocols/ping]
 import ../stubs/autonatclientstub
-import ../helpers
+import ../errorhelpers
 
 proc createSwitch(r: Relay = nil, hpService: Service = nil): Switch =
   let rng = newRng()
@@ -48,7 +48,7 @@ proc main() {.async.} =
       isListener = getEnv("MODE") == "listen"
       switch = createSwitch(relayClient, hpservice)
       auxSwitch = createSwitch()
-      redisClient = open("redis", 6379.Port)
+      redisClient = open("localhost", 6379.Port)
 
     debug "Connected to redis"
 

--- a/tests/hole-punching-interop/hole_punching.nim
+++ b/tests/hole-punching-interop/hole_punching.nim
@@ -48,7 +48,7 @@ proc main() {.async.} =
       isListener = getEnv("MODE") == "listen"
       switch = createSwitch(relayClient, hpservice)
       auxSwitch = createSwitch()
-      redisClient = open("localhost", 6379.Port)
+      redisClient = open("redis", 6379.Port)
 
     debug "Connected to redis"
 

--- a/tests/hole-punching-interop/hole_punching.nim
+++ b/tests/hole-punching-interop/hole_punching.nim
@@ -12,6 +12,7 @@ import ../../libp2p/[builders,
                   protocols/connectivity/autonat/service,
                   protocols/ping]
 import ../stubs/autonatclientstub
+import ../helpers
 
 proc createSwitch(r: Relay = nil, hpService: Service = nil): Switch =
   let rng = newRng()


### PR DESCRIPTION
We use a generically seeming helper to help us track three `Future` exceptions throughout the entire codebase. Move the helper to tests where it finds more use. The helper has several design flaws that make it incompatible with `{.async: (raises).}` usage, and has the potential to swallow one of the three exceptions that we track with it.

The semantics should not change in this PR, this is a pure refactoring.