### PR TITLE
change `SecioError` and `NoiseError` to descendants of `LPStreamError`

### DIFF
--- a/libp2p/protocols/secure/noise.nim
+++ b/libp2p/protocols/secure/noise.nim
@@ -89,7 +89,7 @@ type
     readCs: CipherState
     writeCs: CipherState
 
-  NoiseError* = object of LPError
+  NoiseError* = object of LPStreamError
   NoiseHandshakeError* = object of NoiseError
   NoiseDecryptTagError* = object of NoiseError
   NoiseOversizedPayloadError* = object of NoiseError

--- a/libp2p/protocols/secure/secio.nim
+++ b/libp2p/protocols/secure/secio.nim
@@ -73,7 +73,7 @@ type
     writerCoder: SecureCipher
     readerCoder: SecureCipher
 
-  SecioError* = object of LPError
+  SecioError* = object of LPStreamError
 
 func shortLog*(conn: SecioConn): auto =
   try:


### PR DESCRIPTION
When higher modules read from streams, they often use `Noise` / `Secio` interchangeably with other streams. It simplifies exception handling a lot if they reflect their nature as specialized stream wrappers by also inheriting from `LPStreamError` instead of the root `LPError`.