### PR TITLE
use `race` instead of `or` to avoid lockup

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -265,7 +265,9 @@ method readOnce*(
     raise newLPStreamRemoteClosedError()
   if channel.recvQueue.len == 0:
     channel.receivedData.clear()
-    await channel.closedRemotely or channel.receivedData.wait()
+    try:  # https://github.com/status-im/nim-chronos/issues/516
+      discard await race(channel.closedRemotely, channel.receivedData.wait())
+    except ValueError: raiseAssert("Futures list is not empty")
     if channel.closedRemotely.done() and channel.recvQueue.len == 0:
       channel.returnedEof = true
       channel.isEof = true

--- a/libp2p/protocols/connectivity/relay/utils.nim
+++ b/libp2p/protocols/connectivity/relay/utils.nim
@@ -55,7 +55,9 @@ proc bridge*(connSrc: Connection, connDst: Connection) {.async.} =
 
   try:
     while not connSrc.closed() and not connDst.closed():
-      await futSrc or futDst
+      try:  # https://github.com/status-im/nim-chronos/issues/516
+        discard await race(futSrc, futDst)
+      except ValueError: raiseAssert("Futures list is not empty")
       if futSrc.finished():
         bufRead = await futSrc
         if bufRead > 0:

--- a/libp2p/protocols/secure/secure.nim
+++ b/libp2p/protocols/secure/secure.nim
@@ -97,7 +97,10 @@ proc handleConn(s: Secure,
         let
           fut1 = conn.join()
           fut2 = sconn.join()
-        await fut1 or fut2  # one join() completes, cancel outstanding join()
+        try:  # https://github.com/status-im/nim-chronos/issues/516
+          discard await race(fut1, fut2)
+        except ValueError: raiseAssert("Futures list is not empty")
+        # at least one join() completed, cancel pending one, if any
         if not fut1.finished: await fut1.cancelAndWait()
         if not fut2.finished: await fut2.cancelAndWait()
       block:


### PR DESCRIPTION
`or` futures are currently bugged when using `cancelAndWait` on them. This sometimes show when tests run several minutes longer until the mess is unstucked through a timeout that pokes the machinery again. Use `race` to avoid the lockup.

- https://github.com/status-im/nim-chronos/issues/516