### PR TITLE
don't forget closing the stream when final `{Fin}` fails in yamux

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -199,8 +199,9 @@ method closeImpl*(channel: YamuxChannel) {.async.} =
     channel.closedLocally = true
     channel.isEof = true
 
-    if channel.isReset == false and channel.sendQueue.len == 0:
-      await channel.conn.write(YamuxHeader.data(channel.id, 0, {Fin}))
+    if not channel.isReset and channel.sendQueue.len == 0:
+      try: await channel.conn.write(YamuxHeader.data(channel.id, 0, {Fin}))
+      except CancelledError, LPStreamError: discard
     await channel.actuallyClose()
 
 proc reset(channel: YamuxChannel, isLocal: bool = false) {.async.} =


### PR DESCRIPTION
When there is an error during the final graceful `{Fin}`, we currently don't call `channel.actuallyClose()`. Fix that by ignoring such errors.