### PR TITLE
use new Chronos `trackCounter` APIs for leaks checks in tests

### DIFF
--- a/libp2p/stream/lpstream.nim
+++ b/libp2p/stream/lpstream.nim
@@ -1,5 +1,5 @@
 # Nim-LibP2P
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -77,30 +77,6 @@ type
     opened*: uint64
     closed*: uint64
 
-proc setupStreamTracker*(name: string): StreamTracker =
-  let tracker = new StreamTracker
-
-  proc dumpTracking(): string {.gcsafe.} =
-    return "Opened " & tracker.id & ": " & $tracker.opened & "\n" &
-            "Closed " & tracker.id & ": " & $tracker.closed
-
-  proc leakTransport(): bool {.gcsafe.} =
-    return (tracker.opened != tracker.closed)
-
-  tracker.id = name
-  tracker.opened = 0
-  tracker.closed = 0
-  tracker.dump = dumpTracking
-  tracker.isLeaked = leakTransport
-  addTracker(name, tracker)
-
-  return tracker
-
-proc getStreamTracker(name: string): StreamTracker {.gcsafe.} =
-  result = cast[StreamTracker](getTracker(name))
-  if isNil(result):
-    result = setupStreamTracker(name)
-
 proc newLPStreamReadError*(p: ref CatchableError): ref LPStreamReadError =
   var w = newException(LPStreamReadError, "Read stream failed")
   w.msg = w.msg & ", originated from [" & $p.name & "] " & p.msg
@@ -157,7 +133,7 @@ method initStream*(s: LPStream) {.base.} =
   s.oid = genOid()
 
   libp2p_open_streams.inc(labelValues = [s.objName, $s.dir])
-  inc getStreamTracker(s.objName).opened
+  trackCounter(s.objName)
   trace "Stream created", s, objName = s.objName, dir = $s.dir
 
 proc join*(
@@ -304,7 +280,7 @@ method closeImpl*(s: LPStream): Future[void] {.async, base.} =
   ## Implementation of close - called only once
   trace "Closing stream", s, objName = s.objName, dir = $s.dir
   libp2p_open_streams.dec(labelValues = [s.objName, $s.dir])
-  inc getStreamTracker(s.objName).closed
+  untrackCounter(s.objName)
   s.closeEvent.fire()
   trace "Closed stream", s, objName = s.objName, dir = $s.dir
 

--- a/tests/helpers.nim
+++ b/tests/helpers.nim
@@ -35,25 +35,19 @@ const
     ChronosStreamTrackerName
   ]
 
-iterator testTrackers*(extras: openArray[string] = []): TrackerBase =
-  for name in trackerNames:
-    let t = getTracker(name)
-    if not isNil(t): yield t
-  for name in extras:
-    let t = getTracker(name)
-    if not isNil(t): yield t
-
 template checkTracker*(name: string) =
-  var tracker = getTracker(name)
-  if tracker.isLeaked():
-    checkpoint tracker.dump()
+  if isCounterLeaked(name):
+    let
+      tracker = getTrackerCounter(name)
+      trackerDescription =
+        "Opened " & name & ": " & $tracker.opened & "\n" &
+        "Closed " & name & ": " & $tracker.closed
+    checkpoint trackerDescription
     fail()
 
 template checkTrackers*() =
-  for tracker in testTrackers():
-    if tracker.isLeaked():
-      checkpoint tracker.dump()
-      fail()
+  for name in trackerNames:
+    checkTracker(name)
   # Also test the GC is not fooling with us
   when defined(nimHasWarnBareExcept):
     {.push warning[BareExcept]:off.}

--- a/tests/testbufferstream.nim
+++ b/tests/testbufferstream.nim
@@ -1,7 +1,7 @@
 {.used.}
 
 # Nim-Libp2p
-# Copyright (c) 2023 Status Research & Development GmbH
+# Copyright (c) 2023-2024 Status Research & Development GmbH
 # Licensed under either of
 #  * Apache License, version 2.0, ([LICENSE-APACHE](LICENSE-APACHE))
 #  * MIT license ([LICENSE-MIT](LICENSE-MIT))
@@ -18,8 +18,7 @@ import ./helpers
 
 suite "BufferStream":
   teardown:
-    # echo getTracker(BufferStreamTrackerName).dump()
-    check getTracker(BufferStreamTrackerName).isLeaked() == false
+    checkTrackers()
 
   asyncTest "push data to buffer":
     let buff = BufferStream.new()


### PR DESCRIPTION
The previous `addTracker` / `getTracker` Chronos APIs were deprecated. Switch to their equivalent new APIs which need less manual management.