### PR TITLE
avoid `KeyError` in edge case of yamux handler

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -525,7 +525,12 @@ method handle*(m: Yamux) {.async.} =
               await m.connection.readExactly(addr buffer[0], int(header.length))
           continue
 
-        let channel = m.channels[header.streamId]
+        let channel =
+          try:
+            m.channels[header.streamId]
+          except KeyError:
+            raise newException(YamuxError,
+              "Stream was cleaned up before handling data: " & $header.streamId)
 
         if header.msgType == WindowUpdate:
           channel.sendWindow += int(header.length)


### PR DESCRIPTION
There are two edge cases that currently trigger `KeyError`:

1. `await newStream.open()` succeeds, but Chronos injects an implicit suspend point when an `{.async.}` function that suspended returns. During this implicit suspend point, another task could get scheduled and close the stream, which removes it from `m.channels` again. `let channel = m.channels[header.streamId` then gives `KeyError`. More explanation of implicit suspend point on return after await: https://github.com/status-im/nim-chronos/pull/273

2. During the `Flush the data` block, `await m.connection.readExactly` is called which may suspend. If it suspends, same as above, another task may get scheduled that closes the stream, also resulting in the `KeyError` below.

The `YamuxError` is subsequently properly handled below.