### PR TITLE
avoid pointless exception raising in `dcutr/server`

### DIFF
--- a/libp2p/protocols/connectivity/dcutr/server.nim
+++ b/libp2p/protocols/connectivity/dcutr/server.nim
@@ -65,14 +65,14 @@ proc new*(T: typedesc[Dcutr], switch: Switch, connectTimeout = 15.seconds, maxDi
     except CancelledError as err:
       raise err
     except AllFuturesFailedError as err:
-      debug "Dcutr receiver could not connect to the remote peer, all connect attempts failed", peerDialableAddrs, msg = err.msg
-      raise newException(DcutrError, "Dcutr receiver could not connect to the remote peer, all connect attempts failed", err)
+      debug "Dcutr receiver could not connect to the remote peer, " &
+        "all connect attempts failed", peerDialableAddrs, msg = err.msg
     except AsyncTimeoutError as err:
-      debug "Dcutr receiver could not connect to the remote peer, all connect attempts timed out", peerDialableAddrs, msg = err.msg
-      raise newException(DcutrError, "Dcutr receiver could not connect to the remote peer, all connect attempts timed out", err)
+      debug "Dcutr receiver could not connect to the remote peer, " &
+        "all connect attempts timed out", peerDialableAddrs, msg = err.msg
     except CatchableError as err:
-      warn "Unexpected error when Dcutr receiver tried to connect to the remote peer", msg = err.msg
-      raise newException(DcutrError, "Unexpected error when Dcutr receiver tried to connect to the remote peer", err)
+      warn "Unexpected error when Dcutr receiver tried to connect " &
+        "to the remote peer", msg = err.msg
 
   let self = T()
   self.handler = handleStream


### PR DESCRIPTION
`dcutr/server` is the only protocol handler outside tests / examples that raises exceptions. The only caller of this handler is defined in `MultStreamSelect.handle`, which has a surrounding `except` block that catches `CatchableError`.

When the handler raises a non-`CancelledError` the flow is:

1. `await protocolHolder.protocol.handler(conn, ms)`
2. The `finally` block after it
3. The `return`, both in successful and in exception case
4. The outer `except CatchableError as exc:`, it logs and discards `exc`
5. The outer `finally`: `await conn.close()`
6. `Stopped multistream handler` log, both in successful and exc case.

By changing `dcutr/server` to only log but not also raise, difference is that the outer `except CatchableError` in step (4) is skipped.

As that is a redundant log anyway (`dcutr/server` already logs), it should be fine to not raise. That's in line with all the other protocol handlers (besides tests / examples) and opens up limiting `{.raises.}` annotation for handlers to just `[CancelledError]`.