### PR TITLE
define proper parent error type for `YamuxError`

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -34,7 +34,7 @@ when defined(libp2p_yamux_metrics):
     buckets = [0.0, 100.0, 250.0, 1000.0, 2000.0, 3200.0, 6400.0, 25600.0, 256000.0]
 
 type
-  YamuxError* = object of CatchableError
+  YamuxError* = object of MuxerError
 
   MsgType = enum
     Data = 0x0


### PR DESCRIPTION
All errors raised by `nim-libp2p` should descend from `LPError`. `YamuxError` was not correctly classified. Proposing it to be a specialized `MuxerError`, in line with `mplex` and `muxer` errors.