### PR TITLE
in yamux, do not write `{Rst}` packet to stream that's in use

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -218,7 +218,7 @@ proc reset(channel: YamuxChannel, isLocal: bool = false) {.async.} =
   channel.recvQueue = @[]
   channel.sendWindow = 0
   if not channel.closedLocally:
-    if isLocal:
+    if isLocal and not channel.isSending:
       try: await channel.conn.write(YamuxHeader.data(channel.id, 0, {Rst}))
       except LPStreamEOFError as exc: discard
       except LPStreamClosedError as exc: discard


### PR DESCRIPTION
When a yamux channel is reset, the connection may still be in use with pending writes. In that situation, the socket cannot be used to send the terminating `{Rst}` packet without corrupting the data. Waiting for the pending write to complete is also not too useful, and also would need a refactoring to even support so, as we don't track the `trySend` future that is currently writing, and also already purged the `sendQueue`.

Note that this also fixes assertions depending on chronos scheduling in local tests that use `pushData` on `BufferStream`. Because `pushData` checks no other pushes are in progress, tests may have randomly failed.