### PR TITLE
catch `WebSocketError` in `wstransport`

### DIFF
--- a/libp2p/transports/wstransport.nim
+++ b/libp2p/transports/wstransport.nim
@@ -63,13 +63,17 @@ template mapExceptions(body: untyped) =
   try:
     body
   except AsyncStreamIncompleteError:
-    raise newLPStreamEOFError()
+    raise newLPStreamIncompleteError()
+  except AsyncStreamLimitError:
+    raise newLPStreamLimitError()
   except AsyncStreamUseClosedError:
     raise newLPStreamEOFError()
   except WSClosedError:
     raise newLPStreamEOFError()
-  except AsyncStreamLimitError:
-    raise newLPStreamLimitError()
+  except WebSocketError:
+    raise newLPStreamEOFError()
+  except CatchableError:
+    raise newLPStreamEOFError()
 
 method readOnce*(
   s: WsStream,


### PR DESCRIPTION
Ensure all errors raised by `nim-websock` are caught. That library is not yet updated regarding `{.async: (raises).}`, so an extra entry is needed for `CatchableError` to avoid polluting the callstack with it.