### PR TITLE
do not log yamux buffers without sanitization (trace log level)

### DIFF
--- a/libp2p/muxers/yamux/yamux.nim
+++ b/libp2p/muxers/yamux/yamux.nim
@@ -538,7 +538,7 @@ method handle*(m: Yamux) {.async.} =
           if header.length > 0:
             var buffer = newSeqUninitialized[byte](header.length)
             await m.connection.readExactly(addr buffer[0], int(header.length))
-            trace "Msg Rcv", msg=string.fromBytes(buffer)
+            trace "Msg Rcv", msg=shortLog(buffer)
             await channel.gotDataFromRemote(buffer)
 
         if MsgFlags.Fin in header.flags:


### PR DESCRIPTION
The `Msg Rcv` trace log does not sanitize the buffer against binary data, which may trigger oddities in the terminal displaying it, as binary control characters get interpreted. Using `shortLog` instead is consistent with `Mplex` and displays the start and end as hex. It makes more sense anyway because the exchanged messages actually do contain binary headers very often, and displaying these as string is most likely incorrect.